### PR TITLE
[13.0][FIX] edi_storage: remove duplicate backend_type_id field in edi backend form

### DIFF
--- a/edi_storage/views/edi_backend_views.xml
+++ b/edi_storage/views/edi_backend_views.xml
@@ -6,7 +6,6 @@
         <field name="arch" type="xml">
             <group name="config" position="after">
                 <group name="storage_config">
-                    <field name="backend_type_id" />
                     <field name="storage_id" />
                     <field name="input_dir_pending" />
                     <field name="input_dir_done" />


### PR DESCRIPTION
The field backend_type_id is already added in the base edi_backend_view_form inside the config group, so adding it here duplicates it in the view.