### PR TITLE
[14.0] several fixes on account_invoice_import

### DIFF
--- a/account_invoice_import/models/res_partner.py
+++ b/account_invoice_import/models/res_partner.py
@@ -31,3 +31,18 @@ class ResPartner(models.Model):
         }
         for partner in self:
             partner.invoice_import_count = mapped_data.get(partner.id, 0)
+
+    def show_account_invoice_import_config(self):
+        self.ensure_one()
+        action = (
+            self.env.ref("account_invoice_import.account_invoice_import_config_action")
+            .sudo()
+            .read()[0]
+        )
+        action["context"] = {
+            "default_name": self.name,
+            "default_partner_id": self.id,
+            "search_default_partner_id": self.id,
+            "invoice_import_config_main_view": True,
+        }
+        return action

--- a/account_invoice_import/views/account_invoice_import_config.xml
+++ b/account_invoice_import/views/account_invoice_import_config.xml
@@ -16,6 +16,8 @@
                         bg_color="bg-danger"
                         attrs="{'invisible': [('active', '=', True)]}"
                     />
+                    <div class="oe_button_box" name="button_box">
+                    </div>
                     <group name="main">
                         <field name="name" />
                         <field name="partner_id" />

--- a/account_invoice_import/views/res_partner.xml
+++ b/account_invoice_import/views/res_partner.xml
@@ -19,10 +19,9 @@
                     colspan="2"
                 >
                     <button
-                        type="action"
+                        type="object"
                         class="btn-link"
-                        name="%(account_invoice_import_config_action)d"
-                        context="{'search_default_partner_id': active_id, 'default_partner_id': active_id, 'default_name': name}"
+                        name="show_account_invoice_import_config"
                     >
                         <field
                             name="invoice_import_count"

--- a/account_invoice_import/wizard/account_invoice_import.py
+++ b/account_invoice_import/wizard/account_invoice_import.py
@@ -252,7 +252,7 @@ class AccountInvoiceImport(models.TransientModel):
         analytic_account = import_config.get("account_analytic", False)
         if analytic_account:
             for line in vals["invoice_line_ids"]:
-                line[2]["account_analytic_id"] = analytic_account.id
+                line[2]["analytic_account_id"] = analytic_account.id
         return vals
 
     @api.model
@@ -1256,7 +1256,7 @@ class AccountInvoiceImport(models.TransientModel):
         self.post_process_invoice(parsed_inv, invoice, import_config)
         if import_config["account_analytic"]:
             invoice.invoice_line_ids.write(
-                {"account_analytic_id": import_config["account_analytic"].id}
+                {"analytic_account_id": import_config["account_analytic"].id}
             )
         self.post_create_or_update(parsed_inv, invoice)
         logger.info(


### PR DESCRIPTION
This PR include 2 fixes:
- bad analytic account field name
- bad default value for partner_id on account.invoice.import.config when the partner is created via the invoice import wizard.