### PR TITLE
[13.0][ADD] account_invoice_export

### DIFF
--- a/account_invoice_export/__init__.py
+++ b/account_invoice_export/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/account_invoice_export/__manifest__.py
+++ b/account_invoice_export/__manifest__.py
@@ -1,0 +1,20 @@
+# Copyright 2020 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+{
+    "name": "Account Invoice Export",
+    "version": "13.0.1.0.0",
+    "category": "Invoicing Management",
+    "license": "AGPL-3",
+    "summary": "",
+    "author": "Camptocamp SA, Odoo Community Association (OCA)",
+    "website": "https://github.com/oca/edi",
+    "depends": ["account_invoice_transmit_method", "queue_job"],
+    "data": [
+        "data/mail_activity_type.xml",
+        "views/transmit_method.xml",
+        "views/account_move.xml",
+        "views/message_template.xml",
+    ],
+    "installable": True,
+}

--- a/account_invoice_export/data/mail_activity_type.xml
+++ b/account_invoice_export/data/mail_activity_type.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <data noupdate="1">
+        <record id="mail_activity_transmit_warning" model="mail.activity.type">
+            <field name="name">Transmission Error</field>
+            <field name="icon">fa-warning</field>
+            <field name="delay_count">0</field>
+            <field name="sequence">99</field>
+            <field name="decoration_type">warning</field>
+        </record>
+    </data>
+</odoo>

--- a/account_invoice_export/models/__init__.py
+++ b/account_invoice_export/models/__init__.py
@@ -1,2 +1,2 @@
-from . import transmit_method
 from . import account_move
+from . import transmit_method

--- a/account_invoice_export/models/__init__.py
+++ b/account_invoice_export/models/__init__.py
@@ -1,0 +1,2 @@
+from . import transmit_method
+from . import account_move

--- a/account_invoice_export/models/account_move.py
+++ b/account_invoice_export/models/account_move.py
@@ -1,0 +1,122 @@
+# Copyright 2020 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+import requests
+
+import odoo
+from odoo import _, fields, models
+from odoo.exceptions import UserError
+
+from odoo.addons.queue_job.job import job
+
+
+class AccountMove(models.Model):
+    _inherit = "account.move"
+
+    invoice_sent_through_http = fields.Boolean(copy=False)
+
+    def send_through_http(self):
+        for invoice in self:
+            if invoice.transmit_method_id.send_through_http:
+                invoice.with_delay()._send_through_http()
+
+    @job
+    def _send_through_http(self):
+        """Send invoice to server configured in transmit method."""
+        self.ensure_one()
+        if self.invoice_sent_through_http:
+            return "Invoice has already been sent through http before."
+
+        try:
+            if not self.transmit_method_id.send_through_http:
+                raise UserError(
+                    _("Transmit method is not configured to send through HTTP")
+                )
+            file_data = self._get_file_for_transmission_method()
+            headers = self.transmit_method_id.get_transmission_http_header()
+            res = requests.post(
+                self.transmit_method_id.destination_url,
+                headers=headers,
+                files=file_data,
+            )
+            if res.status_code != 200:
+                raise UserError(
+                    _(
+                        "HTTP error {} sending invoice to {}".format(
+                            res.status_code, self.transmit_method_id.name
+                        )
+                    )
+                )
+        except Exception as e:
+            values = {
+                "job_id": self.env.context.get("job_uuid"),
+                "error_detail": "",
+                "error_type": type(e).__name__,
+                "transmit_method_name": self.transmit_method_id.name,
+            }
+            if type(e) == UserError:
+                values["error_detail"] = e.name
+            with odoo.api.Environment.manage():
+                with odoo.registry(self.env.cr.dbname).cursor() as new_cr:
+                    # Create a new environment with new cursor database
+                    new_env = odoo.api.Environment(
+                        new_cr, self.env.uid, self.env.context
+                    )
+                    # The chatter of the invoice need to be updated, when the job fails
+                    self.with_env(new_env).log_error_sending_invoice(values)
+            raise
+
+        self.invoice_sent_through_http = True
+        self.invoice_send = True
+        self.log_success_sending_invoice()
+        return res.text
+
+    def _get_file_for_transmission_method(self):
+        """Return the file description to send.
+
+        Use the format expected by the request library
+        By default returns the PDF report.
+        """
+        r = self.env["ir.actions.report"]._get_report_from_name(
+            "account.report_invoice"
+        )
+        pdf, _ = r.render([self.id])
+        filename = self._get_report_base_filename().replace("/", "_") + ".pdf"
+        return {"file": (filename, pdf, "application/pdf")}
+
+    def log_error_sending_invoice(self, values):
+        """Log an exception in invoice's chatter when sending fails.
+
+        If an exception already exists it is update otherwise a new one
+        is created.
+
+        """
+        activity_type = "account_invoice_export.mail_activity_transmit_warning"
+        activity = self.activity_reschedule(
+            [activity_type], date_deadline=fields.Date.today()
+        )
+        if not activity:
+            message = self.env.ref(
+                "account_invoice_export.exception_sending_invoice"
+            ).render(values=values)
+            activity = self.activity_schedule(
+                activity_type, summary="Job error sending invoice", note=message
+            )
+        error_log = values.get("error_detail")
+        if not error_log:
+            error_log = _("An error of type {} occured.").format(
+                values.get("error_type")
+            )
+        activity.note += "<div class='mt16'><p>{}</p></div>".format(error_log)
+
+    def log_success_sending_invoice(self):
+        """Log success sending invoice and clear existing exception, if any."""
+        self.activity_feedback(
+            ["account_invoice_export.mail_activity_transmit_warning"],
+            feedback="It worked on a later try",
+        )
+        self.message_post(
+            body=_("Invoice successfuly sent to {}").format(
+                self.transmit_method_id.name
+            )
+        )

