### PR TITLE
[ADD] Account Invoice Factur-X Buyer Reference

### DIFF
--- a/account_invoice_facturx_buyer_ref/__init__.py
+++ b/account_invoice_facturx_buyer_ref/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/account_invoice_facturx_buyer_ref/__manifest__.py
+++ b/account_invoice_facturx_buyer_ref/__manifest__.py
@@ -1,0 +1,19 @@
+# Copyright 2021 Camptocamp
+# @author: Iván Todorovich <ivan.todorovich@gmail.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+{
+    'name': 'Account Invoice Factur-X Buyer Reference',
+    'version': '12.0.1.0.0',
+    'category': 'Invoicing Management',
+    'license': 'AGPL-3',
+    'summary': 'Set a Buyer Reference to be used in Factur-X/ZUGFeRD invoices',
+    'author': 'Camptocamp, Odoo Community Association (OCA)',
+    'website': 'https://github.com/OCA/edi',
+    'depends': [
+        'account_invoice_facturx',
+    ],
+    'data': [
+        'views/res_partner.xml',
+    ],
+}

--- a/account_invoice_facturx_buyer_ref/models/__init__.py
+++ b/account_invoice_facturx_buyer_ref/models/__init__.py
@@ -1,0 +1,2 @@
+from . import res_partner
+from . import account_invoice

--- a/account_invoice_facturx_buyer_ref/models/account_invoice.py
+++ b/account_invoice_facturx_buyer_ref/models/account_invoice.py
@@ -1,0 +1,17 @@
+# Copyright 2021 Camptocamp
+# @author: Iván Todorovich <ivan.todorovich@gmail.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import api, models
+
+
+class AccountInvoice(models.Model):
+    _inherit = "account.invoice"
+
+    @api.model
+    def _cii_trade_agreement_buyer_ref(self, partner):
+        return (
+            partner.facturx_ref
+            or partner.commercial_partner_id.facturx_ref
+            or super()._cii_trade_agreement_buyer_ref(partner)
+        )

--- a/account_invoice_facturx_buyer_ref/models/res_partner.py
+++ b/account_invoice_facturx_buyer_ref/models/res_partner.py
@@ -1,0 +1,16 @@
+# Copyright 2021 Camptocamp
+# @author: Iván Todorovich <ivan.todorovich@gmail.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import models, fields
+
+
+class ResPartner(models.Model):
+    _inherit = "res.partner"
+
+    facturx_ref = fields.Char(
+        string="Factur-X Reference",
+        help="Used as Buyer Reference in Factur-X data.\n"
+             "It's a requirement by some countries regulations.\n"
+             "* Germany : Used for Leitweg ID",
+    )

--- a/account_invoice_facturx_buyer_ref/readme/CONTRIBUTORS.rst
+++ b/account_invoice_facturx_buyer_ref/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Iván Todorovich <ivan.todorovich@gmail.com>

--- a/account_invoice_facturx_buyer_ref/readme/DESCRIPTION.rst
+++ b/account_invoice_facturx_buyer_ref/readme/DESCRIPTION.rst
@@ -1,0 +1,11 @@
+Some companies are affected by country-specific regulations that require you to 
+set a BuyerReference in the FacturX data.
+
+For instance, German Public Organizations will require that you set a Leitweg ID
+when invoicing to them. This information needs to be set in the BuyerReference.
+
+This requirement is not localization-specific because it affects all EU companies
+invoicing that particular organization.
+
+This module allows you to set on partners a Buyer Reference to be used on FacturX
+invoices, complying with this regulation and potentially others of this kind.

--- a/account_invoice_facturx_buyer_ref/readme/USAGE.rst
+++ b/account_invoice_facturx_buyer_ref/readme/USAGE.rst
@@ -1,0 +1,1 @@
+In the partner form view, set a FacturX Buyer Reference

--- a/account_invoice_facturx_buyer_ref/views/res_partner.xml
+++ b/account_invoice_facturx_buyer_ref/views/res_partner.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Copyright 2021 Camptocamp
+  @author: Iván Todorovich <ivan.todorovich@gmail.com>
+  License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+-->
+<odoo>
+
+    <record id="view_partner_form" model="ir.ui.view">
+        <field name="model">res.partner</field>
+        <field name="inherit_id" ref="base.view_partner_form" />
+        <field name="arch" type="xml">
+            <field name="ref" position="after">
+                <field name="facturx_ref"/>
+            </field>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
This PR adds a facturx_ref field to res.partner:

![image](https://user-images.githubusercontent.com/1914185/110684886-70215700-81bc-11eb-9172-855bfe4a5d5e.png)

When set, it's used as BuyerReference in facturx xml.

This is required to comply with some countries regulations. For instance, when selling to German Public Organizations this field need to be set with a "routing number" (Leitweg ID)

I considered adding this to l10n-germany AFAIK this affects any company from any eu country invoicing to a german public organization

@alexis-via your opinion is most welcomed :)