### PR TITLE
[10.0] Auto-creation of bank accounts upon invoice import is now optional

### DIFF
--- a/account_invoice_import/models/account_config_settings.py
+++ b/account_invoice_import/models/account_config_settings.py
@@ -14,3 +14,5 @@ class AccountConfigSettings(models.TransientModel):
         related='company_id.adjustment_debit_account_id')
     invoice_import_email = fields.Char(
         related='company_id.invoice_import_email')
+    invoice_import_create_bank_account = fields.Boolean(
+        related='company_id.invoice_import_create_bank_account')

--- a/account_invoice_import/models/company.py
+++ b/account_invoice_import/models/company.py
@@ -19,6 +19,8 @@ class ResCompany(models.Model):
         'Mail Gateway: Destination E-mail',
         help="This field is used in multi-company setups to import the "
         "invoices received by the mail gateway in the appropriate company")
+    invoice_import_create_bank_account = fields.Boolean(
+        string='Auto-create Bank Account of Supplier')
 
     _sql_constraints = [(
         'invoice_import_email_uniq',

--- a/account_invoice_import/views/account_config_settings.xml
+++ b/account_invoice_import/views/account_config_settings.xml
@@ -23,6 +23,10 @@
                         <label for="adjustment_credit_account_id"/>
                         <field name="adjustment_credit_account_id" class="oe_inline"/>
                     </div>
+                    <div name="invoice_import_create_bank_account">
+                        <field name="invoice_import_create_bank_account"/>
+                        <label for="invoice_import_create_bank_account" class="oe_inline"/>
+                    </div>
                     <div name="invoice_import_email">
                         <label for="invoice_import_email"/>
                         <field name="invoice_import_email" class="oe_inline"/>

--- a/account_invoice_import/wizard/account_invoice_import.py
+++ b/account_invoice_import/wizard/account_invoice_import.py
@@ -177,8 +177,8 @@ class AccountInvoiceImport(models.TransientModel):
         ailo = self.env['account.invoice.line']
         bdio = self.env['business.document.import']
         rpo = self.env['res.partner']
-        company_id = self._context.get('force_company') or\
-            self.env.user.company_id.id
+        company = self.env['res.company'].browse(
+            self._context.get('force_company')) or self.env.user.company_id
         start_end_dates_installed = hasattr(ailo, 'start_date') and\
             hasattr(ailo, 'end_date')
         if parsed_inv['type'] in ('out_invoice', 'out_refund'):
@@ -193,12 +193,12 @@ class AccountInvoiceImport(models.TransientModel):
             parsed_inv.get('currency'), parsed_inv['chatter_msg'])
         journal_id = aio.with_context(
             type=parsed_inv['type'],
-            company_id=company_id)._default_journal().id
+            company_id=company.id)._default_journal().id
         vals = {
             'partner_id': partner.id,
             'currency_id': currency.id,
             'type': parsed_inv['type'],
-            'company_id': company_id,
+            'company_id': company.id,
             'origin': parsed_inv.get('origin'),
             'reference': parsed_inv.get('invoice_number'),
             'date_invoice': parsed_inv.get('date'),
@@ -215,7 +215,8 @@ class AccountInvoiceImport(models.TransientModel):
             partner = rpo.browse(vals['partner_id'])
             partner_bank = bdio._match_partner_bank(
                 partner, parsed_inv['iban'], parsed_inv.get('bic'),
-                parsed_inv['chatter_msg'], create_if_not_found=True)
+                parsed_inv['chatter_msg'],
+                create_if_not_found=company.invoice_import_create_bank_account)
             if partner_bank:
                 vals['partner_bank_id'] = partner_bank.id
         config = import_config  # just to make variable name shorter
@@ -819,7 +820,7 @@ class AccountInvoiceImport(models.TransientModel):
         return vals
 
     @api.model
-    def _prepare_update_invoice_vals(self, parsed_inv, partner):
+    def _prepare_update_invoice_vals(self, parsed_inv, invoice):
         bdio = self.env['business.document.import']
         vals = {
             'reference': parsed_inv.get('invoice_number'),
@@ -828,9 +829,11 @@ class AccountInvoiceImport(models.TransientModel):
         if parsed_inv.get('date_due'):
             vals['date_due'] = parsed_inv['date_due']
         if parsed_inv.get('iban'):
+            company = invoice.company_id
             partner_bank = bdio._match_partner_bank(
-                partner, parsed_inv['iban'], parsed_inv.get('bic'),
-                parsed_inv['chatter_msg'], create_if_not_found=True)
+                invoice.commercial_partner_id, parsed_inv['iban'],
+                parsed_inv.get('bic'), parsed_inv['chatter_msg'],
+                create_if_not_found=company.invoice_import_create_bank_account)
             if partner_bank:
                 vals['partner_bank_id'] = partner_bank.id
         return vals
@@ -871,7 +874,7 @@ class AccountInvoiceImport(models.TransientModel):
                 "The currency of the imported invoice (%s) is different from "
                 "the currency of the existing invoice (%s)") % (
                 currency.name, invoice.currency_id.name))
-        vals = self._prepare_update_invoice_vals(parsed_inv, partner)
+        vals = self._prepare_update_invoice_vals(parsed_inv, invoice)
         logger.debug('Updating supplier invoice with vals=%s', vals)
         self.invoice_id.write(vals)
         if (

--- a/base_business_document_import/models/business_document_import.py
+++ b/base_business_document_import/models/business_document_import.py
@@ -306,8 +306,16 @@ class BusinessDocumentImport(models.AbstractModel):
             chatter_msg.append(_(
                 "The bank account <b>IBAN %s</b> has been automatically "
                 "added on the supplier <b>%s</b>") % (
-                iban, partner.name))
+                iban, partner.display_name))
             return partner_bank
+        else:
+            chatter_msg.append(_(
+                "The analysis of the business document returned "
+                "<b>IBAN %s</b> as bank account, but there is no such "
+                "bank account in Odoo linked to partner <b>%s</b> and "
+                "the option to automatically create bank "
+                "accounts upon import is disabled.")
+                % (iban, partner.display_name))
 
     @api.model
     def _match_product(self, product_dict, chatter_msg, seller=False):


### PR DESCRIPTION
Creation of bank accounts is sensitive because, if you generate SEPA credit transfer XML files with Odoo, a wrong bank account can route money to a bad person. That's why I propose to make the auto-creation of bank accounts upon invoice import optional and disabled by default.