### PR TITLE
[FiX][12.0] Need to pin invoice2data to 0.3.5

### DIFF
--- a/account_invoice_import_invoice2data/__manifest__.py
+++ b/account_invoice_import_invoice2data/__manifest__.py
@@ -11,7 +11,7 @@
     'author': 'Akretion,Odoo Community Association (OCA)',
     'website': 'https://github.com/OCA/edi',
     'depends': ['account_invoice_import'],
-    'external_dependencies': {'python': ['invoice2data']},
+    'external_dependencies': {'python': ['invoice2data==0.3.5']},
     'data': ['wizard/account_invoice_import_view.xml'],
     'demo': ['demo/demo_data.xml'],
     'installable': True,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 PyPDF2
 phonenumbers
-invoice2data
+invoice2data==0.3.5
 factur-x

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 PyPDF2
 phonenumbers
-git+https://github.com/invoice-x/invoice2data@v0.3.5
+invoice2data==0.3.5
 factur-x

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 PyPDF2
 phonenumbers
-invoice2data==0.3.5
+git+https://github.com/invoice-x/invoice2data@v0.3.5
 factur-x


### PR DESCRIPTION
Newer versions use f-formats which fails on python 3.5