### PR TITLE
[ADD][13.0]sale_order_import no mail subscribe

### DIFF
--- a/sale_order_import/wizard/sale_order_import.py
+++ b/sale_order_import/wizard/sale_order_import.py
@@ -248,7 +248,7 @@ class SaleOrderImport(models.TransientModel):
 
     @api.model
     def create_order(self, parsed_order, price_source, order_filename=None):
-        soo = self.env["sale.order"]
+        soo = self.env["sale.order"].with_context(mail_create_nosubscribe=True)
         bdio = self.env["business.document.import"]
         so_vals = self._prepare_order(parsed_order, price_source)
         order = soo.create(so_vals)


### PR DESCRIPTION
Disable the subscription (mail chatter) to the new sales order
for the user used by the endpoint.
To me it does make sense because good practice would be to have a
specific user for the endpoint.