### PR TITLE
[13.0][ADD] sale_order_import_ubl_http

### DIFF
--- a/oca_dependencies.txt
+++ b/oca_dependencies.txt
@@ -9,3 +9,4 @@ server-tools
 stock-logistics-workflow
 connector
 storage
+server-auth

--- a/sale_order_import_ubl_http/__init__.py
+++ b/sale_order_import_ubl_http/__init__.py
@@ -1,0 +1,3 @@
+from . import controllers
+from . import models
+from . import tests

--- a/sale_order_import_ubl_http/__manifest__.py
+++ b/sale_order_import_ubl_http/__manifest__.py
@@ -1,0 +1,16 @@
+# Copyright 2020 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+{
+    "name": "Sale Order Import Http",
+    "version": "13.0.1.0.0",
+    "category": "Sales Management",
+    "license": "AGPL-3",
+    "summary": "Add an HTTP endpoint to import UBL formatted orders"
+    "automatically as sales order",
+    "author": "Camptocamp,Odoo Community Association (OCA)",
+    "website": "https://github.com/oca/edi",
+    "depends": ["auth_api_key", "queue_job", "sale_order_import_ubl"],
+    "data": ["data/res_users.xml", "views/res_config_settings.xml"],
+    "installable": True,
+}

--- a/sale_order_import_ubl_http/controllers/__init__.py
+++ b/sale_order_import_ubl_http/controllers/__init__.py
@@ -1,0 +1,1 @@
+from . import main

--- a/sale_order_import_ubl_http/controllers/main.py
+++ b/sale_order_import_ubl_http/controllers/main.py
@@ -1,0 +1,65 @@
+# Copyright 2020 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+import werkzeug
+from lxml import etree
+
+from odoo import http
+from odoo.exceptions import UserError
+from odoo.http import request
+
+
+class ImportController(http.Controller):
+    @http.route(
+        "/ubl_api/sales", type="http", auth="api_key", methods=["POST"], csrf=False
+    )
+    def import_sale_order(self, **kw):
+        """Endpoint to import an UBL order.
+
+        Example to test from the terminal:
+
+        curl -X POST -d @tests/examples/test_invoice.xml \
+             -H "Content-Type: application/xml" \
+             -H "API-KEY: your-secret-key" \
+            http://localhost/ubl_api/sales
+
+        """
+        req = request.httprequest
+        env = request.env
+        if req.content_type != "application/xml":
+            raise werkzeug.exceptions.UnsupportedMediaType()
+        self.check_api_key(env, request.auth_api_key_id)
+        xml_data = req.get_data()
+        self.check_data_to_import(env, xml_data)
+        description = "Import UBL order from http"
+        env["sale.order"].with_delay(description=description).import_ubl_from_http(
+            xml_data.decode("utf-8")
+        )
+        return "Thank you. Your order will be processed, shortly"
+
+    def check_data_to_import(self, env, data):
+        """ Check the data received looks valid.
+
+        For any problem with the data an exception is raised and the HTTP
+        request will return an error.
+        """
+        try:
+            xml_root = etree.fromstring(data)
+        except etree.XMLSyntaxError:
+            raise werkzeug.exceptions.BadRequest(description="Invalid XML data")
+        try:
+            env["sale.order.import"].parse_xml_order(xml_root, detect_doc_type=True)
+        except UserError:
+            raise werkzeug.exceptions.BadRequest(description="Unsupported XML document")
+
+    def check_api_key(self, env, api_key_id):
+        """Check the api key being used is valid.
+
+        By default this function test that the user linked to the key is the
+        one created by the module.
+        """
+        api_key = env["auth.api.key"].browse(api_key_id)
+        if not api_key.exists():
+            raise werkzeug.exceptions.Unauthorized()
+        if api_key.user_id != env.ref("sale_order_import_ubl_http.user_endpoint"):
+            raise werkzeug.exceptions.Unauthorized()

