### PR TITLE
[IMP] . amounts decimal places should be no more than 2

### DIFF
--- a/account_invoice_ubl/models/account_invoice.py
+++ b/account_invoice_ubl/models/account_invoice.py
@@ -95,6 +95,7 @@ class AccountInvoice(models.Model):
             parent_node, ns['cac'] + 'LegalMonetaryTotal')
         cur_name = self.currency_id.name
         prec = self.currency_id.decimal_places
+        prec = prec if prec <= 2 else 2
         line_total = etree.SubElement(
             monetary_total, ns['cbc'] + 'LineExtensionAmount',
             currencyID=cur_name)
@@ -126,7 +127,9 @@ class AccountInvoice(models.Model):
         dpo = self.env['decimal.precision']
         qty_precision = dpo.precision_get('Product Unit of Measure')
         price_precision = dpo.precision_get('Product Price')
+        price_precision = price_precision if price_precision <= 2 else 2
         account_precision = self.currency_id.decimal_places
+        account_precision = account_precision if account_precision <= 2 else 2
         line_id = etree.SubElement(line_root, ns['cbc'] + 'ID')
         line_id.text = str(line_number)
         uom_unece_code = False
@@ -174,6 +177,7 @@ class AccountInvoice(models.Model):
             self, iline, parent_node, ns, version='2.1'):
         cur_name = self.currency_id.name
         prec = self.currency_id.decimal_places
+        prec = prec if prec <= 2 else 2
         tax_total_node = etree.SubElement(parent_node, ns['cac'] + 'TaxTotal')
         price = iline.price_unit * (1 - (iline.discount or 0.0) / 100.0)
         res_taxes = iline.invoice_line_tax_ids.compute_all(
@@ -200,6 +204,7 @@ class AccountInvoice(models.Model):
         tax_amount_node = etree.SubElement(
             tax_total_node, ns['cbc'] + 'TaxAmount', currencyID=cur_name)
         prec = self.currency_id.decimal_places
+        prec = prec if prec <= 2 else 2
         tax_amount_node.text = '%0.*f' % (prec, self.amount_tax)
         if not float_is_zero(self.amount_tax, precision_digits=prec):
             for tline in self.tax_line_ids:

--- a/base_ubl/models/ubl.py
+++ b/base_ubl/models/ubl.py
@@ -395,6 +395,7 @@ class BaseUbl(models.AbstractModel):
             self, taxable_amount, tax_amount, tax, currency_code,
             parent_node, ns, version='2.1'):
         prec = self.env['decimal.precision'].precision_get('Account')
+        prec = prec if prec <= 2 else 2
         tax_subtotal = etree.SubElement(parent_node, ns['cac'] + 'TaxSubtotal')
         if not float_is_zero(taxable_amount, precision_digits=prec):
             taxable_amount_node = etree.SubElement(


### PR DESCRIPTION
According to UBL standars and validations 
[BR-DEC-19]-The allowed maximum number of decimals for the VATcategory taxable amount (BT-116) is 2.;
[BR-DEC-20]-The allowedmaximum number of decimals for the VAT category tax amount (BT-117) is 2.    ;
[UBL-DT-01]-Amounts shall be decimal up to two fractiondigits;[UBL-DT-01]-Amounts shall be decimal up to two fraction digits

Currently with accounting precision set to 3 or more decimal places we generate invalid XML file
This fix hardcodes 2 decimal places instead of using any given precission, 

Same fix shoul be applied to base_ubl module