### PR TITLE
[FIX] test if res_ids is int, in this case change it in array

### DIFF
--- a/account_invoice_ubl/models/ir_actions_report.py
+++ b/account_invoice_ubl/models/ir_actions_report.py
@@ -30,6 +30,8 @@ class IrActionsReport(models.Model):
     def render_qweb_pdf(self, res_ids=None, data=None):
         """This is only necessary when tests are enabled.
         It forces the creation of pdf instead of html."""
+        if isinstance(res_ids, int):
+            res_ids = [res_ids]
         if len(res_ids or []) == 1 and not self.env.context.get("no_embedded_ubl_xml"):
             if len(self) == 1 and self.is_ubl_xml_to_embed_in_invoice():
                 self = self.with_context(force_report_rendering=True)


### PR DESCRIPTION
* Purpose
If we try to validate a bank statement, it send an res_id as int, so length test of array failed.

* dev
test if res_id is an int, in this case transform it into an array