### PR TITLE
[13.0][IMP] Add sale order ubl parse latest delivery

### DIFF
--- a/base_ubl/models/ubl.py
+++ b/base_ubl/models/ubl.py
@@ -724,6 +724,18 @@ class BaseUbl(models.AbstractModel):
                 )
         return partner_dict
 
+    @api.model
+    def ubl_parse_delivery_details(self, delivery_node, ns):
+        delivery_dict = {}
+        latest_date = delivery_node.xpath("cbc:LatestDeliveryDate", namespaces=ns)
+        latest_time = delivery_node.xpath("cbc:LatestDeliveryTime", namespaces=ns)
+        if latest_date:
+            latest_delivery = latest_date[0].text
+            if latest_time:
+                latest_delivery += " " + latest_time[0].text[:-3]
+            delivery_dict["commitment_date"] = latest_delivery
+        return delivery_dict
+
     def ubl_parse_incoterm(self, delivery_term_node, ns):
         incoterm_xpath = delivery_term_node.xpath("cbc:ID", namespaces=ns)
         if incoterm_xpath:

--- a/sale_order_import/wizard/sale_order_import.py
+++ b/sale_order_import/wizard/sale_order_import.py
@@ -227,6 +227,10 @@ class SaleOrderImport(models.TransientModel):
                 parsed_order["ship_to"], partner, parsed_order["chatter_msg"]
             )
             so_vals["partner_shipping_id"] = shipping_partner.id
+
+        if parsed_order.get("delivery_detail"):
+            so_vals.update(parsed_order.get("delivery_detail"))
+
         if parsed_order.get("invoice_to"):
             invoicing_partner = bdio._match_partner(
                 parsed_order["partner"], parsed_order["chatter_msg"], partner_type=""

--- a/sale_order_import_ubl/tests/files/UBL-Order-2.0-Example.xml
+++ b/sale_order_import_ubl/tests/files/UBL-Order-2.0-Example.xml
@@ -132,6 +132,7 @@
         </cac:Party>
     </cac:OriginatorCustomerParty>
     <cac:Delivery>
+        <cbc:LatestDeliveryDate>2010-02-26</cbc:LatestDeliveryDate>
         <cac:DeliveryAddress>
             <cbc:StreetName>Avon Way</cbc:StreetName>
             <cbc:BuildingName>Thereabouts</cbc:BuildingName>

--- a/sale_order_import_ubl/tests/files/UBL-Order-2.1-Example.xml
+++ b/sale_order_import_ubl/tests/files/UBL-Order-2.1-Example.xml
@@ -236,6 +236,8 @@
         </cac:DeliveryContact>
     </cac:AccountingCustomerParty>
     <cac:Delivery>
+        <cbc:LatestDeliveryDate>2010-02-26</cbc:LatestDeliveryDate>
+        <cbc:LatestDeliveryTime>18:00:00.0Z</cbc:LatestDeliveryTime>
         <cac:DeliveryLocation>
             <cac:Address>
                 <cbc:ID schemeAgencyID="9" schemeID="GLN">1234567890123</cbc:ID>

--- a/sale_order_import_ubl/tests/test_ubl_order_import.py
+++ b/sale_order_import_ubl/tests/test_ubl_order_import.py
@@ -20,6 +20,7 @@ class TestUblOrderImport(TransactionCase):
                 ),
                 "invoicing_partner": self.env.ref("sale_order_import_ubl.karlsson"),
                 "currency": self.env.ref("base.SEK"),
+                "commitment_date": "2010-02-26 18:00:00",
             },
             "UBL-Order-2.0-Example.xml": {
                 "client_order_ref": "AEG012345",
@@ -27,6 +28,7 @@ class TestUblOrderImport(TransactionCase):
                 "partner": self.env.ref("sale_order_import_ubl.fred_churchill"),
                 "shipping_partner": self.env.ref("sale_order_import_ubl.iyt"),
                 "currency": self.env.ref("base.GBP"),
+                "commitment_date": "2010-02-26 00:00:00",
             },
             "UBL-RequestForQuotation-2.0-Example.xml": {
                 "partner": self.env.ref("sale_order_import_ubl.s_massiah"),
@@ -59,3 +61,10 @@ class TestUblOrderImport(TransactionCase):
                 self.assertEqual(date_order[:10], res["date_order"])
             if res.get("shipping_partner"):
                 self.assertEqual(so.partner_shipping_id, res["shipping_partner"])
+            if res.get("commitment_date"):
+                self.assertEqual(
+                    so.commitment_date.strftime("%Y-%m-%d %H:%M:%S"),
+                    res["commitment_date"],
+                )
+            else:
+                self.assertFalse(so.commitment_date)

--- a/sale_order_import_ubl/wizard/sale_order_import.py
+++ b/sale_order_import_ubl/wizard/sale_order_import.py
@@ -111,8 +111,10 @@ class SaleOrderImport(models.TransientModel):
             company_dict = {"vat": company_dict_full["vat"]}
         delivery_xpath = xml_root.xpath("/%s/cac:Delivery" % root_name, namespaces=ns)
         shipping_dict = {}
+        delivery_dict = {}
         if delivery_xpath:
             shipping_dict = self.ubl_parse_delivery(delivery_xpath[0], ns)
+            delivery_dict = self.ubl_parse_delivery_details(delivery_xpath[0], ns)
         # In the demo UBL 2.1 file, they use 'IMCOTERM'... but I guess
         # it's a mistake and they should use 'INCOTERM'
         # So, for the moment, I ignore the attributes in the xpath for incoterm
@@ -149,6 +151,7 @@ class SaleOrderImport(models.TransientModel):
             "note": note_xpath and note_xpath[0].text or False,
             "lines": res_lines,
             "doc_type": doc_type,
+            "delivery_detail": delivery_dict,
         }
         # Stupid hack to remove invalid VAT of sample files
         if res["partner"]["vat"] in ["SE1234567801", "12356478", "DK12345678"]:


### PR DESCRIPTION
Parse the latest delivery date and time from the delivery node of an UBL
sales order.
And assign the value to the `commitment_date` of the sales order.