### PR TITLE
[13.0][FIX] account_invoice_ubl: do not force report rendering

### DIFF
--- a/account_invoice_ubl/models/ir_actions_report.py
+++ b/account_invoice_ubl/models/ir_actions_report.py
@@ -28,16 +28,6 @@ class IrActionsReport(models.Model):
                     pdf_content = invoice.embed_ubl_xml_in_pdf(pdf_content)
         return pdf_content
 
-    def render_qweb_pdf(self, res_ids=None, data=None):
-        """This is only necessary when tests are enabled.
-        It forces the creation of pdf instead of html."""
-        if isinstance(res_ids, int):
-            res_ids = [res_ids]
-        if len(res_ids or []) == 1 and not self.env.context.get("no_embedded_ubl_xml"):
-            if len(self) == 1 and self.is_ubl_xml_to_embed_in_invoice():
-                self = self.with_context(force_report_rendering=True)
-        return super().render_qweb_pdf(res_ids, data)
-
     def is_ubl_xml_to_embed_in_invoice(self):
         return (
             self.model == "account.move"


### PR DESCRIPTION
There is no need for this because there exists a conext in
standard (`force_report_rendering`) for that purpose and that
is correctly set in the tests of this module.

Before this change it was forced for any of pdf report
related to this module (basically invoice reports). This
could make the tests of other addons installed in the database
and not depending on this module fail.

@ForgeFlow