### PR TITLE
[13.0][FIX] account_invoice_ubl customer ref

### DIFF
--- a/account_invoice_ubl/__manifest__.py
+++ b/account_invoice_ubl/__manifest__.py
@@ -15,6 +15,7 @@
         "account_payment_partner",
         "base_ubl_payment",
         "account_tax_unece",
+        "sale",
     ],
     "data": ["views/account_move.xml", "views/res_config_settings.xml"],
     "post_init_hook": "set_xml_format_in_pdf_invoice_to_ubl",

--- a/account_invoice_ubl/models/account_move.py
+++ b/account_invoice_ubl/models/account_move.py
@@ -39,10 +39,17 @@ class AccountMove(models.Model):
 
     def _ubl_add_order_reference(self, parent_node, ns, version="2.1"):
         self.ensure_one()
-        if self.name:
-            order_ref = etree.SubElement(parent_node, ns["cac"] + "OrderReference")
+        order_id = self.line_ids.mapped("sale_line_ids.order_id")
+        if len(order_id) > 1:
+            logger.warning("UBL Invoice for multiple sale order")
+            order_id = order_id[0]
+        order_ref = etree.SubElement(parent_node, ns["cac"] + "OrderReference")
+        order_ref_orderid = etree.SubElement(order_ref, ns["cbc"] + "SalesOrderID")
+        order_ref_orderid.text = order_id.name
+        customer_ref = order_id.client_order_ref
+        if customer_ref:
             order_ref_id = etree.SubElement(order_ref, ns["cbc"] + "ID")
-            order_ref_id.text = self.name
+            order_ref_id.text = customer_ref
 
     def _ubl_get_contract_document_reference_dict(self):
         """Result: dict with key = Doc Type Code, value = ID"""

--- a/account_invoice_ubl/models/account_move.py
+++ b/account_invoice_ubl/models/account_move.py
@@ -45,7 +45,7 @@ class AccountMove(models.Model):
             order_id = order_id[0]
         order_ref = etree.SubElement(parent_node, ns["cac"] + "OrderReference")
         order_ref_orderid = etree.SubElement(order_ref, ns["cbc"] + "SalesOrderID")
-        order_ref_orderid.text = order_id.name
+        order_ref_orderid.text = order_id.name or ""
         customer_ref = order_id.client_order_ref
         if customer_ref:
             order_ref_id = etree.SubElement(order_ref, ns["cbc"] + "ID")


### PR DESCRIPTION
From the little I understand of the specification, it seems that the
OrderReference can contain more than an ID element. See :
https://docs.oasis-open.org/ubl/csprd02-UBL-2.3/mod/summary/reports/UBL-Invoice-2.3.html#Table-OrderReference.Details

But this does not pass the validation and it seems that the only
accepted element in OrderReference is ID.

The goal of this PR is to add the customer reference and ID of the
sale.order being invoiced.