### PR TITLE
[FIX] edi & edi_storage

### DIFF
--- a/edi/models/edi_exchange_record.py
+++ b/edi/models/edi_exchange_record.py
@@ -151,6 +151,12 @@ class EDIExchangeRecord(models.Model):
 
     @property
     def record(self):
+        # In some case the res_model (and res_id) could be empty so we have to load
+        # data from parent
+        if not self.model and not self.parent_id:
+            return None
+        if not self.model and self.parent_id:
+            return self.parent_id.record
         return self.env[self.model].browse(self.res_id)
 
     def _set_file_content(

--- a/edi/models/edi_exchange_record.py
+++ b/edi/models/edi_exchange_record.py
@@ -375,13 +375,12 @@ class EDIExchangeRecord(models.Model):
         super(EDIExchangeRecord, self).check_access_rule(operation)
         if self.env.is_superuser():
             return
-        for exchange_record in self:
-            sudo_record = exchange_record.sudo()
-            if not sudo_record.model or not sudo_record.res_id:
+        for exchange_record in self.sudo():
+            if not exchange_record.model or not exchange_record.res_id:
                 continue
             record = (
-                self.env[sudo_record.model]
-                .browse(sudo_record.res_id)
+                self.env[exchange_record.model]
+                .browse(exchange_record.res_id)
                 .with_user(self._uid)
             )
             if hasattr(record, "get_edi_access"):

--- a/edi/tests/test_record.py
+++ b/edi/tests/test_record.py
@@ -70,3 +70,26 @@ class EDIRecordTestCase(EDIBackendCommonTestCase):
         self.assertIn(record1, record.related_exchange_ids)
         self.assertIn(record2, record.related_exchange_ids)
         self.assertEqual(record.ack_exchange_id, record2)
+
+    def test_record_empty_with_parent(self):
+        """
+        Simulate the case when the child record doesn't have a model and res_id.
+        In this case the .record should return the record of the parent.
+        :return:
+        """
+        vals = {
+            "model": self.partner._name,
+            "res_id": self.partner.id,
+        }
+        record = self.backend.create_record("test_csv_output", vals)
+        record1 = self.backend.create_record(
+            "test_csv_output", dict(vals, parent_id=record.id)
+        )
+        self.assertTrue(record1.model)
+        self.assertEqual(record.record, record1.record)
+        # Don't use the vals to lets empty model and res_id
+        record2 = self.backend.create_record(
+            "test_csv_output_ack", dict(parent_id=record.id)
+        )
+        self.assertFalse(record2.model)
+        self.assertEqual(record.record, record2.record)

--- a/edi_storage/models/edi_backend.py
+++ b/edi_storage/models/edi_backend.py
@@ -73,4 +73,6 @@ class EDIBackend(models.Model):
         # Override to give precedence by storage_backend_type when needed.
         if not self.storage_id:
             return res
-        return (1 if component_class._storage_backend_type else 0,) + res
+        return (
+            1 if getattr(component_class, "_storage_backend_type", False) else 0,
+        ) + res


### PR DESCRIPTION
This PR solves three issues:
1- Security on edi
2- Filtering on edi (the records not assigned could not be found)
3- Sorting of components after edi storage was giving an error when the backend has a storage id.

@simahawk 