### PR TITLE
[10.0] FIX Avoid warning 

### DIFF
--- a/base_ubl/models/ubl.py
+++ b/base_ubl/models/ubl.py
@@ -536,7 +536,7 @@ class BaseUbl(models.AbstractModel):
         new_pdf_filestream.appendPagesFromReader(original_pdf)
         new_pdf_filestream.addAttachment(xml_filename, xml_string)
         if pdf_file:
-            f = open(pdf_file, 'w')
+            f = open(pdf_file, 'wb')
             new_pdf_filestream.write(f)
             f.close()
         elif pdf_content:


### PR DESCRIPTION
This PR will avoid the following warning when generating a py3o document with an embedded UBL file
"UserWarning: File </tmp/p3o.report.tmp.nVix6I.ods> to write to is not in binary mode. It may not be written to correctly. [pdf.py:453]