### PR TITLE
[12.0] Improve integration in reporting engine

### DIFF
--- a/account_e-invoice_generate/__manifest__.py
+++ b/account_e-invoice_generate/__manifest__.py
@@ -12,6 +12,7 @@
     'author': 'Akretion,Odoo Community Association (OCA)',
     'website': 'https://github.com/OCA/edi',
     'depends': ['account'],
+    'excludes': ['account_facturx'],
     'data': [
         'views/res_config_settings.xml',
     ],

--- a/account_e-invoice_generate/models/account_invoice.py
+++ b/account_e-invoice_generate/models/account_invoice.py
@@ -1,7 +1,7 @@
 # Copyright 2018 Akretion (Alexis de Lattre <alexis.delattre@akretion.com>)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import models
+from odoo import api, models
 
 
 class AccountInvoice(models.Model):
@@ -11,3 +11,9 @@ class AccountInvoice(models.Model):
         """This method is designed to be inherited in localization modules"""
         self.ensure_one()
         return None
+
+    @api.model
+    def _get_invoice_report_names(self):
+        return [
+            'account.report_invoice',
+            'account.report_invoice_with_payments']

--- a/account_e-invoice_generate/readme/CONFIGURE.rst
+++ b/account_e-invoice_generate/readme/CONFIGURE.rst
@@ -1,2 +1,2 @@
 The new configuration parameter *XML Format embedded in PDF invoice*
-is available in the menu *Accounting > Configuration > Settings*.
+is available in the menu *Invoicing > Configuration > Settings*.

--- a/account_e-invoice_generate/readme/INSTALL.rst
+++ b/account_e-invoice_generate/readme/INSTALL.rst
@@ -1,0 +1,5 @@
+The project `OCA/edi <https://github.com/OCA/edi>`_ provides modules to generate UBL and Factur-X invoices. This solution designed by OCA is an **alternative** to the solution provided by Odoo S.A. in the official addons (Community version), it is not a solution built above it.
+
+As a consequence, before installing this module, you should uninstall the module *account_facturx* of Odoo S.A. The module *account_facturx* is an auto-install module, so it is probably installed by default on your Odoo.
+
+If you want to generate Factur-X invoices, you should install the OCA module *account_invoice_factur-x* available on `OCA/edi <https://github.com/OCA/edi>`_.

--- a/account_invoice_ubl/models/ir_actions_report.py
+++ b/account_invoice_ubl/models/ir_actions_report.py
@@ -9,15 +9,15 @@ class IrActionsReport(models.Model):
     _inherit = "ir.actions.report"
 
     @api.multi
-    def render_qweb_pdf(self, res_ids=None, data=None):
+    def _post_pdf(self, save_in_attachment, pdf_content=None, res_ids=None):
         """We go through that method when the PDF is generated for the 1st
         time and also when it is read from the attachment.
         This method is specific to QWeb"""
-        pdf_content = super().render_qweb_pdf(res_ids, data)
         invoice_reports = self._get_invoice_reports_ubl()
         if (
                 len(self) == 1 and
                 self.report_name in invoice_reports and
+                res_ids and
                 len(res_ids) == 1 and
                 not self._context.get('no_embedded_ubl_xml')):
             invoice = self.env['account.invoice'].browse(res_ids[0])
@@ -27,7 +27,8 @@ class IrActionsReport(models.Model):
                 pdf_content = invoice.with_context(
                     no_embedded_pdf=True).embed_ubl_xml_in_pdf(
                     pdf_content=pdf_content)
-        return pdf_content
+        return super()._post_pdf(
+            save_in_attachment, pdf_content=pdf_content, res_ids=res_ids)
 
     @classmethod
     def _get_invoice_reports_ubl(cls):

--- a/base_ubl/models/ubl.py
+++ b/base_ubl/models/ubl.py
@@ -526,7 +526,7 @@ class BaseUbl(models.AbstractModel):
         if pdf_file:
             original_pdf_file = pdf_file
         elif pdf_content:
-            original_pdf_file = BytesIO(pdf_content[0])
+            original_pdf_file = BytesIO(pdf_content)
         original_pdf = PdfFileReader(original_pdf_file)
         new_pdf_filestream = PdfFileWriter()
         new_pdf_filestream.appendPagesFromReader(original_pdf)
@@ -545,8 +545,7 @@ class BaseUbl(models.AbstractModel):
             with NamedTemporaryFile(prefix='odoo-ubl-', suffix='.pdf') as f:
                 new_pdf_filestream.write(f)
                 f.seek(0)
-                file_content = f.read()
-                new_pdf_content = (file_content, pdf_content[1])
+                new_pdf_content = f.read()
                 f.close()
         logger.info('%s file added to PDF', xml_filename)
         return new_pdf_content


### PR DESCRIPTION
With this new implementation, the PDF attachment of the invoice is stored with the XML data; if attachment_use is True, when you print the invoice again, it will NOT regenerate the XML, it will give you the original PDF file with the original XML attachment.