### PR TITLE
[14.0][FIX] edi_storage: incorrect call to output checker in receive component

### DIFF
--- a/edi_storage_oca/components/receive.py
+++ b/edi_storage_oca/components/receive.py
@@ -14,12 +14,6 @@ class EDIStorageReceiveComponent(Component):
     _usage = "storage.receive"
 
     def receive(self):
-        checker = self.component(usage="storage.check")
-        result = checker.check()
-        if not result:
-            # all good here
-            return True
-
         direction = self.exchange_record.direction
         filename = self.exchange_record.exchange_filename
         path = self._remote_file_path(direction, "pending", filename)


### PR DESCRIPTION
Checker is only relevant for output direction.

Forward port of https://github.com/OCA/edi/pull/439.

@ForgeFlow