### PR TITLE
[13.0][Fix] account_invoice_ubl print error

### DIFF
--- a/account_invoice_ubl/models/account_move.py
+++ b/account_invoice_ubl/models/account_move.py
@@ -325,7 +325,7 @@ class AccountMove(models.Model):
 
     def add_xml_in_pdf_buffer(self, buffer):
         self.ensure_one()
-        if self.is_ubl_sale_invoice_posted:
+        if self.is_ubl_sale_invoice_posted():
             version = self.get_ubl_version()
             xml_filename = self.get_ubl_filename(version=version)
             xml_string = self.generate_ubl_xml_string(version=version)
@@ -334,7 +334,7 @@ class AccountMove(models.Model):
 
     def embed_ubl_xml_in_pdf(self, pdf_content):
         self.ensure_one()
-        if self.is_ubl_sale_invoice_posted:
+        if self.is_ubl_sale_invoice_posted():
             version = self.get_ubl_version()
             xml_filename = self.get_ubl_filename(version=version)
             xml_string = self.generate_ubl_xml_string(version=version)

--- a/account_invoice_ubl/models/ir_actions_report.py
+++ b/account_invoice_ubl/models/ir_actions_report.py
@@ -24,7 +24,8 @@ class IrActionsReport(models.Model):
         if res_ids and len(res_ids) == 1:
             if self.is_ubl_xml_to_embed_in_invoice():
                 invoice = self.env["account.move"].browse(res_ids)
-                pdf_content = invoice.embed_ubl_xml_in_pdf(pdf_content)
+                if invoice.is_ubl_sale_invoice_posted():
+                    pdf_content = invoice.embed_ubl_xml_in_pdf(pdf_content)
         return pdf_content
 
     def render_qweb_pdf(self, res_ids=None, data=None):

--- a/account_invoice_ubl/views/account_move.xml
+++ b/account_invoice_ubl/views/account_move.xml
@@ -12,9 +12,8 @@
                 <button
                     type="object"
                     name="attach_ubl_xml_file_button"
-                    attrs="{'invisible': [('type', 'not in', ['out_invoice', 'out_refund'])]}"
+                    attrs="{'invisible': ['|', ('type', 'not in', ['out_invoice', 'out_refund']), ('state', '!=', 'posted')]}"
                     string="Generate UBL XML File"
-                    states="posted"
                 />
             </button>
         </field>


### PR DESCRIPTION
Hide the Generate UBL XML file button when the move is not posted as it
can not be generated in that state.

Also fix some crash when generating pdf for non supported invoice type
and state.