### PR TITLE
[10.0][FIX] account_invoice_import_factur-x: facturx Python module does not exist

### DIFF
--- a/account_invoice_factur-x/__manifest__.py
+++ b/account_invoice_factur-x/__manifest__.py
@@ -16,7 +16,7 @@
         'base_zugferd',
         'base_vat',
         ],
-    'external_dependencies': {'python': ['facturx']},
+    'external_dependencies': {'python': ['factur-x']},
     'data': [
         'views/res_partner.xml',
         'views/account_config_settings.xml',

--- a/account_invoice_factur-x_py3o/__manifest__.py
+++ b/account_invoice_factur-x_py3o/__manifest__.py
@@ -11,6 +11,6 @@
     'author': 'Akretion,Odoo Community Association (OCA)',
     'website': 'http://www.akretion.com',
     'depends': ['account_invoice_factur-x', 'report_py3o'],
-    'external_dependencies': {'python': ['facturx']},
+    'external_dependencies': {'python': ['factur-x']},
     'installable': True,
 }

--- a/account_invoice_import_factur-x/__manifest__.py
+++ b/account_invoice_import_factur-x/__manifest__.py
@@ -11,7 +11,7 @@
     'author': 'Akretion,Odoo Community Association (OCA)',
     'website': 'http://www.akretion.com',
     'depends': ['account_invoice_import', 'base_zugferd'],
-    'external_dependencies': {'python': ['facturx']},
+    'external_dependencies': {'python': ['factur-x']},
     'data': ['wizard/account_invoice_import_view.xml'],
     'demo': ['demo/demo_data.xml'],
     'installable': True,


### PR DESCRIPTION
```
$ pip install facturx
DEPRECATION: Python 2.7 reached the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 is no longer maintained. A future version of pip will drop support for Python 2.7. More details about Python 2 support in pip, can be found at https://pip.pypa.io/en/latest/development/release-process/#python-2-support
ERROR: Could not find a version that satisfies the requirement facturx (from versions: none)
ERROR: No matching distribution found for facturx
```
This is also why Travis is currently not able to build the test environment.