### PR TITLE
[FIX] dependencies. (moved from travis to requirements.txt file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,10 +54,6 @@ install:
   #- wget -P /tmp http://public.akretion.com/pdftotext-3.04
   #- sudo mv /tmp/pdftotext-3.04 /usr/local/bin/pdftotext
   #- sudo chmod 755 /usr/local/bin/pdftotext
-  - pip install phonenumbers
-  - pip install weboob
-  - pip install ovh
-  - pip install PyPDF2
 
 script:
   - travis_run_tests

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,6 @@
 invoice2data>=0.2.74
 factur-x>=0.3
+phonenumbers
+weboob
+ovh
+PyPDF2


### PR DESCRIPTION
Hi. trying to fix l10n-france travis that is broken since monthes.

- l10n-france 10.0 contains a module ``l10n_fr_business_document_import`` that depends on ``edi/base_business_document_import``
-base_business_document_import depends on a python library named ``PyPDF2``
- in edi repository, the installation of PyPDF2 is located in the Travis file and not in the requirement file.
- AFAIK when Travis is installing, it loads the requirements of all the oca_dependencies repositories but not all the .travis file of those repositories.

So moving the installation of the librairies from travis file to requirement file. It should fix this PR that is currently failing. https://travis-ci.org/OCA/l10n-france/jobs/494960118#L1152 

@pedrobaeza : Is it a good approach ?

kind regards.

CC : @remi-filament 