### PR TITLE
[13.0][ADD] sale_order_customer_free_ref

### DIFF
--- a/sale_order_customer_free_ref/__init__.py
+++ b/sale_order_customer_free_ref/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/sale_order_customer_free_ref/__manifest__.py
+++ b/sale_order_customer_free_ref/__manifest__.py
@@ -1,0 +1,17 @@
+# Copyright 2021 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+{
+    "name": "Sale Order Customer Free Reference",
+    "version": "13.0.1.0.0",
+    "category": "Sale",
+    "license": "AGPL-3",
+    "summary": "Splits the Customer Reference on sale orders into two fields. "
+    "An Id and a Free reference. The existing field is transformed "
+    "into a computed one.",
+    "author": "Camptocamp SA, Odoo Community Association (OCA)",
+    "website": "https://github.com/oca/edi",
+    "depends": ["sale"],
+    "data": ["views/sale_order.xml", "views/account_move.xml"],
+    "installable": True,
+}

--- a/sale_order_customer_free_ref/models/__init__.py
+++ b/sale_order_customer_free_ref/models/__init__.py
@@ -1,0 +1,2 @@
+from . import account_move
+from . import sale_order

--- a/sale_order_customer_free_ref/models/account_move.py
+++ b/sale_order_customer_free_ref/models/account_move.py
@@ -1,0 +1,11 @@
+# Copyright 2021 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+from odoo import fields, models
+
+
+class AccountMove(models.Model):
+    _inherit = "account.move"
+
+    customer_order_number = fields.Char(string="Customer Order Number", copy=False)
+    customer_order_free_ref = fields.Char(string="Customer Free Reference", copy=False)

--- a/sale_order_customer_free_ref/models/sale_order.py
+++ b/sale_order_customer_free_ref/models/sale_order.py
@@ -1,0 +1,45 @@
+# Copyright 2021 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+from odoo import api, fields, models
+
+
+class SaleOrder(models.Model):
+    _inherit = "sale.order"
+
+    _client_order_ref_separator = " - "
+
+    client_order_ref = fields.Char(
+        compute="_compute_client_order_ref",
+        inverse="_inverse_client_order_ref",
+        string="Customer Reference",
+        store=True,
+        copy=False,
+    )
+    customer_order_number = fields.Char(string="Customer Order Number", copy=False)
+    customer_order_free_ref = fields.Char(string="Customer Free Reference", copy=False)
+
+    @api.depends("customer_order_number", "customer_order_free_ref")
+    def _compute_client_order_ref(self):
+        for order in self:
+            refs = [order.customer_order_number, order.customer_order_free_ref]
+            refs = [ref for ref in refs if ref and ref.strip()]
+            order.client_order_ref = self._client_order_ref_separator.join(refs)
+
+    def _inverse_client_order_ref(self):
+        for order in self:
+            if not order.client_order_ref:
+                order.customer_order_number = ""
+                order.customer_order_free_ref = ""
+            refs = order.client_order_ref.split(self._client_order_ref_separator, 1)
+            order.customer_order_number = refs[0]
+            if len(refs) == 2:
+                order.customer_order_free_ref = refs[1]
+            else:
+                order.customer_order_free_ref = ""
+
+    def _prepare_invoice(self):
+        res = super()._prepare_invoice()
+        res["customer_order_number"] = self.customer_order_number
+        res["customer_order_free_ref"] = self.customer_order_free_ref
+        return res

--- a/sale_order_customer_free_ref/models/sale_order.py
+++ b/sale_order_customer_free_ref/models/sale_order.py
@@ -31,12 +31,13 @@ class SaleOrder(models.Model):
             if not order.client_order_ref:
                 order.customer_order_number = ""
                 order.customer_order_free_ref = ""
-            refs = order.client_order_ref.split(self._client_order_ref_separator, 1)
-            order.customer_order_number = refs[0]
-            if len(refs) == 2:
-                order.customer_order_free_ref = refs[1]
             else:
-                order.customer_order_free_ref = ""
+                refs = order.client_order_ref.split(self._client_order_ref_separator, 1)
+                order.customer_order_number = refs[0]
+                if len(refs) == 2:
+                    order.customer_order_free_ref = refs[1]
+                else:
+                    order.customer_order_free_ref = ""
 
     def _prepare_invoice(self):
         res = super()._prepare_invoice()

--- a/sale_order_customer_free_ref/readme/CONTRIBUTORS.rst
+++ b/sale_order_customer_free_ref/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Thierry Ducrest <thierry.ducrest@camptocamp.com>

--- a/sale_order_customer_free_ref/readme/DESCRIPTION.rst
+++ b/sale_order_customer_free_ref/readme/DESCRIPTION.rst
@@ -1,0 +1,12 @@
+The goal of this module is to improve on the `client_order_ref` on `sale.order`.
+
+By default, Odoo only has one field to handle the customer reference of a sales order.
+
+However, an order provided by the buyer can contain an id (PO number) and a free reference.
+When exchanging with the other parties, you sometimes need to differentiate them.
+For instance, this is required by some EDI flows.
+
+To help with this, this module adds two specific fields for them and transforms the
+`client_order_ref` standard field into a computed one.
+
+The two new fields are also passed on to generated invoices.

