### PR TITLE
[12.0][FIX] account_invoice_ubl: fix error in general settings when uninstall

### DIFF
--- a/account_invoice_ubl/__init__.py
+++ b/account_invoice_ubl/__init__.py
@@ -1,4 +1,5 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from . import models
-from .post_install import set_xml_format_in_pdf_invoice_to_ubl
+from .hooks import set_xml_format_in_pdf_invoice_to_ubl
+from .hooks import remove_ubl_xml_format_in_pdf_invoice

--- a/account_invoice_ubl/__manifest__.py
+++ b/account_invoice_ubl/__manifest__.py
@@ -21,5 +21,6 @@
         'views/res_config_settings.xml',
         ],
     'post_init_hook': 'set_xml_format_in_pdf_invoice_to_ubl',
+    'uninstall_hook': 'remove_ubl_xml_format_in_pdf_invoice',
     'installable': True,
 }

--- a/account_invoice_ubl/hooks.py
+++ b/account_invoice_ubl/hooks.py
@@ -1,5 +1,6 @@
 # Copyright 2018 Akretion (http://www.akretion.com)
 # @author: Alexis de Lattre <alexis.delattre@akretion.com>
+# Copyright 2019 Onestein (<https://www.onestein.eu>)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from odoo import api, SUPERUSER_ID
@@ -10,4 +11,12 @@ def set_xml_format_in_pdf_invoice_to_ubl(cr, registry):
         env = api.Environment(cr, SUPERUSER_ID, {})
         companies = env['res.company'].search([])
         companies.write({'xml_format_in_pdf_invoice': 'ubl'})
-    return
+
+
+def remove_ubl_xml_format_in_pdf_invoice(cr, registry):
+    with api.Environment.manage():
+        env = api.Environment(cr, SUPERUSER_ID, {})
+        companies = env['res.company'].search([
+            ('xml_format_in_pdf_invoice', '=', 'ubl')
+        ])
+        companies.write({'xml_format_in_pdf_invoice': 'none'})

--- a/account_invoice_ubl/tests/test_ubl_generate.py
+++ b/account_invoice_ubl/tests/test_ubl_generate.py
@@ -1,9 +1,13 @@
 # Copyright 2016-2017 Akretion (http://www.akretion.com)
 # @author: Alexis de Lattre <alexis.delattre@akretion.com>
+# Copyright 2019 Onestein (<https://www.onestein.eu>)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from odoo.addons.account_tax_unece.tests.test_account_invoice import \
     TestAccountInvoice
+
+from ..hooks import set_xml_format_in_pdf_invoice_to_ubl
+from ..hooks import remove_ubl_xml_format_in_pdf_invoice
 
 
 class TestUblInvoice(TestAccountInvoice):
@@ -22,3 +26,17 @@ class TestUblInvoice(TestAccountInvoice):
             res = buo.get_xml_files_from_pdf(pdf_file)
             invoice_filename = invoice.get_ubl_filename(version=version)
             self.assertTrue(invoice_filename in res)
+
+    def test_install_uninstall_hooks(self):
+        set_xml_format_in_pdf_invoice_to_ubl(self.env.cr, None)
+        self.assertTrue(self.env['res.company'].search([
+            ('xml_format_in_pdf_invoice', '=', 'ubl')
+        ]))
+        remove_ubl_xml_format_in_pdf_invoice(self.env.cr, None)
+        self.assertFalse(self.env['res.company'].search([
+            ('xml_format_in_pdf_invoice', '=', 'ubl')
+        ]))
+        set_xml_format_in_pdf_invoice_to_ubl(self.env.cr, None)
+        self.assertTrue(self.env['res.company'].search([
+            ('xml_format_in_pdf_invoice', '=', 'ubl')
+        ]))


### PR DESCRIPTION
This PR fixes an error displayed when uninstalling `account_invoice_ubl` in case the general settings *XML Format embedded in PDF invoice* is set to *Universal Business Language (UBL)*, .