### PR TITLE
[FIX]Restore new api compatibility to get_pdf method

### DIFF
--- a/purchase_order_ubl/models/report.py
+++ b/purchase_order_ubl/models/report.py
@@ -37,5 +37,5 @@ class Report(models.Model):
 
     @api.v8  # noqa
     def get_pdf(self, records, report_name, html=None, data=None):
-        return Report.get_pdf(self._model, self._cr, self._uid, records.ids,
+        return self._model.get_pdf(self._cr, self._uid, records.ids,
                               report_name, html=html, data=data, context=self._context)

--- a/purchase_order_ubl/models/report.py
+++ b/purchase_order_ubl/models/report.py
@@ -34,3 +34,8 @@ class Report(models.Model):
             pdf_content = order.embed_ubl_xml_in_pdf(
                 pdf_content)
         return pdf_content
+
+    @api.v8  # noqa
+    def get_pdf(self, records, report_name, html=None, data=None):
+        return Report.get_pdf(self._model, self._cr, self._uid, records.ids,
+                              report_name, html=html, data=data, context=self._context)


### PR DESCRIPTION
@sbidoul @alexis-via @bealdav 

This api.v7 break the compatibility with new api call to get_pdf.
To address this issue, I do the same as in the official report module.