--- a/sale_order_import_ubl_http/data/res_users.xml
+++ b/sale_order_import_ubl_http/data/res_users.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo noupdate="1">
+    <record model="res.partner" id="partner_endpoint">
+        <field name="name">UBL API endpoint</field>
+        <field name="email">ubl.api.endpoint@test.test</field>
+    </record>
+    <record model="res.users" id="user_endpoint">
+        <field name="login">ublapi.endpoint</field>
+        <field name="partner_id" ref="partner_endpoint" />
+        <field
+            name="groups_id"
+            eval="[(6,0,[
+        ref('base.group_user'),
+        ref('sales_team.group_sale_manager'),
+      ])]"
+        />
+    </record>
+</odoo>

--- a/sale_order_import_ubl_http/models/__init__.py
+++ b/sale_order_import_ubl_http/models/__init__.py
@@ -1,0 +1,3 @@
+from . import res_company
+from . import res_config_settings
+from . import sale_order

--- a/sale_order_import_ubl_http/models/res_company.py
+++ b/sale_order_import_ubl_http/models/res_company.py
@@ -1,0 +1,14 @@
+# Copyright 2021 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+from odoo import fields, models
+
+
+class ResCompany(models.Model):
+    _inherit = "res.company"
+
+    sale_order_ubl_import_http_confirmed = fields.Boolean(
+        string="UBL order imported through HTTP set as confirmed",
+        help="When set the UBL sales order imported through HTTP "
+        "will be set as confirmed. Otherwise they are kept as draft.",
+    )

--- a/sale_order_import_ubl_http/models/res_config_settings.py
+++ b/sale_order_import_ubl_http/models/res_config_settings.py
@@ -1,0 +1,12 @@
+# Copyright 2021 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+from odoo import fields, models
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = "res.config.settings"
+
+    sale_order_ubl_import_http_confirmed = fields.Boolean(
+        related="company_id.sale_order_ubl_import_http_confirmed", readonly=False
+    )

--- a/sale_order_import_ubl_http/models/sale_order.py
+++ b/sale_order_import_ubl_http/models/sale_order.py
@@ -1,0 +1,41 @@
+# Copyright 2020 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+from base64 import b64encode
+
+from odoo import _, api, models
+from odoo.exceptions import UserError
+
+from odoo.addons.queue_job.job import job
+
+
+class SaleOrder(models.Model):
+    _inherit = "sale.order"
+
+    @api.model
+    @job(default_channel="root.ubl_import")
+    def import_ubl_from_http(self, data):
+        """Job called by the endpoint to import received data."""
+        wiz = self.env["sale.order.import"].create({})
+        wiz.order_file = b64encode(str.encode(data))
+        wiz.order_filename = "imported_invoice.xml"
+        wiz.order_file_change()
+        wiz.price_source = self._get_default_price_source()
+        res = wiz.sudo().import_order_button()
+        action_xmlid = res["xml_id"]
+        if action_xmlid == "sale_order_import.sale_order_import_action":
+            # TODO: Order has already been imported
+            #   there could be more than one to update ?
+            return _("Sales order has already been imported before, nothing done.")
+        elif action_xmlid == "sale.action_quotations":
+            order_id = res["res_id"]
+            order = self.env["sale.order"].browse(order_id)
+            if self.company_id.sale_order_ubl_import_http_confirmed:
+                order.action_confirm()
+            return _("Sales order {} created").format(order.name)
+        else:
+            raise UserError(_("Something went wrong with the importing wizard."))
+
+    @api.model
+    def _get_default_price_source(self):
+        return "pricelist"

--- a/sale_order_import_ubl_http/readme/CONTRIBUTORS.rst
+++ b/sale_order_import_ubl_http/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Thierry Ducrest <thierry.ducrest@camptocamp.com>

--- a/sale_order_import_ubl_http/readme/DESCRIPTION.rst
+++ b/sale_order_import_ubl_http/readme/DESCRIPTION.rst
@@ -1,0 +1,10 @@
+This module extends the `sale_order_import_ubl` module to allow for importing
+sales order automatically. To do so it adds a HTTP endpoint `ubl_api/sales`
+accepting a POST requests containing the XML UBL formatted order.
+
+On reception the endpoint will check the validity of the XML received and
+if ok creates a queue.job that will import the sale.order and set it as confirmed.
+
+By default the endpoint uses the api key authentication method. For security
+reason the api key is not created by the module but the user that needs to be
+linked to the key is.

