### PR TITLE
[14.0][FIX] edi_storage_oca: remove duplicate backend_type_id field in edi backend form

### DIFF
--- a/edi_storage_oca/views/edi_backend_views.xml
+++ b/edi_storage_oca/views/edi_backend_views.xml
@@ -6,7 +6,6 @@
         <field name="arch" type="xml">
             <group name="config" position="after">
                 <group name="storage_config">
-                    <field name="backend_type_id" />
                     <field name="storage_id" />
                     <field name="input_dir_pending" />
                     <field name="input_dir_done" />


### PR DESCRIPTION
Forwardport of https://github.com/OCA/edi/pull/426. The field is already added in the base view https://github.com/OCA/edi/blob/14.0/edi_oca/views/edi_backend_views.xml#L23