### PR TITLE
[10.0] FIX #104 base_ubl: use address of partner, not of commercial_parter

### DIFF
--- a/base_ubl/models/ubl.py
+++ b/base_ubl/models/ubl.py
@@ -186,10 +186,10 @@ class BaseUbl(models.AbstractModel):
         if partner.lang:
             self._ubl_add_language(partner.lang, party, ns, version=version)
         self._ubl_add_address(
-            commercial_partner, 'PostalAddress', party, ns, version=version)
+            partner, 'PostalAddress', party, ns, version=version)
         self._ubl_add_party_tax_scheme(
             commercial_partner, party, ns, version=version)
-        if company:
+        if commercial_partner.is_company or company:
             self._ubl_add_party_legal_entity(
                 commercial_partner, party, ns, version='2.1')
         self._ubl_add_contact(partner, party, ns, version=version)


### PR DESCRIPTION
Add legal entity block when commercial_partner.is_company = True