--- a/sale_order_import_ubl_http/readme/USAGE.rst
+++ b/sale_order_import_ubl_http/readme/USAGE.rst
@@ -1,0 +1,3 @@
+The new endpoint created uses the api key mechanism for authentication.
+So to start using it, an api key linked to the user added by the module
+must be created in the system.

--- a/sale_order_import_ubl_http/tests/__init__.py
+++ b/sale_order_import_ubl_http/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_sale_order_import_endpoint

--- a/sale_order_import_ubl_http/tests/examples/UBL-Order-2.0-Example.xml
+++ b/sale_order_import_ubl_http/tests/examples/UBL-Order-2.0-Example.xml
@@ -1,0 +1,193 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<Order
+    xmlns:qdt="urn:oasis:names:specification:ubl:schema:xsd:QualifiedDatatypes-2"
+    xmlns:ccts="urn:oasis:names:specification:ubl:schema:xsd:CoreComponentParameters-2"
+    xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2"
+    xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+    xmlns:udt="urn:un:unece:uncefact:data:draft:UnqualifiedDataTypesSchemaModule:2"
+    xmlns="urn:oasis:names:specification:ubl:schema:xsd:Order-2"
+>
+    <cbc:UBLVersionID>2.0</cbc:UBLVersionID>
+    <cbc:CustomizationID
+    >urn:oasis:names:specification:ubl:xpath:Order-2.0:sbs-1.0-draft</cbc:CustomizationID>
+    <cbc:ProfileID
+    >bpid:urn:oasis:names:draft:bpss:ubl-2-sbs-order-with-simple-response-draft</cbc:ProfileID>
+    <cbc:ID>AEG012345</cbc:ID>
+    <cbc:SalesOrderID>CON0095678</cbc:SalesOrderID>
+    <cbc:CopyIndicator>false</cbc:CopyIndicator>
+    <cbc:UUID>6E09886B-DC6E-439F-82D1-7CCAC7F4E3B1</cbc:UUID>
+    <cbc:IssueDate>2010-06-20</cbc:IssueDate>
+    <!-- I just changed the date, to avoid a raise on currency rates -->
+    <cbc:Note>sample</cbc:Note>
+    <cac:BuyerCustomerParty>
+        <cbc:CustomerAssignedAccountID>XFB01</cbc:CustomerAssignedAccountID>
+        <cbc:SupplierAssignedAccountID>GT00978567</cbc:SupplierAssignedAccountID>
+        <cac:Party>
+            <cac:PartyName>
+                <cbc:Name>IYT Corporation</cbc:Name>
+            </cac:PartyName>
+            <cac:PostalAddress>
+                <cbc:StreetName>Avon Way</cbc:StreetName>
+                <cbc:BuildingName>Thereabouts</cbc:BuildingName>
+                <cbc:BuildingNumber>56A</cbc:BuildingNumber>
+                <cbc:CityName>Bridgtow</cbc:CityName>
+                <cbc:PostalZone>ZZ99 1ZZ</cbc:PostalZone>
+                <cbc:CountrySubentity>Avon</cbc:CountrySubentity>
+                <cac:AddressLine>
+                    <cbc:Line>3rd Floor, Room 5</cbc:Line>
+                </cac:AddressLine>
+                <cac:Country>
+                    <cbc:IdentificationCode>GB</cbc:IdentificationCode>
+                </cac:Country>
+            </cac:PostalAddress>
+            <cac:PartyTaxScheme>
+                <cbc:RegistrationName>Bridgtow District Council</cbc:RegistrationName>
+                <cbc:CompanyID>12356478</cbc:CompanyID>
+                <cbc:ExemptionReason>Local Authority</cbc:ExemptionReason>
+                <cac:TaxScheme>
+                    <cbc:ID>UK VAT</cbc:ID>
+                    <cbc:TaxTypeCode>VAT</cbc:TaxTypeCode>
+                </cac:TaxScheme>
+            </cac:PartyTaxScheme>
+            <cac:Contact>
+                <cbc:Name>Mr Fred Churchill</cbc:Name>
+                <cbc:Telephone>0127 2653214</cbc:Telephone>
+                <cbc:Telefax>0127 2653215</cbc:Telefax>
+                <cbc:ElectronicMail>fred@iytcorporation.gov.uk</cbc:ElectronicMail>
+            </cac:Contact>
+        </cac:Party>
+    </cac:BuyerCustomerParty>
+    <cac:SellerSupplierParty>
+        <cbc:CustomerAssignedAccountID>CO001</cbc:CustomerAssignedAccountID>
+        <cac:Party>
+            <cac:PartyName>
+                <cbc:Name>Consortial</cbc:Name>
+            </cac:PartyName>
+            <cac:PostalAddress>
+                <cbc:StreetName>Busy Street</cbc:StreetName>
+                <cbc:BuildingName>Thereabouts</cbc:BuildingName>
+                <cbc:BuildingNumber>56A</cbc:BuildingNumber>
+                <cbc:CityName>Farthing</cbc:CityName>
+                <cbc:PostalZone>AA99 1BB</cbc:PostalZone>
+                <cbc:CountrySubentity>Heremouthshire</cbc:CountrySubentity>
+                <cac:AddressLine>
+                    <cbc:Line>The Roundabout</cbc:Line>
+                </cac:AddressLine>
+                <cac:Country>
+                    <cbc:IdentificationCode>GB</cbc:IdentificationCode>
+                </cac:Country>
+            </cac:PostalAddress>
+            <cac:PartyTaxScheme>
+                <cbc:RegistrationName
+                >Farthing Purchasing Consortia</cbc:RegistrationName>
+                <cbc:CompanyID>175 269 2355</cbc:CompanyID>
+                <cbc:ExemptionReason>N/A</cbc:ExemptionReason>
+                <cac:TaxScheme>
+                    <cbc:ID>VAT</cbc:ID>
+                    <cbc:TaxTypeCode>VAT</cbc:TaxTypeCode>
+                </cac:TaxScheme>
+            </cac:PartyTaxScheme>
+            <cac:Contact>
+                <cbc:Name>Mrs Bouquet</cbc:Name>
+                <cbc:Telephone>0158 1233714</cbc:Telephone>
+                <cbc:Telefax>0158 1233856</cbc:Telefax>
+                <cbc:ElectronicMail>bouquet@fpconsortial.co.uk</cbc:ElectronicMail>
+            </cac:Contact>
+        </cac:Party>
+    </cac:SellerSupplierParty>
+    <cac:OriginatorCustomerParty>
+        <cac:Party>
+            <cac:PartyName>
+                <cbc:Name>The Terminus</cbc:Name>
+            </cac:PartyName>
+            <cac:PostalAddress>
+                <cbc:StreetName>Avon Way</cbc:StreetName>
+                <cbc:BuildingName>Thereabouts</cbc:BuildingName>
+                <cbc:BuildingNumber>56A</cbc:BuildingNumber>
+                <cbc:CityName>Bridgtow</cbc:CityName>
+                <cbc:PostalZone>ZZ99 1ZZ</cbc:PostalZone>
+                <cbc:CountrySubentity>Avon</cbc:CountrySubentity>
+                <cac:AddressLine>
+                    <cbc:Line>3rd Floor, Room 5</cbc:Line>
+                </cac:AddressLine>
+                <cac:Country>
+                    <cbc:IdentificationCode>GB</cbc:IdentificationCode>
+                </cac:Country>
+            </cac:PostalAddress>
+            <cac:PartyTaxScheme>
+                <cbc:RegistrationName>Bridgtow District Council</cbc:RegistrationName>
+                <cbc:CompanyID>12356478</cbc:CompanyID>
+                <cbc:ExemptionReason>Local Authority</cbc:ExemptionReason>
+                <cac:TaxScheme>
+                    <cbc:ID>UK VAT</cbc:ID>
+                    <cbc:TaxTypeCode>VAT</cbc:TaxTypeCode>
+                </cac:TaxScheme>
+            </cac:PartyTaxScheme>
+            <cac:Contact>
+                <cbc:Name>S Massiah</cbc:Name>
+                <cbc:Telephone>0127 98876545</cbc:Telephone>
+                <cbc:Telefax>0127 98876546</cbc:Telefax>
+                <cbc:ElectronicMail>smassiah@the-email.co.uk</cbc:ElectronicMail>
+            </cac:Contact>
+        </cac:Party>
+    </cac:OriginatorCustomerParty>
+    <cac:Delivery>
+        <cac:DeliveryAddress>
+            <cbc:StreetName>Avon Way</cbc:StreetName>
+            <cbc:BuildingName>Thereabouts</cbc:BuildingName>
+            <cbc:BuildingNumber>56A</cbc:BuildingNumber>
+            <cbc:CityName>Bridgtow</cbc:CityName>
+            <cbc:PostalZone>ZZ99 1ZZ</cbc:PostalZone>
+            <cbc:CountrySubentity>Avon</cbc:CountrySubentity>
+            <cac:AddressLine>
+                <cbc:Line>3rd Floor, Room 5</cbc:Line>
+            </cac:AddressLine>
+            <cac:Country>
+                <cbc:IdentificationCode>GB</cbc:IdentificationCode>
+            </cac:Country>
+        </cac:DeliveryAddress>
+        <cac:RequestedDeliveryPeriod>
+            <cbc:StartDate>2005-06-29</cbc:StartDate>
+            <cbc:StartTime>09:30:47.0Z</cbc:StartTime>
+            <cbc:EndDate>2005-06-29</cbc:EndDate>
+            <cbc:EndTime>09:30:47.0Z</cbc:EndTime>
+        </cac:RequestedDeliveryPeriod>
+    </cac:Delivery>
+    <cac:DeliveryTerms>
+        <cbc:SpecialTerms
+        >1% deduction for late delivery as per contract</cbc:SpecialTerms>
+    </cac:DeliveryTerms>
+    <cac:TransactionConditions>
+        <cbc:Description
+        >order response required; payment is by BACS or by cheque</cbc:Description>
+    </cac:TransactionConditions>
+    <cac:AnticipatedMonetaryTotal>
+        <cbc:LineExtensionAmount currencyID="GBP">100.00</cbc:LineExtensionAmount>
+        <cbc:PayableAmount currencyID="GBP">100.00</cbc:PayableAmount>
+    </cac:AnticipatedMonetaryTotal>
+    <cac:OrderLine>
+        <cbc:Note>this is an illustrative order line</cbc:Note>
+        <cac:LineItem>
+            <cbc:ID>1</cbc:ID>
+            <cbc:SalesOrderID>A</cbc:SalesOrderID>
+            <cbc:LineStatusCode>NoStatus</cbc:LineStatusCode>
+            <cbc:Quantity unitCode="KG">100</cbc:Quantity>
+            <cbc:LineExtensionAmount currencyID="GBP">100.00</cbc:LineExtensionAmount>
+            <cbc:TotalTaxAmount currencyID="GBP">17.50</cbc:TotalTaxAmount>
+            <cac:Price>
+                <cbc:PriceAmount currencyID="GBP">100.00</cbc:PriceAmount>
+                <cbc:BaseQuantity unitCode="KG">1</cbc:BaseQuantity>
+            </cac:Price>
+            <cac:Item>
+                <cbc:Description>Acme beeswax</cbc:Description>
+                <cbc:Name>beeswax</cbc:Name>
+                <cac:BuyersItemIdentification>
+                    <cbc:ID>6578489</cbc:ID>
+                </cac:BuyersItemIdentification>
+                <cac:SellersItemIdentification>
+                    <cbc:ID>17589683</cbc:ID>
+                </cac:SellersItemIdentification>
+            </cac:Item>
+        </cac:LineItem>
+    </cac:OrderLine>
+</Order>

