### PR TITLE
[13.0] edi: refactor component lookup

### DIFF
--- a/edi/components/base.py
+++ b/edi/components/base.py
@@ -9,6 +9,9 @@ class EDIBackendComponentMixin(AbstractComponent):
 
     _name = "edi.component.mixin"
     _collection = "edi.backend"
+    _usage = None
+    _backend_type = None
+    _exchange_type = None
 
     @property
     def exchange_record(self):
@@ -21,3 +24,43 @@ class EDIBackendComponentMixin(AbstractComponent):
     @property
     def record(self):
         return self.work.exchange_record.record
+
+    @staticmethod
+    def _match_attrs():
+        """Attributes to be used for matching this component.
+
+        By default, match by backend and exchange type.
+
+        NOTE: the class attribute must have an underscore, the name here not.
+        """
+        return ("backend_type", "exchange_type")
+
+    @classmethod
+    def _component_match(cls, work, usage=None, model_name=None, **kw):
+        """Override to customize match.
+
+        Registry lookup filtered by usage and model_name when landing here.
+        Now, narrow match to `_match_attrs` attributes.
+        """
+        match_attrs = cls._match_attrs()
+        if not any([kw.get(k) for k in match_attrs]):
+            # No attr to check
+            return True
+
+        backend_type = kw.get("backend_type")
+        exchange_type = kw.get("exchange_type")
+
+        if cls._backend_type and cls._exchange_type:
+            # They must match both
+            return (
+                cls._backend_type == backend_type
+                and cls._exchange_type == exchange_type
+            )
+
+        if cls._backend_type not in (None, kw.get("backend_type")):
+            return False
+
+        if cls._exchange_type not in (None, kw.get("exchange_type")):
+            return False
+
+        return True

--- a/edi/components/base.py
+++ b/edi/components/base.py
@@ -17,3 +17,7 @@ class EDIBackendComponentMixin(AbstractComponent):
     @property
     def backend(self):
         return self.work.backend
+
+    @property
+    def record(self):
+        return self.work.exchange_record.record

--- a/edi/models/edi_exchange_consumer_mixin.py
+++ b/edi/models/edi_exchange_consumer_mixin.py
@@ -11,6 +11,8 @@ from lxml import etree
 from odoo import api, fields, models
 from odoo.tools.safe_eval import safe_eval
 
