### PR TITLE
[13.0][ADD] account_invoice_export_server_env

### DIFF
--- a/account_invoice_export_server_env/__init__.py
+++ b/account_invoice_export_server_env/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/account_invoice_export_server_env/__manifest__.py
+++ b/account_invoice_export_server_env/__manifest__.py
@@ -1,0 +1,13 @@
+# Copyright 2021 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+{
+    "name": "Server environment for Account Invoice Export",
+    "version": "13.0.1.0.0",
+    "author": "Camptocamp,Odoo Community Association (OCA)",
+    "license": "AGPL-3",
+    "category": "Tools",
+    "depends": ["server_environment", "account_invoice_export"],
+    "website": "https://www.camptocamp.com",
+    "installable": True,
+}

--- a/account_invoice_export_server_env/models/__init__.py
+++ b/account_invoice_export_server_env/models/__init__.py
@@ -1,0 +1,1 @@
+from . import transmit_method

--- a/account_invoice_export_server_env/models/transmit_method.py
+++ b/account_invoice_export_server_env/models/transmit_method.py
@@ -1,0 +1,19 @@
+# Copyright 2021 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class TransmitMethod(models.Model):
+    _name = "transmit.method"
+    _inherit = ["transmit.method", "server.env.mixin"]
+
+    _server_env_section_name_field = "code"
+
+    @property
+    def _server_env_fields(self):
+        return {
+            "destination_user": {},
+            "destination_pwd": {},
+            "destination_url": {},
+        }

--- a/account_invoice_export_server_env/readme/DESCRIPTION.rst
+++ b/account_invoice_export_server_env/readme/DESCRIPTION.rst
@@ -1,0 +1,14 @@
+Server environment for Account Invoice Export
+=============================================
+
+This module is based on the `server_environment` module to use files for
+configuration. So we can have a different configuration for each
+environment (dev, test, integration, prod).  This module define the config
+variables for the `account_invoice_export` module.
+
+Exemple of the section to put in the configuration file::
+
+    [transmit_method.transmition_method_code]
+    destination_pwd: password,
+    destination_user: user,
+    destination_url: url,

--- a/setup/account_invoice_export_server_env/odoo/addons/account_invoice_export_server_env
+++ b/setup/account_invoice_export_server_env/odoo/addons/account_invoice_export_server_env
@@ -1,0 +1,1 @@
+../../../../account_invoice_export_server_env

--- a/setup/account_invoice_export_server_env/setup.py
+++ b/setup/account_invoice_export_server_env/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
This module is based on the `server_environment` module to use files for
configuration. So we can have a different configuration for each
environment (dev, test, integration, prod).  This module define the config
variables for the `account_invoice_export` module.

Exemple of the section to put in the configuration file::

    [transmit_method.transmition_method_name]
    destination_pwd: password,
    destination_user: user,