### PR TITLE
[8.0][IMP] Support tax exemption, default tax, default uom

### DIFF
--- a/account_invoice_ubl/README.rst
+++ b/account_invoice_ubl/README.rst
@@ -20,6 +20,8 @@ Configuration
 
 On the form view of the company, there is an option to embed the PDF of the invoices inside the XML invoice.
 
+There is also an option to select a default tax, which will be added as a zero-sum tax subtotal in case an invoice has no taxes specified. This is useful to satisfy PEPPOL rule BR-CO-18 for Dutch non-profits that are exempted from tax.
+
 Usage
 =====
 

--- a/account_invoice_ubl/README.rst
+++ b/account_invoice_ubl/README.rst
@@ -22,6 +22,8 @@ On the form view of the company, there is an option to embed the PDF of the invo
 
 There is also an option to select a default tax, which will be added as a zero-sum tax subtotal in case an invoice has no taxes specified. This is useful to satisfy PEPPOL rule BR-CO-18 for Dutch non-profits that are exempted from tax.
 
+Finally, there is an option to select a default unit of measure, of which the UNECE code will be used in case an invoice line has no unit or product unit. A typical default unit could be the Odoo 'unit', configured with a UNECE code of UN, XUN or C62.
+
 Usage
 =====
 

--- a/account_invoice_ubl/models/account_invoice.py
+++ b/account_invoice_ubl/models/account_invoice.py
@@ -133,6 +133,10 @@ class AccountInvoice(models.Model):
         # on v8, uos_id is not a required field on account.invoice.line
         if iline.uos_id and iline.uos_id.unece_code:
             uom_unece_code = iline.uos_id.unece_code
+        if not uom_unece_code and iline.product_id.uom_id:
+            uom_unece_code = iline.product_id.uom_id.unece_code
+        if not uom_unece_code:
+            uom_unece_code = self.company_id.ubl_default_uom_id.unece_code
         if uom_unece_code:
             quantity = etree.SubElement(
                 line_root, ns['cbc'] + 'InvoicedQuantity',

--- a/account_invoice_ubl/models/account_invoice.py
+++ b/account_invoice_ubl/models/account_invoice.py
@@ -150,7 +150,7 @@ class AccountInvoice(models.Model):
             iline, line_root, ns, version=version)
         self._ubl_add_item(
             iline.name, iline.product_id, line_root, ns, type='sale',
-            version=version)
+            taxes=iline.invoice_line_tax_id, version=version)
         price_node = etree.SubElement(line_root, ns['cac'] + 'Price')
         price_amount = etree.SubElement(
             price_node, ns['cbc'] + 'PriceAmount', currencyID=cur_name)
@@ -222,6 +222,10 @@ class AccountInvoice(models.Model):
             self._ubl_add_tax_subtotal(
                 tline.base, tline.amount, tax, cur_name, tax_total_node, ns,
                 version=version)
+        if not self.tax_line and self.company_id.ubl_default_tax:
+            self._ubl_add_tax_subtotal(
+                self.amount_untaxed, 0.0, self.company_id.ubl_default_tax,
+                cur_name, tax_total_node, ns, version=version)
 
     @api.multi
     def generate_invoice_ubl_xml_etree(self, version='2.1'):

--- a/account_invoice_ubl/models/company.py
+++ b/account_invoice_ubl/models/company.py
@@ -14,3 +14,6 @@ class ResCompany(models.Model):
         "PDF of the invoice in base64 under the node "
         "'AdditionalDocumentReference'. For example, to be compliant with the "
         "e-fff standard used in Belgium, you should activate this option.")
+    ubl_default_uom_id = fields.Many2one(
+        comodel_name="product.uom",
+        string="Use this unit if an invoice line has no unit or product unit")

--- a/account_invoice_ubl/views/company.xml
+++ b/account_invoice_ubl/views/company.xml
@@ -14,6 +14,7 @@
     <field name="arch" type="xml">
         <xpath expr="//group[@name='ubl_invoice']" position="inside">
             <field name="embed_pdf_in_ubl_xml_invoice"/>
+            <field name="ubl_default_uom_id"/>
         </xpath>
     </field>
 </record>

--- a/base_ubl/models/__init__.py
+++ b/base_ubl/models/__init__.py
@@ -1,3 +1,4 @@
 # -*- coding: utf-8 -*-
 
+from . import company
 from . import ubl

--- a/base_ubl/models/company.py
+++ b/base_ubl/models/company.py
@@ -1,0 +1,15 @@
+# Copyright 2020 Sunflower IT <info@sunflowerweb.nl>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from openerp import models, fields
+
+
+class ResCompany(models.Model):
+    _inherit = 'res.company'
+
+    ubl_default_tax = fields.Many2one(
+        comodel_name="account.tax",
+        string="Use this tax as a 0.0 tax if an invoice has no taxes",
+        help="According to PEPPOL BR-CO-18, an invoice must always have a tax "
+        "subtotal, but for example non-profits are exempt from charging VAT. "
+        "With this option you can choose a default tax to use.")

--- a/base_ubl/views/company_view.xml
+++ b/base_ubl/views/company_view.xml
@@ -12,6 +12,9 @@
             <page name="ubl" string="UBL">
                 <h2>Universal Business Langage</h2>
                 <group name="ubl_main" col="4">
+                    <group name="ubl_general" string="General" colspan="2">
+                        <field name="ubl_default_tax"/>
+                    </group>
                     <group name="ubl_invoice" string="Invoices" colspan="2">
                     </group>
                 </group>

--- a/sale_order_ubl/models/sale.py
+++ b/sale_order_ubl/models/sale.py
@@ -76,7 +76,7 @@ class SaleOrder(models.Model):
             oline.product_uom_qty, oline.product_uom, line_root, ns,
             currency=self.currency_id, price_subtotal=oline.price_subtotal,
             qty_precision=qty_precision, price_precision=price_precision,
-            version=version)
+            taxes=oline.tax_id, version=version)
 
     @api.multi
     def generate_quotation_ubl_xml_etree(self, version='2.1'):


### PR DESCRIPTION
Taxes:

- [x] Allow configuring a default tax that will be used when an invoice has no tax (BR-CO-18 PEPPOL requires a tax)
- [x] Add TaxExemptionReason for empty taxes
- [x] First try to use invoice line taxes before turning to product taxes

UOM:

- [x] Allow configuring a default UOM that will be used when an invoice line has no unit (PEPPOL requires invoice line units)