+from odoo.addons.base_sparse_field.models.fields import Serialized
+
 
 class EDIExchangeConsumerMixin(models.AbstractModel):
     """Record that might have related EDI Exchange records
@@ -25,7 +27,7 @@ class EDIExchangeConsumerMixin(models.AbstractModel):
         domain=lambda r: [("model", "=", r._name)],
     )
     exchange_record_count = fields.Integer(compute="_compute_exchange_record_count")
-    expected_edi_configuration = fields.Serialized(
+    expected_edi_configuration = Serialized(
         compute="_compute_expected_edi_configuration", default={},
     )
     has_expected_edi_configuration = fields.Boolean(

--- a/edi/tests/__init__.py
+++ b/edi/tests/__init__.py
@@ -1,6 +1,7 @@
 from . import test_backend_type
 from . import test_exchange_type
 from . import test_record
+from . import test_component_match
 from . import test_backend_base
 from . import test_backend_output
 from . import test_backend_input

--- a/edi/tests/fake_components.py
+++ b/edi/tests/fake_components.py
@@ -46,7 +46,9 @@ class FakeComponentMixin(Component):
 class FakeOutputGenerator(FakeComponentMixin):
     _name = "fake.output.generator"
     _inherit = "edi.component.output.mixin"
-    _usage = "edi.output.generate.demo_backend.test_csv_output"
+    _usage = "output.generate"
+    _backend_type = "demo_backend"
+    _exchange_type = "test_csv_output"
 
     _action = "generate"
 
@@ -57,7 +59,9 @@ class FakeOutputGenerator(FakeComponentMixin):
 class FakeOutputSender(FakeComponentMixin):
     _name = "fake.output.sender"
     _inherit = "edi.component.send.mixin"
-    _usage = "edi.output.send.demo_backend.test_csv_output"
+    _usage = "output.send"
+    _backend_type = "demo_backend"
+    _exchange_type = "test_csv_output"
 
     _action = "send"
 
@@ -68,7 +72,9 @@ class FakeOutputSender(FakeComponentMixin):
 class FakeOutputChecker(FakeComponentMixin):
     _name = "fake.output.checker"
     _inherit = "edi.component.check.mixin"
-    _usage = "edi.output.check.demo_backend.test_csv_output"
+    _usage = "output.check"
+    _backend_type = "demo_backend"
+    _exchange_type = "test_csv_output"
 
     _action = "check"
 
@@ -79,7 +85,9 @@ class FakeOutputChecker(FakeComponentMixin):
 class FakeInputProcess(FakeComponentMixin):
     _name = "fake.input.process"
     _inherit = "edi.component.input.mixin"
-    _usage = "edi.input.process.demo_backend.test_csv_input"
+    _usage = "input.process"
+    _backend_type = "demo_backend"
+    _exchange_type = "test_csv_input"
 
     _action = "process"
 
@@ -90,7 +98,9 @@ class FakeInputProcess(FakeComponentMixin):
 class FakeInputReceive(FakeComponentMixin):
     _name = "fake.input.receive"
     _inherit = "edi.component.input.mixin"
-    _usage = "edi.input.receive.demo_backend.test_csv_input"
+    _usage = "input.receive"
+    _backend_type = "demo_backend"
+    _exchange_type = "test_csv_input"
 
     _action = "receive"
 
@@ -101,7 +111,9 @@ class FakeInputReceive(FakeComponentMixin):
 class FakeOutputValidate(FakeComponentMixin):
     _name = "fake.out.validate"
     _inherit = "edi.component.validate.mixin"
-    _usage = "edi.output.validate.demo_backend.test_csv_output"
+    _usage = "output.validate"
+    _backend_type = "demo_backend"
+    _exchange_type = "test_csv_output"
 
     _action = "validate"
 
@@ -113,7 +125,9 @@ class FakeOutputValidate(FakeComponentMixin):
 class FakeInputValidate(FakeComponentMixin):
     _name = "fake.in.validate"
     _inherit = "edi.component.validate.mixin"
-    _usage = "edi.input.validate.demo_backend.test_csv_input"
+    _usage = "input.validate"
+    _backend_type = "demo_backend"
+    _exchange_type = "test_csv_input"
 
     _action = "validate"
 

--- a/edi/tests/test_backend_base.py
+++ b/edi/tests/test_backend_base.py
@@ -33,20 +33,12 @@ class EDIBackendTestCase(EDIBackendCommonTestCase):
         record = self.backend.create_record("test_csv_input", vals)
         candidates = self.backend._get_component_usage_candidates(record, "process")
         self.assertEqual(
-            candidates,
-            [
-                "edi.input.process.demo_backend.test_csv_input",
-                "edi.input.process.demo_backend",
-            ],
+            candidates, ["input.process"],
         )
         record = self.backend.create_record("test_csv_output", vals)
         candidates = self.backend._get_component_usage_candidates(record, "generate")
         self.assertEqual(
-            candidates,
-            [
-                "edi.output.generate.demo_backend.test_csv_output",
-                "edi.output.generate.demo_backend",
-            ],
+            candidates, ["output.generate"],
         )
         # set advanced settings on type
         settings = """
