### PR TITLE
[13.0][IMP] base_ubl: add customer as an argument in _ubl_add_item method

### DIFF
--- a/base_ubl/models/ubl.py
+++ b/base_ubl/models/ubl.py
@@ -197,6 +197,9 @@ class BaseUbl(models.AbstractModel):
             )
         self._ubl_add_contact(partner, party, ns, version=version)
 
+    def _ubl_get_customer_assigned_id(self, partner):
+        return partner.commercial_partner_id.ref
+
     @api.model
     def _ubl_add_customer_party(
         self, partner, company, node_name, parent_node, ns, version="2.1"
@@ -210,11 +213,12 @@ class BaseUbl(models.AbstractModel):
             else:
                 partner = company.partner_id
         customer_party_root = etree.SubElement(parent_node, ns["cac"] + node_name)
-        if not company and partner.commercial_partner_id.ref:
+        partner_ref = self._ubl_get_customer_assigned_id(partner)
+        if partner_ref:
             customer_ref = etree.SubElement(
                 customer_party_root, ns["cbc"] + "SupplierAssignedAccountID"
             )
-            customer_ref.text = partner.commercial_partner_id.ref
+            customer_ref.text = partner_ref
         self._ubl_add_party(
             partner, company, "Party", customer_party_root, ns, version=version
         )
@@ -228,9 +232,6 @@ class BaseUbl(models.AbstractModel):
                 node_name="AccountingContact",
                 version=version,
             )
-
-    def _ubl_get_customer_assigned_id(self, partner):
-        return partner.commercial_partner_id.ref
 
     @api.model
     def _ubl_add_supplier_party(
@@ -259,11 +260,12 @@ class BaseUbl(models.AbstractModel):
             else:
                 partner = company.partner_id
         supplier_party_root = etree.SubElement(parent_node, ns["cac"] + node_name)
-        if not company and partner.commercial_partner_id.ref:
+        partner_ref = self._ubl_get_customer_assigned_id(partner)
+        if partner_ref:
             supplier_ref = etree.SubElement(
                 supplier_party_root, ns["cbc"] + "CustomerAssignedAccountID"
             )
-            supplier_ref.text = self._ubl_get_customer_assigned_id(partner)
+            supplier_ref.text = partner_ref
         self._ubl_add_party(
             partner, company, "Party", supplier_party_root, ns, version=version
         )
@@ -349,7 +351,7 @@ class BaseUbl(models.AbstractModel):
         """Inherit and overwrite if another custom product code is required"""
         return product.default_code
 
-    def _ubl_get_customer_product_code(self, product):
+    def _ubl_get_customer_product_code(self, product, customer):
         """Inherit and overwrite to return the customer product sku either from
         product, invoice_line or customer (product.customer_sku,
         invoice_line.customer_sku, customer.product_sku)"""
@@ -364,6 +366,7 @@ class BaseUbl(models.AbstractModel):
         ns,
         type_="purchase",
         seller=False,
+        customer=False,
         version="2.1",
     ):
         """Beware that product may be False (in particular on invoices)"""
@@ -393,7 +396,7 @@ class BaseUbl(models.AbstractModel):
         name_node = etree.SubElement(item, ns["cbc"] + "Name")
         name_node.text = product_name or name.split("\n")[0]
 
-        customer_code = self._ubl_get_customer_product_code(product)
+        customer_code = self._ubl_get_customer_product_code(product, customer)
         if customer_code:
             buyer_identification = etree.SubElement(
                 item, ns["cac"] + "BuyersItemIdentification"


### PR DESCRIPTION
- Add _customer_ as an argument in the __ubl_add_item_ method the same way as the seller, as default set to false
- Add also _customer_ as an argument in the __ubl_get_customer_product_code_ so the product code can be taken either from the customer or from the product
- Fixed: the current version of the _ubl_add_supplier_party and _ubl_add_customer_party was not allowing to add the cbc:CustomerAssignedID and the cbc:SupplierAssignedID respectively, if the partner for which we want to build the party block was our company.The if not company condition has been removed, and a call to the _ubl_get_customer_assigned_id() method is first added, so if it does not return False, the UBL field is added.