### PR TITLE
[FIX] Remove partner_bank_id after play_onchanges

### DIFF
--- a/account_invoice_import/wizard/account_invoice_import.py
+++ b/account_invoice_import/wizard/account_invoice_import.py
@@ -219,6 +219,8 @@ class AccountInvoiceImport(models.TransientModel):
                 create_if_not_found=company.invoice_import_create_bank_account)
             if partner_bank:
                 vals['partner_bank_id'] = partner_bank.id
+            else:
+                vals['partner_bank_id'] = False
         config = import_config  # just to make variable name shorter
         if not config:
             if not partner.invoice_import_ids:


### PR DESCRIPTION
This is about having a supplier with an old bank account and not activating the option "Create bank when not found"

Selecting the old bank is not a good idea as it gives the bad impression nothing changed on Partner side. And could lead on paying on an obsolete bank account.

Thus it's probably better to let the field empty and let the user decide on the invoice.


Suppose we have a case:
- no Bank account found on Invoice import
- boolean field https://github.com/OCA/edi/blob/7b4a97dce95a39fe07061f60103eee6982356f93/account_invoice_import/models/company.py#L22 on Settings isn't selected.
So, it's expected here https://github.com/OCA/edi/blob/7b4a97dce95a39fe07061f60103eee6982356f93/account_invoice_import/wizard/account_invoice_import.py#L220 no Bank account should be used to prepare invoice values.
But, values are already updated with play_onchanges https://github.com/OCA/edi/blob/7b4a97dce95a39fe07061f60103eee6982356f93/account_invoice_import/wizard/account_invoice_import.py#L208
The main goal of this fix is to have Bank Account field empty on Import Vendor bill action. 

EDIT @yvaucher some context