@@ -59,19 +51,9 @@ class EDIBackendTestCase(EDIBackendCommonTestCase):
         record.type_id.advanced_settings_edit = settings
         candidates = self.backend._get_component_usage_candidates(record, "generate")
         self.assertEqual(
-            candidates,
-            [
-                "my.special.generate",
-                "edi.output.generate.demo_backend.test_csv_output",
-                "edi.output.generate.demo_backend",
-            ],
+            candidates, ["my.special.generate", "output.generate"],
         )
         candidates = self.backend._get_component_usage_candidates(record, "send")
         self.assertEqual(
-            candidates,
-            [
-                "my.special.send",
-                "edi.output.send.demo_backend.test_csv_output",
-                "edi.output.send.demo_backend",
-            ],
+            candidates, ["my.special.send", "output.send"],
         )

--- a/edi/tests/test_component_match.py
+++ b/edi/tests/test_component_match.py
@@ -1,0 +1,64 @@
+# Copyright 2020 ACSONE
+# @author: Simone Orsi <simahawk@gmail.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.addons.component.core import Component
+
+from .common import EDIBackendCommonComponentRegistryTestCase
+
+
+class EDIBackendTestCase(EDIBackendCommonComponentRegistryTestCase):
+    def test_component_match(self):
+        """Lookup with special match method."""
+
+        class MatchByBackendTypeOnly(Component):
+            _name = "backend_type.only"
+            _inherit = "edi.component.mixin"
+            _usage = "generate"
+            _backend_type = "demo_backend"
+            _apply_on = ["res.partner"]
+
+        class MatchByExchangeTypeOnly(Component):
+            _name = "exchange_type.only"
+            _inherit = "edi.component.mixin"
+            _usage = "generate"
+            _exchange_type = "test_csv_output"
+            _apply_on = ["res.partner"]
+
+        class MatchByBackendExchangeType(Component):
+            _name = "backend_type.and.exchange_type"
+            _inherit = "edi.component.mixin"
+            _usage = "generate"
+            _backend_type = "demo_backend"
+            _exchange_type = "test_csv_output"
+            _apply_on = ["res.partner"]
+
+        self._build_components(
+            MatchByBackendTypeOnly,
+            MatchByExchangeTypeOnly,
+            # This one is registered last but since edi.backend
+            # is going to sort them by priority, we'll get the right one
+            # when looking for both match
+            MatchByBackendExchangeType,
+        )
+
+        # Search by both backend and exchange type
+        component = self.backend._find_component(
+            "res.partner",
+            ["generate"],
+            backend_type="demo_backend",
+            exchange_type="test_csv_output",
+        )
+        self.assertEqual(component._name, MatchByBackendExchangeType._name)
+
+        # Search by backend type only
+        component = self.backend._find_component(
+            "res.partner", ["generate"], backend_type="demo_backend"
+        )
+        self.assertEqual(component._name, MatchByBackendTypeOnly._name)
+
+        # Search by exchange type only
+        component = self.backend._find_component(
+            "res.partner", ["generate"], exchange_type="test_csv_output"
+        )
+        self.assertEqual(component._name, MatchByExchangeTypeOnly._name)

--- a/edi_exchange_template/components/common.py
+++ b/edi_exchange_template/components/common.py
@@ -8,6 +8,9 @@ from odoo.addons.component.core import AbstractComponent
 class EDIExchangeInfoMixin(AbstractComponent):
     """Abstract component mixin provide info for exchanges."""
 
+    # TODO: this should be moved to core and renamed to `data`.
+    # A `data` component could be used for both incoming and outgoing.
+
     _name = "edi.info.provider.mixin"
     _collection = "edi.backend"
     # Enable validation of work context attributes

--- a/edi_exchange_template/tests/test_edi_backend_output.py
+++ b/edi_exchange_template/tests/test_edi_backend_output.py
@@ -102,6 +102,10 @@ class TestEDIBackendOutput(TestEDIBackendOutputBase):
         self.assertEqual(
             self.backend._get_output_template(self.record2), self.tmpl_out2
         )
+        self.assertEqual(
+            self.backend._get_output_template(self.record2, code=self.tmpl_out1.code),
+            self.tmpl_out1,
+        )
 
     def test_generate_file(self):
         output = self.backend.generate_output(self.record1)