--- a/sale_order_customer_free_ref/tests/__init__.py
+++ b/sale_order_customer_free_ref/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_sale_order_customer_free_ref

--- a/sale_order_customer_free_ref/tests/test_sale_order_customer_free_ref.py
+++ b/sale_order_customer_free_ref/tests/test_sale_order_customer_free_ref.py
@@ -1,0 +1,47 @@
+# Copyright 2021 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+from odoo.tests.common import SingleTransactionCase
+
+
+class TestSaleOrderCustomerFreeRef(SingleTransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
+        cls.order = cls.env.ref("sale.sale_order_1")
+
+    def test_client_order_ref_computation(self):
+        self.order.customer_order_number = "123"
+        self.order.customer_order_free_ref = ""
+        self.assertEqual(self.order.client_order_ref, "123")
+        self.order.customer_order_free_ref = "MrPink"
+        self.assertEqual(self.order.client_order_ref, "123 - MrPink")
+        self.order.action_confirm()
+        for line in self.order.order_line:
+            line.qty_delivered = line.product_uom_qty
+        invoice = self.order._create_invoices()
+        self.assertTrue(invoice)
+        self.assertEqual(
+            self.order.customer_order_number, invoice.customer_order_number
+        )
+        self.assertEqual(
+            self.order.customer_order_free_ref, invoice.customer_order_free_ref
+        )
+        self.assertEqual(self.order.client_order_ref, invoice.ref)
+
+    def test_client_order_ref_computation_empty_values(self):
+        self.order.customer_order_number = "123"
+        self.order.customer_order_free_ref = "  "
+        self.assertEqual(self.order.client_order_ref, "123")
+        self.order.customer_order_number = ""
+        self.order.customer_order_free_ref = "MrPink"
+        self.assertEqual(self.order.client_order_ref, "MrPink")
+
+    def test_client_order_ref_inverse_function(self):
+        self.order.client_order_ref = "456 - MrBlue"
+        self.assertEqual(self.order.customer_order_number, "456")
+        self.assertEqual(self.order.customer_order_free_ref, "MrBlue")
+        self.order.client_order_ref = "456/abc"
+        self.assertEqual(self.order.customer_order_number, "456/abc")
+        self.assertFalse(self.order.customer_order_free_ref)

--- a/sale_order_customer_free_ref/tests/test_sale_order_customer_free_ref.py
+++ b/sale_order_customer_free_ref/tests/test_sale_order_customer_free_ref.py
@@ -45,3 +45,6 @@ class TestSaleOrderCustomerFreeRef(SingleTransactionCase):
         self.order.client_order_ref = "456/abc"
         self.assertEqual(self.order.customer_order_number, "456/abc")
         self.assertFalse(self.order.customer_order_free_ref)
+        self.order.client_order_ref = ""
+        self.assertFalse(self.order.customer_order_number)
+        self.assertFalse(self.order.customer_order_free_ref)

--- a/sale_order_customer_free_ref/views/account_move.xml
+++ b/sale_order_customer_free_ref/views/account_move.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+  <record id="view_move_form" model="ir.ui.view">
+    <field name="name">account.move.customer.free.ref.form</field>
+    <field name="model">account.move</field>
+    <field name="inherit_id" ref="account.view_move_form" />
+    <field name="arch" type="xml">
+      <field name="ref" position="after">
+        <field name="customer_order_number" />
+        <field name="customer_order_free_ref" />
+      </field>
+    </field>
+  </record>
+</odoo>

--- a/sale_order_customer_free_ref/views/sale_order.xml
+++ b/sale_order_customer_free_ref/views/sale_order.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+  <record id="view_order_form" model="ir.ui.view">
+    <field name="name">sale.order.customer.free.ref.form</field>
+    <field name="model">sale.order</field>
+    <field name="inherit_id" ref="sale.view_order_form" />
+    <field name="arch" type="xml">
+      <xpath expr="//field[@name='client_order_ref']" position="after">
+        <field name="customer_order_number" />
+        <field name="customer_order_free_ref" />
+      </xpath>
+      <xpath expr="//field[@name='client_order_ref']" position="attributes">
+        <attribute name="readonly">1</attribute>
+      </xpath>
+    </field>
+  </record>
+</odoo>


### PR DESCRIPTION
The goal of this module is to improve on the `client_order_ref` on `sale.order`.

By default Odoo only has one field to handle the customer reference of a sale order.
But when using EDI some specifications allow to have two fields for this, the customer
order Id and a customer (free) reference.

To help with this, this module adds two specific fields for them and transform the
`client_order_ref` standard field into a computed one.

The two new fields are also passed on to created invoices.