### PR TITLE
[FIX] 10.0 bad use of play_onchange

### DIFF
--- a/account_invoice_import/wizard/account_invoice_import.py
+++ b/account_invoice_import/wizard/account_invoice_import.py
@@ -205,7 +205,7 @@ class AccountInvoiceImport(models.TransientModel):
             'journal_id': journal_id,
             'invoice_line_ids': [],
         }
-        vals = aio.play_onchanges(vals, ['partner_id'])
+        vals.update(aio.play_onchanges(vals, ['partner_id']))
         vals['invoice_line_ids'] = []
         # Force due date of the invoice
         if parsed_inv.get('date_due'):
@@ -243,7 +243,7 @@ class AccountInvoiceImport(models.TransientModel):
             elif config['invoice_line_method'] == '1line_static_product':
                 product = config['product']
                 il_vals = {'product_id': product.id, 'invoice_id': vals}
-                il_vals = ailo.play_onchanges(il_vals, ['product_id'])
+                il_vals.update(ailo.play_onchanges(il_vals, ['product_id']))
                 il_vals.pop('invoice_id')
             if config.get('label'):
                 il_vals['name'] = config['label']
@@ -267,7 +267,7 @@ class AccountInvoiceImport(models.TransientModel):
             elif config['invoice_line_method'] == 'nline_static_product':
                 sproduct = config['product']
                 static_vals = {'product_id': sproduct.id, 'invoice_id': vals}
-                static_vals = ailo.play_onchanges(static_vals, ['product_id'])
+                static_vals.update(ailo.play_onchanges(static_vals, ['product_id']))
                 static_vals.pop('invoice_id')
             else:
                 static_vals = {}
@@ -278,7 +278,7 @@ class AccountInvoiceImport(models.TransientModel):
                         line['product'], parsed_inv['chatter_msg'],
                         seller=partner)
                     il_vals = {'product_id': product.id, 'invoice_id': vals}
-                    il_vals = ailo.play_onchanges(il_vals, ['product_id'])
+                    il_vals.update(ailo.play_onchanges(il_vals, ['product_id']))
                     il_vals.pop('invoice_id')
                 elif config['invoice_line_method'] == 'nline_no_product':
                     taxes = bdio._match_taxes(

--- a/purchase_order_import/wizard/purchase_order_import.py
+++ b/purchase_order_import/wizard/purchase_order_import.py
@@ -214,7 +214,11 @@ class PurchaseOrderImport(models.TransientModel):
     @api.model
     def _prepare_create_order_line(self, product, uom, import_line, order):
         polo = self.env['purchase.order.line']
-        vals = {'product_id': product.id, 'order_id': order}
+        vals = {
+            'product_id': product.id,
+            'order_id': order,
+            'price_unit': import_line['price_unit'],
+        }
         vals.update(polo.play_onchanges(vals, ['product_id']))
         vals.pop('order_id')
         return vals

--- a/purchase_order_import/wizard/purchase_order_import.py
+++ b/purchase_order_import/wizard/purchase_order_import.py
@@ -139,17 +139,6 @@ class PurchaseOrderImport(models.TransientModel):
             vals['incoterm_id'] = incoterm.id
         return vals
 
-    @api.model
-    def _prepare_create_order_line(
-            self, product, qty, uom, price_unit, so_vals):
-        vals = {
-            'product_id': product.id,
-            'product_qty': qty,
-            'product_uom': uom.id,
-            'price_unit': price_unit,  # TODO fix
-        }
-        return vals
-
     @api.multi
     def update_order_lines(self, parsed_quote, order):
         polo = self.env['purchase.order.line']

--- a/purchase_order_import/wizard/purchase_order_import.py
+++ b/purchase_order_import/wizard/purchase_order_import.py
@@ -226,7 +226,7 @@ class PurchaseOrderImport(models.TransientModel):
     def _prepare_create_order_line(self, product, uom, import_line, order):
         polo = self.env['purchase.order.line']
         vals = {'product_id': product.id, 'order_id': order}
-        vals = polo.play_onchanges(vals, ['product_id'])
+        vals.update(polo.play_onchanges(vals, ['product_id']))
         vals.pop('order_id')
         return vals
 

--- a/sale_order_import/wizard/sale_order_import.py
+++ b/sale_order_import/wizard/sale_order_import.py
@@ -188,7 +188,7 @@ class SaleOrderImport(models.TransientModel):
             'partner_id': partner.id,
             'client_order_ref': parsed_order.get('order_ref'),
             }
-        so_vals = soo.play_onchanges(so_vals, ['partner_id'])
+        so_vals.update(soo.play_onchanges(so_vals, ['partner_id']))
         so_vals['order_line'] = []
         if parsed_order.get('ship_to'):
             shipping_partner = bdio._match_shipping_partner(
@@ -366,7 +366,7 @@ class SaleOrderImport(models.TransientModel):
             # but it is not enough: we also need to play _onchange_discount()
             # to have the right discount for pricelist
             vals['order_id'] = order
-            vals = solo.play_onchanges(vals, ['product_id'])
+            vals.update(solo.play_onchanges(vals, ['product_id']))
             vals.pop('order_id')
         return vals
 


### PR DESCRIPTION
The method `play_onchange` in `server-tools/onchange_helper`
only returns the changed keys in the dictionary it receives as first arguement (see https://github.com/OCA/server-tools/blob/10.0/onchange_helper/models/models.py#L106-L138)
The code in `account_invoice_import`, `purchase_order_import` and `sale_order_import`
was written as if all the keys were returned. Maybe the behavior of play_onchange
was updated in a recent version, but this nevertheless needs fixing in this module.
    
This should fix the unit tests which are red on this branch.

Also remove a method defined twice in `purchase_order_import`. 

Also fix purchase_order_import which would not add the unit price (maybe also related to the play_onchange changes)
