### PR TITLE
[FW][14.0][IMP] Add sale order ubl parse latest delivery

### DIFF
--- a/base_ubl/models/ubl.py
+++ b/base_ubl/models/ubl.py
@@ -724,6 +724,18 @@ class BaseUbl(models.AbstractModel):
                 )
         return partner_dict
 
+    @api.model
+    def ubl_parse_delivery_details(self, delivery_node, ns):
+        delivery_dict = {}
+        latest_date = delivery_node.xpath("cbc:LatestDeliveryDate", namespaces=ns)
+        latest_time = delivery_node.xpath("cbc:LatestDeliveryTime", namespaces=ns)
+        if latest_date:
+            latest_delivery = latest_date[0].text
+            if latest_time:
+                latest_delivery += " " + latest_time[0].text[:-3]
+            delivery_dict["commitment_date"] = latest_delivery
+        return delivery_dict
+
     def ubl_parse_incoterm(self, delivery_term_node, ns):
         incoterm_xpath = delivery_term_node.xpath("cbc:ID", namespaces=ns)
         if incoterm_xpath:

--- a/sale_order_import/wizard/sale_order_import.py
+++ b/sale_order_import/wizard/sale_order_import.py
@@ -227,6 +227,10 @@ class SaleOrderImport(models.TransientModel):
                 parsed_order["ship_to"], partner, parsed_order["chatter_msg"]
             )
             so_vals["partner_shipping_id"] = shipping_partner.id
+
+        if parsed_order.get("delivery_detail"):
+            so_vals.update(parsed_order.get("delivery_detail"))
+
         if parsed_order.get("invoice_to"):
             invoicing_partner = bdio._match_partner(
                 parsed_order["partner"], parsed_order["chatter_msg"], partner_type=""


### PR DESCRIPTION
This is the forward update from PR https://github.com/OCA/edi/pull/349.

Parse the latest delivery date and time from the delivery node of an UBL
sales order.
And assign the value to the `commitment_date` of the sales order.