--- a/account_invoice_export/models/transmit_method.py
+++ b/account_invoice_export/models/transmit_method.py
@@ -1,0 +1,26 @@
+# Copyright 2020 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+import base64
+
+from odoo import fields, models
+
+
+class TransmitMethod(models.Model):
+    _inherit = "transmit.method"
+
+    send_through_http = fields.Boolean()
+    destination_url = fields.Char(string="Url")
+    destination_user = fields.Char(string="User", copy=False)
+    destination_pwd = fields.Char(string="Password", copy=False)
+
+    def get_transmission_http_header(self):
+        """Generate the HTTP header needed by the transmission method.
+
+        For now only basic authentication is implemented.
+
+        """
+        self.ensure_one()
+        auth = "{}:{}".format(self.destination_user, self.destination_pwd,)
+        auth64 = base64.encodebytes(auth.encode("ascii"))[:-1]
+        return {"Authorization": "Basic " + auth64.decode("utf-8")}

--- a/account_invoice_export/readme/CONTRIBUTORS.rst
+++ b/account_invoice_export/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Thierry Ducrest <thierry.ducrest@camptocamp.com>

--- a/account_invoice_export/readme/DESCRIPTION.rst
+++ b/account_invoice_export/readme/DESCRIPTION.rst
@@ -1,7 +1,6 @@
 The goal of this module is to allow sending invoices in different format to external systems.
 
-It is based on the module `account_invoice_transmit_method` and offer the option to configure `transmit.method` applied to customer with an url and credentials (Only Basic Authentication is implemented).
-
-The function `_get_file_for_transmission_method` on `account.move` can be overriden to return the file description specific to a transmit method.
+It extends the module `account_invoice_transmit_method`, adding options to configure an url and credentials (Basic Authentication).
+In the UI a new button `Send ebill` send the invoice pdf to the configure url.
 
 The actual sending of the invoice is manage by queue.job and the standard Odoo chatter on the invoice is used to inform the user on success/failure of the dispatch.

--- a/account_invoice_export/readme/DESCRIPTION.rst
+++ b/account_invoice_export/readme/DESCRIPTION.rst
@@ -1,0 +1,7 @@
+The goal of this module is to allow sending invoices in different format to external systems.
+
+It is based on the module `account_invoice_transmit_method` and offer the option to configure `transmit.method` applied to customer with an url and credentials (Only Basic Authentication is implemented).
+
+The function `_get_file_for_transmission_method` on `account.move` can be overriden to return the file description specific to a transmit method.
+
+The actual sending of the invoice is manage by queue.job and the standard Odoo chatter on the invoice is used to inform the user on success/failure of the dispatch.

--- a/account_invoice_export/tests/__init__.py
+++ b/account_invoice_export/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_export_invoice

--- a/account_invoice_export/tests/test_export_invoice.py
+++ b/account_invoice_export/tests/test_export_invoice.py
@@ -18,7 +18,7 @@ class TestExportAcountInvoice(SingleTransactionCase):
                 "code": "httppost",
                 "customer_ok": True,
                 "send_through_http": True,
-                "destination_url": "https://somewhere.com/post",
+                "destination_url": "https://example.com/post",
                 "destination_user": "user",
                 "destination_pwd": "pwd",
             }
@@ -77,7 +77,5 @@ class TestExportAcountInvoice(SingleTransactionCase):
         self.assertEqual(len(self.invoice_1.activity_ids), 0)
 
     def test_get_file_description(self):
-        self.invoice_1._get_file_for_transmission_method()
-
-    # def test_export_invoice(self):
-    # self.invoice_1.send_through_http()
+        res = self.invoice_1._get_file_for_transmission_method()
+        self.assertTrue(res["file"])

