### PR TITLE
8.0 FIX purch_order_ubl: date in approve state

### DIFF
--- a/purchase_order_ubl/models/purchase.py
+++ b/purchase_order_ubl/models/purchase.py
@@ -29,7 +29,8 @@ class PurchaseOrder(models.Model):
             time = now_utc[11:]
             currency_node_name = 'PricingCurrencyCode'
         elif doc_type == 'order':
-            date = self.date_approve
+            # date_approve is not always set at 'confirmed' state
+            date = self.date_approve or self.date_order[:10]
             currency_node_name = 'DocumentCurrencyCode'
         ubl_version = etree.SubElement(
             parent_node, ns['cbc'] + 'UBLVersionID')


### PR DESCRIPTION
Backport of this code https://github.com/OCA/edi/blob/10.0/purchase_order_ubl/models/purchase.py#L32

cc @lmignon @StefanRijnhart @thomaspaulb

Thanks