### PR TITLE
[12.0][FIX] account_invoice_import: read access on `res.partner` view

### DIFF
--- a/account_invoice_import/models/partner.py
+++ b/account_invoice_import/models/partner.py
@@ -13,6 +13,7 @@ class ResPartner(models.Model):
     invoice_import_count = fields.Integer(
         compute='_compute_invoice_import_count',
         string='Number of Invoice Import Configurations',
+        groups='account.group_account_invoice',
         readonly=True)
 
     def _compute_invoice_import_count(self):


### PR DESCRIPTION
A computed field `invoice_import_count` is defined on `res_partner` model.
Currently, it prevents an user who doesn't belong to the "Billing" (`account.group_account_invoice`) group to access a `res.partner` Form View:
```
Sorry, you are not allowed to access this document.
Only users with the following access level are currently allowed to do that:
- Accounting & Finance/Billing Manager
- Accounting & Finance/Billing

(Document model: account.invoice.import.config) - (Operation: read, User: 6)
```

This PR fixes this Access Error by adding `account.group_account_invoice` on the `groups` key of `invoice_import_count` field.