### PR TITLE
[10.0] Update to work with latest version of invoice2data

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,13 +49,11 @@ install:
   - git clone --depth=1 https://github.com/OCA/maintainer-quality-tools.git ${HOME}/maintainer-quality-tools
   - export PATH=${HOME}/maintainer-quality-tools/travis:${PATH}
   - travis_install_nightly
-  - pip install invoice2data
   # Invoice2data new requires a recent version of pdftotext from https://poppler.freedesktop.org/releases.html
   # and the version below doesn't work any more
   #- wget -P /tmp http://public.akretion.com/pdftotext-3.04
   #- sudo mv /tmp/pdftotext-3.04 /usr/local/bin/pdftotext
   #- sudo chmod 755 /usr/local/bin/pdftotext
-  - pip install git+https://github.com/akretion/factur-x
   - pip install phonenumbers
 
 script:

--- a/account_invoice_import/wizard/account_invoice_import.py
+++ b/account_invoice_import/wizard/account_invoice_import.py
@@ -597,9 +597,9 @@ class AccountInvoiceImport(models.TransientModel):
                 parsed_inv['amount_untaxed']
             invoice.tax_line_ids[0].amount = tax_amount
             cur_symbol = invoice.currency_id.symbol
-            invoice.message_post(
+            invoice.message_post(_(
                 'The total tax amount has been forced to %s %s '
-                '(amount computed by Odoo was: %s %s).'
+                '(amount computed by Odoo was: %s %s).')
                 % (tax_amount, cur_symbol, initial_tax_amount, cur_symbol))
 
     @api.multi

--- a/account_invoice_import_invoice2data/README.rst
+++ b/account_invoice_import_invoice2data/README.rst
@@ -13,13 +13,13 @@ To know the full story behind the development of this module, read this `blog po
 Installation
 ============
 
-This module requires the Python library *invoice2data* available on `Github <https://github.com/m3nu/invoice2data>`_.
+This module requires the Python library *invoice2data* available on `Github <https://github.com/m3nu/invoice2data>`_ with a version >= 0.2.74 (February 2018).
 
-To install the library, run:
+To install the latest version of this library, run:
 
 .. code::
 
-  sudo pip install invoice2data
+  sudo pip install --upgrade invoice2data
 
 If you use Ubuntu 16.04 LTS, you can use the pdftotext version 0.41.0 that is packaged in the distribution:
 

--- a/account_invoice_import_invoice2data/__manifest__.py
+++ b/account_invoice_import_invoice2data/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     'name': 'Account Invoice Import Invoice2data',
-    'version': '10.0.1.0.0',
+    'version': '10.0.1.0.1',
     'category': 'Accounting & Finance',
     'license': 'AGPL-3',
     'summary': 'Import supplier invoices using the invoice2data lib',

--- a/account_invoice_import_invoice2data/wizard/account_invoice_import.py
+++ b/account_invoice_import_invoice2data/wizard/account_invoice_import.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 
 try:
     from invoice2data.main import extract_data
-    from invoice2data.template import read_templates
+    from invoice2data.extract.loader import read_templates
     from invoice2data.main import logger as loggeri2data
 except ImportError:
     logger.debug('Cannot import invoice2data')
@@ -48,8 +48,7 @@ class AccountInvoiceImport(models.TransientModel):
         exclude_built_in_templates = tools.config.get(
             'invoice2data_exclude_built_in_templates', False)
         if not exclude_built_in_templates:
-            templates += read_templates(
-                pkg_resources.resource_filename('invoice2data', 'templates'))
+            templates += read_templates()
         logger.debug(
             'Calling invoice2data.extract_data with templates=%s',
             templates)

--- a/account_invoice_import_invoice2data/wizard/account_invoice_import.py
+++ b/account_invoice_import_invoice2data/wizard/account_invoice_import.py
@@ -6,7 +6,6 @@ from odoo import models, api, tools, _
 from odoo.exceptions import UserError
 import os
 from tempfile import mkstemp
-import pkg_resources
 import logging
 logger = logging.getLogger(__name__)
 

--- a/base_business_document_import/tests/test_business_document_import.py
+++ b/base_business_document_import/tests/test_business_document_import.py
@@ -103,10 +103,9 @@ class TestBaseBusinessDocumentImport(TransactionCase):
         currency_dict = {'iso_or_symbol': u'€'}
         res = bdio._match_currency(currency_dict, [])
         self.assertEquals(res, self.env.ref('base.EUR'))
-        self.env.user.company_id.currency_id = self.env.ref('base.KRW')
         currency_dict = {}
         res = bdio._match_currency(currency_dict, [])
-        self.assertEquals(res, self.env.ref('base.KRW'))
+        self.assertEquals(res, self.env.user.company_id.currency_id)
 
     def test_match_product(self):
         bdio = self.env['business.document.import']

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+invoice2data>=0.2.74
+factur-x>=0.3


### PR DESCRIPTION
A lot a changes have been made in invoice2data when the "v2 branch" was merged last month, cf https://github.com/m3nu/invoice2data/commit/42fda7d4552164c7e526d1bbf843360ebb9f8a69

The consequence is that the module account_invoice_import_invoice2data didn't work with the latest version of invoice2data.  This PR fixes the problem.