### PR TITLE
[10.0][BACKPORT] account_invoice_import: disable check for tax included

### DIFF
--- a/account_invoice_import/models/account_invoice_import_config.py
+++ b/account_invoice_import/models/account_invoice_import_config.py
@@ -30,6 +30,7 @@ class AccountInvoiceImportConfig(models.Model):
         "that don't have an embedded XML file. "
         "The 'Multi Line, Auto-selected Product' method will only work with "
         "ZUGFeRD invoices at Comfort or Extended level, not at Basic level.")
+    tax_control = fields.Boolean(help="Compare total tax with parsed data")
     company_id = fields.Many2one(
         'res.company', string='Company',
         ondelete='cascade', required=True,
@@ -85,6 +86,7 @@ class AccountInvoiceImportConfig(models.Model):
         vals = {
             'invoice_line_method': self.invoice_line_method,
             'account_analytic': self.account_analytic_id or False,
+            "tax_control": self.tax_control,
             }
         if self.invoice_line_method == '1line_no_product':
             vals['account'] = self.account_id

--- a/account_invoice_import/views/account_invoice_import_config.xml
+++ b/account_invoice_import/views/account_invoice_import_config.xml
@@ -26,6 +26,7 @@
             </group>
             <group string="Accounting Parameters" name="accounting">
                 <field name="invoice_line_method"/>
+                <field name="tax_control" />
                 <field name="account_id"
                     attrs="{'invisible': [('invoice_line_method', 'not in', ('1line_no_product', 'nline_no_product'))], 'required': [('invoice_line_method', 'in', ('1line_no_product', 'nline_no_product'))]}"/>
                 <field name="tax_ids"

--- a/account_invoice_import/wizard/account_invoice_import.py
+++ b/account_invoice_import/wizard/account_invoice_import.py
@@ -889,8 +889,7 @@ class AccountInvoiceImport(models.TransientModel):
         if not invoice:
             raise UserError(_(
                 'You must select a supplier invoice or refund to update'))
-        parsed_inv = self.parse_invoice(
-            self.invoice_file, self.invoice_filename)
+        parsed_inv = self._get_parsed_invoice()
         if self.partner_id:
             # True if state='update' ; False when state='update-from-invoice'
             parsed_inv['partner']['recordset'] = self.partner_id
@@ -1067,7 +1066,7 @@ class AccountInvoiceImport(models.TransientModel):
         aiico = self.env['account.invoice.import.config']
         company_id = self._context.get('force_company') or\
             self.env.user.company_id.id
-        parsed_inv = self.parse_invoice(invoice_b64, invoice_filename)
+        parsed_inv = self._get_parsed_invoice()
         partner = bdio._match_partner(
             parsed_inv['partner'], parsed_inv['chatter_msg'])
 

--- a/account_invoice_import/wizard/account_invoice_import.py
+++ b/account_invoice_import/wizard/account_invoice_import.py
@@ -495,8 +495,6 @@ class AccountInvoiceImport(models.TransientModel):
     def _hook_no_partner_found(self, partner_dict):
         """Hook designed to add an action when no partner is found
         For instance to propose to create the partner based on the partner_dict.
-        In that case, the hook is expected to return an action serialized
-        as a dictionary which will be returned to the web client.
         """
         return False
 

--- a/base_business_document_import/models/business_document_import.py
+++ b/base_business_document_import/models/business_document_import.py
@@ -516,7 +516,7 @@ class BusinessDocumentImport(models.AbstractModel):
         for tax_dict in taxes_list:
             taxes_recordset += self._match_tax(
                 tax_dict, chatter_msg, type_tax_use=type_tax_use,
-                price_include=price_include)
+                price_include=tax_dict.get("price_include") or price_include)
         return taxes_recordset
 
     @api.model


### PR DESCRIPTION
Backport fix from #213 
Also include #234 for convenience

In Switzerland most invoices are tax included. And with the arrival of QR-bill tax info is optional in the QR-Code data, thus we can let Odoo compute them.