### PR TITLE
[FIX] edi_voxel_stock_picking: Filter out cancel lines

### DIFF
--- a/edi_voxel_stock_picking/reports/report_voxel_picking.py
+++ b/edi_voxel_stock_picking/reports/report_voxel_picking.py
@@ -84,9 +84,8 @@ class ReportVoxelPicking(models.AbstractModel):
         return [{"PORef": (so.client_order_ref or so.name) if so else picking.origin}]
 
     def _get_products_data(self, picking):
-        return [
-            {"product": self._get_product_data(line)} for line in picking.move_lines
-        ]
+        lines = picking.move_lines.filtered(lambda x: x.state == "done")
+        return [{"product": self._get_product_data(line)} for line in lines]
 
     def _get_product_data(self, line):
         customer_sku = line.picking_id._get_customer_product_sku(

--- a/edi_voxel_stock_picking/tests/test_voxel_stock_picking.py
+++ b/edi_voxel_stock_picking/tests/test_voxel_stock_picking.py
@@ -85,9 +85,11 @@ class TestVoxelStockPickingCommon(common.SavepointCase):
                 "note": "Picking note (test)",
             }
         )
-        cls.picking.move_lines[0].write({"quantity_done": 2})
-        cls.picking.move_lines[1].write({"quantity_done": 1})
-        cls.picking.move_lines[1].move_line_ids.lot_id = cls.lot.id
+        sm = cls.picking.move_lines[0]
+        sm.write({"quantity_done": sm.product_uom_qty})
+        sm = cls.picking.move_lines[1]
+        sm.write({"quantity_done": sm.product_uom_qty})
+        sm.move_line_ids.lot_id = cls.lot.id
         cls.picking.button_validate()
 
     @classmethod


### PR DESCRIPTION
Now on v13, when not transferring whole quantity, if the choice is to not create backorder, the remaining lines are kept on the same picking, but with cancel state, so we need to filter them out from the Voxel report.

@Tecnativa TT29696