### PR TITLE
[FIX] edi: output might be not UTF-8 encodable, like PDFs

### DIFF
--- a/edi/models/edi_backend.py
+++ b/edi/models/edi_backend.py
@@ -178,7 +178,12 @@ class EDIBackend(models.Model):
                     "edi_exchange_state": "output_pending",
                 }
             )
-        output = tools.pycompat.to_text(output)
+        try:
+            # TODO: Remove this on 15.0, we will keep it in order to not break current
+            # installations
+            output = tools.pycompat.to_text(output)
+        except UnicodeDecodeError:
+            pass
         if output:
             try:
                 self._validate_data(exchange_record, output)


### PR DESCRIPTION
The error was raised if a PDF report was returned

@simahawk 