### PR TITLE
[imp] multicompany awarenes for taxes on ubl items

### DIFF
--- a/base_ubl/models/ubl.py
+++ b/base_ubl/models/ubl.py
@@ -375,7 +375,8 @@ class BaseUbl(models.AbstractModel):
             else:
                 taxes = product.supplier_taxes_id
             if taxes:
-                for tax in taxes:
+                for tax in taxes.filtered(
+                        lambda t: t.company_id == self.env.user.company_id):
                     self._ubl_add_tax_category(
                         tax, item, ns, node_name='ClassifiedTaxCategory',
                         version=version)


### PR DESCRIPTION
In multicompany/multi-localization scenario, taxes defined on product will be collected for all companies/localizations, but while generating xml file, we need only the taxes for current company /loaclistion. 

To reproduce error correted with this PR you need to setup multicompany/multi localisation environment, define taxes for each localisation, and then try to create xml file.

If both localizations have taxes setup xml file will contain more tax lines (one for each localisation).
If only one localisation is set for createing UBL files, error will be raised for tax that has no setup on it. 

Aside from this, I'm not realy sure if anywhere else will be needed simmilar patch for multi company environment.