### PR TITLE
[FIX] can not change currency of existing company anymore

### DIFF
--- a/base_business_document_import/tests/test_business_document_import.py
+++ b/base_business_document_import/tests/test_business_document_import.py
@@ -102,7 +102,9 @@ class TestBaseBusinessDocumentImport(TransactionCase):
         currency_dict = {'iso_or_symbol': '€'}
         res = bdio._match_currency(currency_dict, [])
         self.assertEqual(res, self.env.ref('base.EUR'))
-        self.env.user.company_id.currency_id = self.env.ref('base.KRW')
+        currency_id = self.env.ref('base.KRW').id
+        self.cr.execute("UPDATE res_company SET currency_id = %s WHERE id = 1",
+                        (currency_id,))
         currency_dict = {}
         res = bdio._match_currency(currency_dict, [])
         self.assertEqual(res, self.env.ref('base.KRW'))


### PR DESCRIPTION
Fix failing test, because we can not change currency with company having existing data