### PR TITLE
[10.0][IMP] account_invoice_import_ubl remove optional listAgencyID of InvoiceTypeCode to parse the invoice type

### DIFF
--- a/account_invoice_import_ubl/tests/files/efff_BE0505890632_160421_Inv_16117778.xml
+++ b/account_invoice_import_ubl/tests/files/efff_BE0505890632_160421_Inv_16117778.xml
@@ -5,7 +5,7 @@
   <cbc:ProfileID>FFF.BE ExactOnline</cbc:ProfileID>
   <cbc:ID>16117778</cbc:ID>
   <cbc:IssueDate>2016-04-21</cbc:IssueDate>
-  <cbc:InvoiceTypeCode listURI="http://www.FFF.be/ubl/2.0/cl/gc/BE-InvoiceCode-1.0.gc">380</cbc:InvoiceTypeCode>
+  <cbc:InvoiceTypeCode listURI="http://www.FFF.be/ubl/2.0/cl/gc/BE-InvoiceCode-1.0.gc">381</cbc:InvoiceTypeCode>
   <cbc:Note>Exact Online April / Mei 2016</cbc:Note>
   <cbc:TaxPointDate>2016-04-21</cbc:TaxPointDate>
   <cbc:DocumentCurrencyCode>EUR</cbc:DocumentCurrencyCode>

--- a/account_invoice_import_ubl/tests/test_ubl.py
+++ b/account_invoice_import_ubl/tests/test_ubl.py
@@ -18,6 +18,7 @@ class TestUbl(TransactionCase):
                 'date_invoice': '2015-02-16',
                 'due_date': '2015-02-16',
                 'partner_xmlid': 'account_invoice_import_ubl.ketentest',
+                'type': 'in_invoice',
                 },
             'efff_BE0505890632_160421_Inv_16117778.xml': {
                 'invoice_number': '16117778',
@@ -27,6 +28,7 @@ class TestUbl(TransactionCase):
                 'date_invoice': '2016-04-21',
                 'due_date': '2016-04-28',
                 'partner_xmlid': 'account_invoice_import_ubl.exact_belgium',
+                'type': 'in_refund',
                 },
             'UBLInvoice-multitankcard-line_adjust.xml': {
                 'invoice_number': '6311117',
@@ -34,6 +36,7 @@ class TestUbl(TransactionCase):
                 'amount_total': 90.77,
                 'date_invoice': '2017-03-07',
                 'partner_xmlid': 'account_invoice_import_ubl.multi_tank',
+                'type': 'in_invoice',
                 },
             }
         aio = self.env['account.invoice']

--- a/account_invoice_import_ubl/wizard/account_invoice_import.py
+++ b/account_invoice_import_ubl/wizard/account_invoice_import.py
@@ -144,7 +144,7 @@ class AccountInvoiceImport(models.TransientModel):
         self._ubl_check_xml_schema(xml_string, 'Invoice', version=ubl_version)
         prec = self.env['decimal.precision'].precision_get('Account')
         doc_type_xpath = xml_root.xpath(
-            "/inv:Invoice/cbc:InvoiceTypeCode[@listAgencyID='6']",
+            "/inv:Invoice/cbc:InvoiceTypeCode",
             namespaces=namespaces)
         inv_type = 'in_invoice'
         if doc_type_xpath:


### PR DESCRIPTION
**Current behavior**
We receive XML invoices and the invoice type is not correct because we don't have the tag `listAgencyID`.

**Fix**
As the tag (`listAgencyID`) seems optional, just remove it to read the `InvoiceTypeCode`.
(+ Adapt the unit test to ensure it's correctly parsed.)


I really don't know why Travis fail. I check the issue about partner_id is missing but I think it comes from another module.