### PR TITLE
[10.0][FIX] Fill the account_id (required) for every configuration

### DIFF
--- a/account_invoice_import/wizard/account_invoice_import.py
+++ b/account_invoice_import/wizard/account_invoice_import.py
@@ -617,10 +617,13 @@ class AccountInvoiceImport(models.TransientModel):
             self, diff_amount, invoice, import_config):
         ailo = self.env['account.invoice.line']
         prec = invoice.currency_id.rounding
+        account = import_config.get(
+            'account', self.env['account.account'].browse())
         il_vals = {
             'name': _('Adjustment'),
             'quantity': 1,
             'price_unit': diff_amount,
+            'account_id': account.id,
             }
         # no taxes nor product on such a global adjustment line
         if import_config['invoice_line_method'] == 'nline_no_product':


### PR DESCRIPTION
Currently, if you select a "single" method to import invoice and without product, you'll have an error because the account_id is not filled.