### PR TITLE
Added support for importing lines with invoice2data

### DIFF
--- a/account_invoice_import_invoice2data/wizard/account_invoice_import.py
+++ b/account_invoice_import_invoice2data/wizard/account_invoice_import.py
@@ -71,14 +71,14 @@ class AccountInvoiceImport(models.TransientModel):
         processed_lines = []
         for line in lines:
             product_dict = {
-                'barcode': line['barcode'] if line.has_key('barcode') else False,
-                'code': line['code'] if line.has_key('code') else False,
+                'barcode': line['barcode'] if 'barcode' in line else False,
+                'code': line['code'] if 'code' in line else False,
             }
-            uom = {'unece_code': line['uom']} if line.has_key('uom') else {}
+            uom = {'unece_code': line['uom']} if 'uom' in line else {}
             taxes = []
             line_dict = {
-                'qty': line['qty'] if line.has_key('qty') else 1,
-                'name': line['name'] if line.has_key('name') else '-',
+                'qty': line['qty'] if 'qty' in line else 1,
+                'name': line['name'] if 'name' in line else '-',
                 'product': product_dict,
                 'uom': uom,
                 'taxes': taxes,
@@ -87,7 +87,6 @@ class AccountInvoiceImport(models.TransientModel):
 
             processed_lines.append(line_dict)
         return processed_lines
-
 
     @api.model
     def invoice2data_to_parsed_inv(self, invoice2data_res):

--- a/account_invoice_import_invoice2data/wizard/account_invoice_import.py
+++ b/account_invoice_import_invoice2data/wizard/account_invoice_import.py
@@ -67,6 +67,29 @@ class AccountInvoiceImport(models.TransientModel):
         return self.invoice2data_to_parsed_inv(invoice2data_res)
 
     @api.model
+    def invoice2data_process_lines(self, lines):
+        processed_lines = []
+        for line in lines:
+            product_dict = {
+                'barcode': line['barcode'] if line.has_key('barcode') else False,
+                'code': line['code'] if line.has_key('code') else False,
+            }
+            uom = {'unece_code': line['uom']} if line.has_key('uom') else {}
+            taxes = []
+            line_dict = {
+                'qty': line['qty'] if line.has_key('qty') else 1,
+                'name': line['name'] if line.has_key('name') else '-',
+                'product': product_dict,
+                'uom': uom,
+                'taxes': taxes,
+                'price_unit': line['price_unit']
+            }
+
+            processed_lines.append(line_dict)
+        return processed_lines
+
+
+    @api.model
     def invoice2data_to_parsed_inv(self, invoice2data_res):
         parsed_inv = {
             'partner': {
@@ -79,6 +102,8 @@ class AccountInvoiceImport(models.TransientModel):
             'currency': {
                 'iso': invoice2data_res.get('currency'),
                 },
+            'lines': self.invoice2data_process_lines(
+                invoice2data_res.get('lines')),
             'amount_total': invoice2data_res.get('amount'),
             'invoice_number': invoice2data_res.get('invoice_number'),
             'date': invoice2data_res.get('date'),


### PR DESCRIPTION
I have added a very rudimentary line import which processes the data from invoice2data into a format that odoo can understand. I have tried to mimic the behaviour of the UBL importer, but as invoice2pdf will usually not extract any taxes, I have left them out.

Also, I guess some sort of user documentation should be added, so that the user knows how to name their line fields in invoice2data, otherwise this thing will not work at all. Where would be the best place to do that?