--- a/account_invoice_export/tests/test_export_invoice.py
+++ b/account_invoice_export/tests/test_export_invoice.py
@@ -1,0 +1,83 @@
+# Copyright 2020 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+from odoo.tests.common import SingleTransactionCase
+
+
+class TestExportAcountInvoice(SingleTransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
+        cls.send_exception = cls.env.ref(
+            "account_invoice_export.mail_activity_transmit_warning"
+        )
+        cls.transmit_method = cls.env["transmit.method"].create(
+            {
+                "name": "HttpPost",
+                "code": "httppost",
+                "customer_ok": True,
+                "send_through_http": True,
+                "destination_url": "https://somewhere.com/post",
+                "destination_user": "user",
+                "destination_pwd": "pwd",
+            }
+        )
+        cls.country = cls.env.ref("base.ch")
+        cls.customer = cls.env.ref("base.res_partner_1")
+        cls.account = cls.env["account.account"].search(
+            [
+                (
+                    "user_type_id",
+                    "=",
+                    cls.env.ref("account.data_account_type_revenue").id,
+                )
+            ],
+            limit=1,
+        )
+        cls.product = cls.env.ref("product.product_product_1")
+        cls.invoice_1 = cls.env["account.move"].create(
+            {
+                "partner_id": cls.customer.id,
+                "type": "out_invoice",
+                "transmit_method_id": cls.transmit_method.id,
+                "invoice_line_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "account_id": cls.account.id,
+                            "product_id": cls.product.product_variant_ids[:1].id,
+                            "name": "Product 1",
+                            "quantity": 4.0,
+                            "price_unit": 123.00,
+                        },
+                    )
+                ],
+            }
+        )
+        cls.invoice_1.action_post()
+
+    def test_log_error_in_chatter(self):
+        values = {
+            "job_id": "13:123:123",
+            "send_error": 500,
+            "transmit_method_name": "SendMethod",
+        }
+        self.invoice_1.log_error_sending_invoice(values)
+        self.assertEqual(len(self.invoice_1.activity_ids), 1)
+        self.assertEqual(
+            self.invoice_1.activity_ids[0].activity_type_id, self.send_exception
+        )
+        # Multiple error only one exception message
+        self.invoice_1.log_error_sending_invoice(values)
+        self.assertEqual(len(self.invoice_1.activity_ids), 1)
+        # At success exception messages are cleared
+        self.invoice_1.log_success_sending_invoice()
+        self.assertEqual(len(self.invoice_1.activity_ids), 0)
+
+    def test_get_file_description(self):
+        self.invoice_1._get_file_for_transmission_method()
+
+    # def test_export_invoice(self):
+    # self.invoice_1.send_through_http()

--- a/account_invoice_export/views/account_move.xml
+++ b/account_invoice_export/views/account_move.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="view_move_form" model="ir.ui.view">
+        <field name="name">Account Invoice Export on Invoice form view</field>
+        <field name="model">account.move</field>
+        <field name="inherit_id" ref="account.view_move_form" />
+        <field name="arch" type="xml">
+            <field name="transmit_method_id" position="after">
+                <field name="invoice_sent_through_http" invisible="1" />
+            </field>
+            <button name="action_invoice_sent" position="after">
+                <button
+                    name="send_through_http"
+                    string="Send eBill"
+                    type="object"
+                    attrs="{'invisible':['|', ('state', '!=', 'posted'), ('invoice_sent_through_http', '=', True)]}"
+                    groups="base.group_user"
+                    class="oe_highlight"
+                />
+            </button>
+        </field>
+    </record>
+    <record id="view_invoice_tree" model="ir.ui.view">
+        <field name="model">account.move</field>
+        <field name="inherit_id" ref="account.view_invoice_tree" />
+        <field name="arch" type="xml">
+            <field name="state" position="after">
+                <field
+                    name="activity_exception_decoration"
+                    widget="activity_exception"
+                />
+            </field>
+        </field>
+    </record>
+    <record model="ir.actions.server" id="action_send_ebill">
+        <field name="name">Send eBill</field>
+        <field name="model_id" ref="account.model_account_move" />
+        <field name="binding_model_id" ref="account.model_account_move" />
+        <field name="state">code</field>
+        <field name="code">
+        records.send_through_http()
+      </field>
+    </record>
+</odoo>

--- a/account_invoice_export/views/account_move.xml
+++ b/account_invoice_export/views/account_move.xml
@@ -6,16 +6,26 @@
         <field name="inherit_id" ref="account.view_move_form" />
         <field name="arch" type="xml">
             <field name="transmit_method_id" position="after">
-                <field name="invoice_sent_through_http" invisible="1" />
+                <field name="invoice_exported" invisible="1" />
+                <field name="invoice_export_confirmed" invisible="1" />
             </field>
             <button name="action_invoice_sent" position="after">
                 <button
