### PR TITLE
[13.0][IMP] account_invoice_ubl & base_ubl: add hooks

### DIFF
--- a/account_invoice_ubl/models/account_move.py
+++ b/account_invoice_ubl/models/account_move.py
@@ -27,22 +27,30 @@ class AccountMove(models.Model):
         issue_date = etree.SubElement(parent_node, ns["cbc"] + "IssueDate")
         issue_date.text = self.invoice_date.strftime("%Y-%m-%d")
         type_code = etree.SubElement(parent_node, ns["cbc"] + "InvoiceTypeCode")
-        if self.type == "out_invoice":
-            type_code.text = "380"
-        elif self.type == "out_refund":
-            type_code.text = "381"
+        type_code.text = self._ubl_get_invoice_type_code()
         if self.narration:
             note = etree.SubElement(parent_node, ns["cbc"] + "Note")
             note.text = self.narration
         doc_currency = etree.SubElement(parent_node, ns["cbc"] + "DocumentCurrencyCode")
         doc_currency.text = self.currency_id.name
 
+    def _ubl_get_invoice_type_code(self):
+        if self.type == "out_invoice":
+            return "380"
+        elif self.type == "out_refund":
+            return "381"
+
+    def _ubl_get_order_reference(self):
+        """This method is designed to be inherited"""
+        return self.invoice_origin
+
     def _ubl_add_order_reference(self, parent_node, ns, version="2.1"):
         self.ensure_one()
-        if self.name:
+        sale_order_ref = self._ubl_get_order_reference()
+        if sale_order_ref:
             order_ref = etree.SubElement(parent_node, ns["cac"] + "OrderReference")
             order_ref_id = etree.SubElement(order_ref, ns["cbc"] + "ID")
-            order_ref_id.text = self.name
+            order_ref_id.text = sale_order_ref
 
     def _ubl_get_contract_document_reference_dict(self):
         """Result: dict with key = Doc Type Code, value = ID"""

--- a/base_ubl/models/ubl.py
+++ b/base_ubl/models/ubl.py
@@ -229,6 +229,9 @@ class BaseUbl(models.AbstractModel):
                 version=version,
             )
 
+    def _ubl_get_customer_assigned_id(self, partner):
+        return partner.commercial_partner_id.ref
+
     @api.model
     def _ubl_add_supplier_party(
         self, partner, company, node_name, parent_node, ns, version="2.1"
@@ -260,7 +263,7 @@ class BaseUbl(models.AbstractModel):
             supplier_ref = etree.SubElement(
                 supplier_party_root, ns["cbc"] + "CustomerAssignedAccountID"
             )
-            supplier_ref.text = partner.commercial_partner_id.ref
+            supplier_ref.text = self._ubl_get_customer_assigned_id(partner)
         self._ubl_add_party(
             partner, company, "Party", supplier_party_root, ns, version=version
         )
@@ -346,6 +349,12 @@ class BaseUbl(models.AbstractModel):
         """Inherit and overwrite if another custom product code is required"""
         return product.default_code
 
+    def _ubl_get_customer_product_code(self, product):
+        """Inherit and overwrite to return the customer product sku either from
+        product, invoice_line or customer (product.customer_sku,
+        invoice_line.customer_sku, customer.product_sku)"""
+        return ""
+
     @api.model
     def _ubl_add_item(
         self,
@@ -383,6 +392,16 @@ class BaseUbl(models.AbstractModel):
         description.text = name
         name_node = etree.SubElement(item, ns["cbc"] + "Name")
         name_node.text = product_name or name.split("\n")[0]
+
+        customer_code = self._ubl_get_customer_product_code(product)
+        if customer_code:
+            buyer_identification = etree.SubElement(
+                item, ns["cac"] + "BuyersItemIdentification"
+            )
+            buyer_identification_id = etree.SubElement(
+                buyer_identification, ns["cbc"] + "ID"
+            )
+            buyer_identification_id.text = customer_code
         if seller_code:
             seller_identification = etree.SubElement(
                 item, ns["cac"] + "SellersItemIdentification"


### PR DESCRIPTION
- Added the possibility to add a cac:BuyersItemIdentification ubl field if a customer product code exists.
- Added __ubl_get_customer_product_code_ method to be inherited in case a custom customer product code is used in the cac:BuyersItemIdentification ubl field.
- Added __ubl_get_invoice_type_code_ method to be inherited in case a custom invoice code is used instead of the 380/381 default ones.
- Added __ubl_get_customer_assigned_id_ method to be inherited in case a custom customer reference is used in the cbc:CustomerAssignedAccountID ubl field.
- Added __ubl_get_order_reference_ method to be inherited to fill the cbc:ID of the cac:OrderReference ubl field.