### PR TITLE
[13.0][IMP] account_invoice_export send button visibility

### DIFF
--- a/account_invoice_export/models/account_move.py
+++ b/account_invoice_export/models/account_move.py
@@ -16,6 +16,7 @@ class AccountMove(models.Model):
     invoice_exported = fields.Boolean(copy=False)
     # Usefull when the distant system does not validate the export synchronously
     invoice_export_confirmed = fields.Boolean(copy=False)
+    send_through_http = fields.Boolean(related="transmit_method_id.send_through_http")
 
     def export_invoice(self):
         for invoice in self:

--- a/account_invoice_export/models/transmit_method.py
+++ b/account_invoice_export/models/transmit_method.py
@@ -9,7 +9,9 @@ from odoo import fields, models
 class TransmitMethod(models.Model):
     _inherit = "transmit.method"
 
-    send_through_http = fields.Boolean()
+    send_through_http = fields.Boolean(
+        string="Enable send eBill", help="Adds a Send eBill button on the invoice"
+    )
     destination_url = fields.Char(string="Url")
     destination_user = fields.Char(string="User", copy=False)
     destination_pwd = fields.Char(string="Password", copy=False)

--- a/account_invoice_export/views/account_move.xml
+++ b/account_invoice_export/views/account_move.xml
@@ -8,13 +8,14 @@
             <field name="transmit_method_id" position="after">
                 <field name="invoice_exported" invisible="1" />
                 <field name="invoice_export_confirmed" invisible="1" />
+                <field name="send_through_http" invisible="1" />
             </field>
             <button name="action_invoice_sent" position="after">
                 <button
                     name="export_invoice"
                     string="Send eBill"
                     type="object"
-                    attrs="{'invisible':['|', '|', ('state', '!=', 'posted'), ('invoice_exported', '=', True), ('type', 'not in', ('out_invoice', 'out_refund'))]}"
+                    attrs="{'invisible':['|', '|', '|', ('send_through_http', '=', False), ('state', '!=', 'posted'), ('invoice_exported', '=', True), ('type', 'not in', ('out_invoice', 'out_refund'))]}"
                     groups="base.group_user"
                     class="oe_highlight"
                 />
@@ -22,10 +23,10 @@
                     name="export_invoice"
                     string="Resend eBill"
                     type="object"
-                    attrs="{'invisible':['|', '|', ('state', '!=', 'posted'), '|', ('invoice_export_confirmed', '=', True), ('invoice_exported', '=', False), ('type', 'not in', ('out_invoice', 'out_refund'))]}"
+                    attrs="{'invisible':['|', '|', '|', ('send_through_http', '=', False), ('state', '!=', 'posted'), ('invoice_exported', '=', False), ('type', 'not in', ('out_invoice', 'out_refund'))]}"
                     groups="base.group_user"
                     class="oe_highlight"
-                    confirm="Ebill has already been sent, but has not yet been accpeted by the distant system. Are you sure you want to send it again ?"
+                    confirm="Ebill has already been sent. Are you sure you want to send it again ?"
                 />
             </button>
         </field>

--- a/account_invoice_export/views/transmit_method.xml
+++ b/account_invoice_export/views/transmit_method.xml
@@ -14,6 +14,17 @@
                     attrs="{'invisible': [('customer_ok', '=', False)]}"
                 >
                     <field name="send_through_http" />
+                    <div
+                        role="alert"
+                        class="alert alert-info"
+                        colspan="2"
+                        attrs="{'invisible': [('send_through_http', '=', False)]}"
+                    >
+                        <p
+                        >By default the PDF of the invoice will be sent using the connection parameters below (basic authenticaiton).</p>
+                        <p
+                        >Handling specific connection needs and/or exporting other files can be done through code.</p>
+                    </div>
                     <field
                         name="destination_url"
                         attrs="{'invisible': [('send_through_http', '=', False)]}"


### PR DESCRIPTION
This change the visibility of the send eBill button on the invoice.
It is now only shown if the option is checked on the transmit method.
Also improve the configuration on the transmit method adding
information on the process.