### PR TITLE
[12.0][FIX] Fix runbot build

### DIFF
--- a/account_invoice_download_ovh/wizard/ovh_api_credentials.py
+++ b/account_invoice_download_ovh/wizard/ovh_api_credentials.py
@@ -17,7 +17,7 @@ except ImportError:
 
 class OvhApiCredentials(models.TransientModel):
     _name = 'ovh.api.credentials'
-    _generate = 'Generate OVH API credentials'
+    _description = 'Generate OVH API credentials'
 
     download_config_id = fields.Many2one(
         'account.invoice.download.config', string="Download Config",


### PR DESCRIPTION
It's red because of this:

```
WARNING openerp_test odoo.models: The model ovh.api.credentials has no _description
```

Looks like a typo to me
ping @alexis-via 