--- a/sale_order_import_ubl_http/tests/test_sale_order_import_endpoint.py
+++ b/sale_order_import_ubl_http/tests/test_sale_order_import_endpoint.py
@@ -1,0 +1,61 @@
+# Copyright 2020 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+import os
+
+from werkzeug.exceptions import BadRequest, Unauthorized
+
+from odoo import tools
+from odoo.tests.common import SingleTransactionCase
+
+from odoo.addons.sale_order_import_ubl_http.controllers.main import ImportController
+
+
+class TestSaleOrderImportEndpoint(SingleTransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
+        cls.controller = ImportController()
+
+    def test_invalid_data(self):
+        data = "<xml>"
+        with self.assertRaises(BadRequest):
+            self.controller.check_data_to_import(self.env, data)
+
+    def test_import_so_ubl(self):
+        user = self.env.ref("sale_order_import_ubl_http.user_endpoint")
+        path = os.path.join(
+            os.path.dirname(__file__), "examples", "UBL-Order-2.0-Example.xml"
+        )
+        with open(path, "rb") as file:
+            data = file.read()
+        self.controller.check_data_to_import(self.env, data)
+        data = data.decode("utf-8")
+        with tools.mute_logger("odoo.addons.queue_job.models.base"):
+            res = (
+                self.env["sale.order"]
+                .with_user(user)
+                .with_context(test_queue_job_no_delay=True)
+                .import_ubl_from_http(data)
+            )
+        order_ref = res.split(" ")[2]
+        new_order = self.env["sale.order"].search([("name", "=", order_ref)])
+        self.assertEqual(new_order.state, "draft")
+
+    def test_api_key_validity(self):
+        """ Check auth key validity."""
+        valid_key = self.env["auth.api.key"].create(
+            {
+                "name": "test_key",
+                "user_id": self.env.ref("sale_order_import_ubl_http.user_endpoint").id,
+            }
+        )
+        self.controller.check_api_key(self.env, valid_key.id)
+        # Check non existing key
+        with self.assertRaises(Unauthorized):
+            self.controller.check_api_key(self.env, valid_key.id + 1)
+        # Check key with incorrect user
+        valid_key.user_id = self.env.user.id
+        with self.assertRaises(Unauthorized):
+            self.controller.check_api_key(self.env, valid_key.id)

--- a/sale_order_import_ubl_http/views/res_config_settings.xml
+++ b/sale_order_import_ubl_http/views/res_config_settings.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="res_config_settings_view_form" model="ir.ui.view">
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="sale.res_config_settings_view_form" />
+        <field name="arch" type="xml">
+          <xpath
+                expr="//div[@id='sale_config_online_confirmation_sign']/.."
+                position="inside"
+            >
+
+          <div
+                    class="col-12 col-lg-6 o_setting_box"
+                    id="sale_order_ubl_import_http_confirmed"
+                >
+              <div class="o_setting_left_pane">
+                <field name="sale_order_ubl_import_http_confirmed" />
+              </div>
+              <div class="o_setting_right_pane">
+                <label for="sale_order_ubl_import_http_confirmed" />
+              </div>
+            </div>
+
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/setup/sale_order_import_ubl_http/odoo/addons/sale_order_import_ubl_http
+++ b/setup/sale_order_import_ubl_http/odoo/addons/sale_order_import_ubl_http
@@ -1,0 +1,1 @@
+../../../../sale_order_import_ubl_http

--- a/setup/sale_order_import_ubl_http/setup.py
+++ b/setup/sale_order_import_ubl_http/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
This module extends the `sale_order_import_ubl` module to allow for
importing sales order automatically.
To do so it adds a HTTP endpoint `ubl_api\sales` accepting a POST request
containing the XML UBL formatted sale order.

On reception the endpoint will check the validity of the XML received
and if ok create a queue.job that will import the sale.order and
set it as confirmed.