-                    name="send_through_http"
+                    name="export_invoice"
                     string="Send eBill"
                     type="object"
-                    attrs="{'invisible':['|', ('state', '!=', 'posted'), ('invoice_sent_through_http', '=', True)]}"
+                    attrs="{'invisible':['|', ('state', '!=', 'posted'), ('invoice_exported', '=', True)]}"
                     groups="base.group_user"
                     class="oe_highlight"
+                />
+                <button
+                    name="export_invoice"
+                    string="Resend eBill"
+                    type="object"
+                    attrs="{'invisible':['|', ('state', '!=', 'posted'), '|', ('invoice_export_confirmed', '=', True), ('invoice_exported', '=', False)]}"
+                    groups="base.group_user"
+                    class="oe_highlight"
+                    confirm="Ebill has already been sent, but has not yet been accpeted by the distant system. Are you sure you want to send it again ?"
                 />
             </button>
         </field>
@@ -38,7 +48,7 @@
         <field name="binding_model_id" ref="account.model_account_move" />
         <field name="state">code</field>
         <field name="code">
-        records.send_through_http()
+        records.export_invoice()
       </field>
     </record>
 </odoo>

--- a/account_invoice_export/views/account_move.xml
+++ b/account_invoice_export/views/account_move.xml
@@ -14,7 +14,7 @@
                     name="export_invoice"
                     string="Send eBill"
                     type="object"
-                    attrs="{'invisible':['|', ('state', '!=', 'posted'), ('invoice_exported', '=', True)]}"
+                    attrs="{'invisible':['|', '|', ('state', '!=', 'posted'), ('invoice_exported', '=', True), ('type', 'not in', ('out_invoice', 'out_refund'))]}"
                     groups="base.group_user"
                     class="oe_highlight"
                 />
@@ -22,7 +22,7 @@
                     name="export_invoice"
                     string="Resend eBill"
                     type="object"
-                    attrs="{'invisible':['|', ('state', '!=', 'posted'), '|', ('invoice_export_confirmed', '=', True), ('invoice_exported', '=', False)]}"
+                    attrs="{'invisible':['|', '|', ('state', '!=', 'posted'), '|', ('invoice_export_confirmed', '=', True), ('invoice_exported', '=', False), ('type', 'not in', ('out_invoice', 'out_refund'))]}"
                     groups="base.group_user"
                     class="oe_highlight"
                     confirm="Ebill has already been sent, but has not yet been accpeted by the distant system. Are you sure you want to send it again ?"

--- a/account_invoice_export/views/message_template.xml
+++ b/account_invoice_export/views/message_template.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <template id="exception_sending_invoice">
+        <div>
+            <p>Error sending invoice to <t t-esc="transmit_method_name" />.</p>
+            <p>The failed job has the uuid <t t-esc="job_id" /></p>
+        </div>
+    </template>
+</odoo>

--- a/account_invoice_export/views/transmit_method.xml
+++ b/account_invoice_export/views/transmit_method.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="transmit_method_form" model="ir.ui.view">
+        <field name="name">Transmit Method Form view Export</field>
+        <field name="model">transmit.method</field>
+        <field
+            name="inherit_id"
+            ref="account_invoice_transmit_method.transmit_method_form"
+        />
+        <field name="arch" type="xml">
+            <xpath expr="//group[@name='main']" position="after">
+                <group
+                    name="export"
+                    attrs="{'invisible': [('customer_ok', '=', False)]}"
+                >
+                    <field name="send_through_http" />
+                    <field
+                        name="destination_url"
+                        attrs="{'invisible': [('send_through_http', '=', False)]}"
+                    />
+                    <field
+                        name="destination_user"
+                        attrs="{'invisible': [('send_through_http', '=', False)]}"
+                    />
+                    <field
+                        name="destination_pwd"
+                        attrs="{'invisible': [('send_through_http', '=', False)]}"
+                    />
+                </group>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/oca_dependencies.txt
+++ b/oca_dependencies.txt
@@ -2,3 +2,5 @@ community-data-files
 partner-contact
 sale-workflow
 server-tools
+account-invoicing
+queue

--- a/setup/account_invoice_export/odoo/addons/account_invoice_export
+++ b/setup/account_invoice_export/odoo/addons/account_invoice_export
@@ -1,0 +1,1 @@
+../../../../account_invoice_export

--- a/setup/account_invoice_export/setup.py
+++ b/setup/account_invoice_export/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION

The goal of this module is to allow sending invoices in different format to external systems.

It extends the module `account_invoice_transmit_method`, adding options to configure an url and credentials (Basic Authentication).
In the UI a new button `Send ebill` send the invoice pdf to the configure url.

The actual sending of the invoice is manage by queue.job and the standard Odoo chatter on the invoice is used to inform the user on success/failure of the dispatch.