### PR TITLE
8.0 purchase_order_ubl: complete order states

### DIFF
--- a/purchase_order_ubl/models/purchase.py
+++ b/purchase_order_ubl/models/purchase.py
@@ -19,7 +19,7 @@ class PurchaseOrder(models.Model):
 
     @api.model
     def get_order_states(self):
-        return ['approved', 'except_picking', 'except_invoice', 'done']
+        return ['confirmed', 'approved', 'except_picking', 'except_invoice', 'done']
 
     @api.multi
     def _ubl_add_header(self, doc_type, parent_node, ns, version='2.1'):


### PR DESCRIPTION
### What's wrong

"confirmed" state is not considered in purchase_order_ubl

while it's valid odoo state

https://github.com/odoo/odoo/blob/8.0/addons/purchase/purchase.py#L204
