### PR TITLE
[13.0][FIX] order_import_order_ubl_http fail if exists

### DIFF
--- a/sale_order_import_ubl_http/models/sale_order.py
+++ b/sale_order_import_ubl_http/models/sale_order.py
@@ -21,9 +21,7 @@ class SaleOrder(models.Model):
         res = wiz.sudo().import_order_button()
         action_xmlid = res["xml_id"]
         if action_xmlid == "sale_order_import.sale_order_import_action":
-            # TODO: Order has already been imported
-            #   there could be more than one to update ?
-            return _("Sales order has already been imported before, nothing done.")
+            raise UserError(_("Sales order has already been imported before"))
         elif action_xmlid == "sale.action_quotations":
             order_id = res["res_id"]
             order = self.env["sale.order"].browse(order_id)


### PR DESCRIPTION
Raise an error if the same order is being imported a 2nd time.
This will make the job fail and will be noticed.
Otherwise the job is done but the order not updated.