--- a/edi_storage/components/base.py
+++ b/edi_storage/components/base.py
@@ -7,9 +7,21 @@ from pathlib import PurePath
 from odoo.addons.component.core import AbstractComponent
 
 
-class EDIStorageSendComponentMixin(AbstractComponent):
+class EDIStorageComponentMixin(AbstractComponent):
 
     _name = "edi.storage.component.mixin"
+    _inherit = "edi.component.mixin"
+    # Components having `_storage_backend_type` will have precedence.
+    # If the value is not set, generic components will be used.
+    _storage_backend_type = None
+
+    @classmethod
+    def _component_match(cls, work, usage=None, model_name=None, **kw):
+        res = super()._component_match(work, usage=usage, model_name=model_name, **kw)
+        storage_type = kw.get("storage_backend_type")
+        if storage_type and cls._storage_backend_type:
+            return cls._storage_backend_type == storage_type
+        return res
 
     @property
     def storage(self):

--- a/edi_storage/components/check.py
+++ b/edi_storage/components/check.py
@@ -18,7 +18,7 @@ class EDIStorageCheckComponentMixin(Component):
         "edi.component.check.mixin",
         "edi.storage.component.mixin",
     ]
-    _usage = "edi.storage.check"
+    _usage = "storage.check"
 
     def check(self):
         return self._exchange_output_check()

--- a/edi_storage/components/send.py
+++ b/edi_storage/components/send.py
@@ -12,13 +12,13 @@ class EDIStorageSendComponent(Component):
         "edi.component.send.mixin",
         "edi.storage.component.mixin",
     ]
-    _usage = "edi.storage.send"
+    _usage = "storage.send"
 
     def send(self):
         # If the file has been sent already, refresh its state
         # TODO: double check if this is useless
         # since the backend checks the state already
-        checker = self.component(usage="edi.storage.check")
+        checker = self.component(usage="storage.check")
         result = checker.check()
         if not result:
             # all good here

--- a/edi_storage/tests/common.py
+++ b/edi_storage/tests/common.py
@@ -41,10 +41,14 @@ class TestEDIStorageBase(EDIBackendCommonComponentTestCase):
             fakefile.write(b"ERROR XYZ: line 2 broken on bla bla")
 
         cls.checker = cls.backend._find_component(
-            ["edi.storage.check"], work_ctx={"exchange_record": cls.record}
+            cls.partner._name,
+            ["storage.check"],
+            work_ctx={"exchange_record": cls.record},
         )
         cls.sender = cls.backend._find_component(
-            ["edi.storage.send"], work_ctx={"exchange_record": cls.record}
+            cls.partner._name,
+            ["storage.send"],
+            work_ctx={"exchange_record": cls.record},
         )
 
     def setUp(self):

