### PR TITLE
[12.0][FIX] account_invoice_ubl: related field must be not readonly

### DIFF
--- a/account_invoice_ubl/models/res_config_settings.py
+++ b/account_invoice_ubl/models/res_config_settings.py
@@ -9,4 +9,5 @@ class ResConfigSettings(models.TransientModel):
     _inherit = 'res.config.settings'
 
     embed_pdf_in_ubl_xml_invoice = fields.Boolean(
-        related='company_id.embed_pdf_in_ubl_xml_invoice')
+        related='company_id.embed_pdf_in_ubl_xml_invoice',
+        readonly=False)


### PR DESCRIPTION
This PR fixed the following issue:

- Go to menu *Invoicing > Configuration > Settings > Invoicing*.
- Under *Electronic Invoices*, the field "*Embed PDF in UBL XML Invoice*" is not selectable.

Field "*Embed PDF in UBL XML Invoice*"  is a related field and must be set as `readonly=False`.
