### PR TITLE
[13.0][IMP] base_ubl: hook to add the AdditionalAccountID ubl field

### DIFF
--- a/base_ubl/models/ubl.py
+++ b/base_ubl/models/ubl.py
@@ -232,6 +232,7 @@ class BaseUbl(models.AbstractModel):
                 node_name="AccountingContact",
                 version=version,
             )
+        return customer_party_root
 
     @api.model
     def _ubl_add_supplier_party(
@@ -269,6 +270,7 @@ class BaseUbl(models.AbstractModel):
         self._ubl_add_party(
             partner, company, "Party", supplier_party_root, ns, version=version
         )
+        return supplier_party_root
 
     @api.model
     def _ubl_add_delivery(self, delivery_partner, parent_node, ns, version="2.1"):


### PR DESCRIPTION
Added a _ubl_get_additional_reference method to be able to add the AdditionalAccountID ubl field in the _ubl_add_supplier_party