--- a/edi_storage/tests/test_component_match.py
+++ b/edi_storage/tests/test_component_match.py
@@ -1,0 +1,86 @@
+# Copyright 2020 ACSONE
+# @author: Simone Orsi <simahawk@gmail.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.addons.component.core import Component
+from odoo.addons.edi.tests.common import EDIBackendCommonComponentRegistryTestCase
+
+
+class EDIBackendTestCase(EDIBackendCommonComponentRegistryTestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls._load_module_components(cls, "edi_storage")
+
+    @classmethod
+    def _get_backend(cls):
+        return cls.env.ref("edi_storage.demo_edi_backend_storage")
+
+    def test_component_match(self):
+        """Lookup with special match method."""
+
+        class SFTPCheck(Component):
+            _name = "sftp.check"
+            _inherit = "edi.storage.component.check"
+            _usage = "storage.check"
+            # _backend_type = "demo_backend"
+            _storage_backend_type = "sftp"
+
+        class SFTPSend(Component):
+            _name = "sftp.send"
+            _inherit = "edi.storage.component.send"
+            _usage = "storage.send"
+            # _backend_type = "demo_backend"
+            _storage_backend_type = "sftp"
+
+        class S3Check(Component):
+            _name = "s3.check"
+            _inherit = "edi.storage.component.check"
+            _usage = "storage.check"
+            # _exchange_type = "test_csv_output"
+            _storage_backend_type = "s3"
+
+        class S3Send(Component):
+            _name = "s3.send"
+            _inherit = "edi.storage.component.send"
+            _usage = "storage.send"
+            # _exchange_type = "test_csv_output"
+            _storage_backend_type = "s3"
+
+        self._build_components(SFTPCheck, SFTPSend, S3Check, S3Send)
+
+        component = self.backend._find_component(
+            "res.partner",
+            ["storage.check"],
+            backend_type="demo_backend",
+            exchange_type="test_csv_output",
+            storage_backend_type="s3",
+        )
+        self.assertEqual(component._name, S3Check._name)
+
+        component = self.backend._find_component(
+            "res.partner",
+            ["storage.check"],
+            backend_type="demo_backend",
+            exchange_type="test_csv_output",
+            storage_backend_type="sftp",
+        )
+        self.assertEqual(component._name, SFTPCheck._name)
+
+        component = self.backend._find_component(
+            "res.partner",
+            ["storage.send"],
+            backend_type="demo_backend",
+            exchange_type="test_csv_output",
+            storage_backend_type="sftp",
+        )
+        self.assertEqual(component._name, SFTPSend._name)
+
+        component = self.backend._find_component(
+            "res.partner",
+            ["storage.send"],
+            backend_type="demo_backend",
+            exchange_type="test_csv_output",
+            storage_backend_type="s3",
+        )
+        self.assertEqual(component._name, S3Send._name)

--- a/edi_storage/tests/test_components_base.py
+++ b/edi_storage/tests/test_components_base.py
@@ -7,7 +7,7 @@ import mock
 from .common import STORAGE_BACKEND_MOCK_PATH, TestEDIStorageBase
 
 
-class EDIBackendTestCase(TestEDIStorageBase):
+class EDIStorageComponentTestCase(TestEDIStorageBase):
     def test_remote_file_path(self):
         to_test = (
             (("input", "pending", "foo.csv"), "demo_in/pending/foo.csv"),

--- a/edi_xml/tests/test_xml.py
+++ b/edi_xml/tests/test_xml.py
@@ -21,16 +21,20 @@ class BusinessHeaderTestCase(SavepointComponentCase, XMLTestCaseMixin):
         super().setUpClass()
         cls.backend = cls.env.ref("edi.demo_edi_backend")
         cls.handler = cls.backend._find_component(
-            ["edi.xml"], work_ctx={"schema_path": "edi_xml:tests/fixtures/Test.xsd"}
+            cls.backend._name,
+            ["edi.xml"],
+            work_ctx={"schema_path": "edi_xml:tests/fixtures/Test.xsd"},
         )
 
     def test_xml_schema_fail(self):
         with self.assertRaises(ValueError):
             self.backend._find_component(
-                ["edi.xml"], work_ctx={"schema_path": "Nothing"}
+                self.backend._name, ["edi.xml"], work_ctx={"schema_path": "Nothing"}
             )
         with self.assertRaises(AttributeError):
-            self.backend._find_component(["edi.xml"], work_ctx={"no_schema": "Nothing"})
+            self.backend._find_component(
+                self.backend._name, ["edi.xml"], work_ctx={"no_schema": "Nothing"}
+            )
 
     def test_xml(self):
         data = self.handler.parse_xml(TEST_XML)


### PR DESCRIPTION
Depends on https://github.com/OCA/connector/pull/392

The match is now done based on specific control keys: backend type, exchange type.
This makes components more clean and their behavior more understandable.

@etobella this is what I was talking about last time :wink: 

