### PR TITLE
[13.0][IMP] edi_storage: add listener to move files to done/error dirs

### DIFF
--- a/edi/models/edi_backend.py
+++ b/edi/models/edi_backend.py
@@ -400,7 +400,6 @@ class EDIBackend(models.Model):
             return False
         state = exchange_record.edi_exchange_state
         error = False
-        message = None
         try:
             self._exchange_process(exchange_record)
         except self._swallable_exceptions() as err:
@@ -408,10 +407,8 @@ class EDIBackend(models.Model):
                 raise
             error = repr(err)
             state = "input_processed_error"
-            message = exchange_record._exchange_status_message("process_ko")
             res = False
         else:
-            message = exchange_record._exchange_status_message("process_ok")
             error = None
             state = "input_processed"
             res = True
@@ -425,8 +422,10 @@ class EDIBackend(models.Model):
                     "exchanged_on": fields.Datetime.now(),
                 }
             )
-            if message:
-                exchange_record._notify_related_record(message)
+            if state == "input_processed_error":
+                exchange_record._notify_error("process_ko")
+            elif state == "input_processed":
+                exchange_record._notify_done()
         return res
 
     def _exchange_process(self, exchange_record):

--- a/edi_storage/components/__init__.py
+++ b/edi_storage/components/__init__.py
@@ -2,3 +2,4 @@ from . import base
 from . import check
 from . import send
 from . import receive
+from . import listener

--- a/edi_storage/components/listener.py
+++ b/edi_storage/components/listener.py
@@ -1,0 +1,60 @@
+# Copyright 2021 ForgeFlow S.L. (https://www.forgeflow.com)
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+import functools
+from pathlib import PurePath
+
+from odoo.addons.component.core import Component
+
+
+class EdiStorageListener(Component):
+    _name = "edi.storage.component.listener"
+    _inherit = "base.event.listener"
+
+    def _move_file(self, storage, from_dir_str, to_dir_str, filename):
+        from_dir = PurePath(from_dir_str)
+        to_dir = PurePath(to_dir_str)
+        if filename not in storage.list_files(from_dir):
+            # The file might have been moved after a previous error.
+            return False
+        self._add_after_commit_hook(
+            storage._move_files, [(from_dir / filename).as_posix()], to_dir.as_posix()
+        )
+        return True
+
+    def _add_after_commit_hook(self, move_func, sftp_filepath, sftp_destination_path):
+        """Add hook after commit to move the file when transaction is over.
+        """
+        self.env.cr.after(
+            "commit",
+            functools.partial(move_func, sftp_filepath, sftp_destination_path),
+        )
+
+    def on_edi_exchange_done(self, record):
+        storage = record.backend_id.storage_id
+        res = False
+        if record.direction == "input" and storage:
+            file = record.exchange_filename
+            pending_dir = record.backend_id.input_dir_pending
+            done_dir = record.backend_id.input_dir_done
+            error_dir = record.backend_id.input_dir_error
+            if not done_dir:
+                return res
+            res = self._move_file(storage, pending_dir, done_dir, file)
+            if not res:
+                # If a file previously failed it should have been previously
+                # moved to the error dir, therefore it is not present in the
+                # pending dir and we need to retry from error dir.
+                res = self._move_file(storage, error_dir, done_dir, file)
+        return res
+
+    def on_edi_exchange_error(self, record):
+        storage = record.backend_id.storage_id
+        res = False
+        if record.direction == "input" and storage:
+            file = record.exchange_filename
+            pending_dir = record.backend_id.input_dir_pending
+            error_dir = record.backend_id.input_dir_error
+            if error_dir:
+                res = self._move_file(storage, pending_dir, error_dir, file)
+        return res

--- a/edi_storage/tests/__init__.py
+++ b/edi_storage/tests/__init__.py
@@ -1,2 +1,3 @@
 from . import test_edi_backend_storage
 from . import test_components_base
+from . import test_edi_storage_listener

--- a/edi_storage/tests/test_edi_storage_listener.py
+++ b/edi_storage/tests/test_edi_storage_listener.py
@@ -1,0 +1,68 @@
+# Copyright 2021 ForgeFlow S.L. (https://www.forgeflow.com)
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+import base64
+
+import mock
+
+from odoo.addons.edi.tests.common import EDIBackendCommonComponentRegistryTestCase
+from odoo.addons.edi.tests.fake_components import FakeInputProcess
+
+LISTENER_MOCK_PATH = "odoo.addons.edi_storage.components.listener.EdiStorageListener"
+
+
+class EDIBackendTestCase(EDIBackendCommonComponentRegistryTestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls._load_module_components(cls, "edi_storage")
+        cls._build_components(
+            cls, FakeInputProcess,
+        )
+        vals = {
+            "model": cls.partner._name,
+            "res_id": cls.partner.id,
+            "exchange_file": base64.b64encode(b"1234"),
+        }
+        cls.record = cls.backend.create_record("test_csv_input", vals)
+        cls.fake_move_args = None
+
+    @classmethod
+    def _get_backend(cls):
+        return cls.env.ref("edi_storage.demo_edi_backend_storage")
+
+    def setUp(self):
+        super().setUp()
+        FakeInputProcess.reset_faked()
+
+    def _move_file_mocked(self, *args):
+        self.fake_move_args = [*args]
+        if not all([*args]):
+            return False
+        return True
+
+    def _mock_listener_move_file(self):
+        return mock.patch(LISTENER_MOCK_PATH + "._move_file", self._move_file_mocked)
+
+    def test_01_process_record_success(self):
+        with self._mock_listener_move_file():
+            self.record.write({"edi_exchange_state": "input_received"})
+            self.record.action_exchange_process()
+            storage, from_dir_str, to_dir_str, filename = self.fake_move_args
+            self.assertEqual(storage, self.backend.storage_id)
+            self.assertEqual(from_dir_str, self.backend.input_dir_pending)
+            self.assertEqual(to_dir_str, self.backend.input_dir_done)
+            self.assertEqual(filename, self.record.exchange_filename)
+
+    def test_02_process_record_with_error(self):
+        with self._mock_listener_move_file():
+            self.record.write({"edi_exchange_state": "input_received"})
+            self.record._set_file_content("TEST %d" % self.record.id)
+            self.record.with_context(
+                test_break_process="OOPS! Something went wrong :("
+            ).action_exchange_process()
+            storage, from_dir_str, to_dir_str, filename = self.fake_move_args
+            self.assertEqual(storage, self.backend.storage_id)
+            self.assertEqual(from_dir_str, self.backend.input_dir_pending)
+            self.assertEqual(to_dir_str, self.backend.input_dir_error)
+            self.assertEqual(filename, self.record.exchange_filename)


### PR DESCRIPTION
When a file is processed the listener will move it to the done directory or the error directory based on the result of processing the file.

cc @simahawk 

@ForgeFlow