### PR TITLE
[8.0][ADD] account_invoice_ubl: DueDate

### DIFF
--- a/account_invoice_ubl/models/account_invoice.py
+++ b/account_invoice_ubl/models/account_invoice.py
@@ -24,6 +24,9 @@ class AccountInvoice(models.Model):
         doc_id.text = self.number
         issue_date = etree.SubElement(parent_node, ns['cbc'] + 'IssueDate')
         issue_date.text = self.date_invoice
+        if version >= '2.1':
+            due_date = etree.SubElement(parent_node, ns['cbc'] + 'DueDate')
+            due_date.text = self.date_due
         type_code = etree.SubElement(
             parent_node, ns['cbc'] + 'InvoiceTypeCode')
         if self.type == 'out_invoice':


### PR DESCRIPTION
Add the payment due date to UBL invoice.

[PEPPOL BR-CO-25](https://docs.peppol.eu/poacc/billing/3.0/rules/BR-CO-25) specifies that if the invoice amount is positive, either the due date or the payment terms are filled, so this is pretty much mandatory.