### PR TITLE
[IMP] edi: Add buttons for not automatically managed and EDI errors

### DIFF
--- a/edi/models/edi_backend.py
+++ b/edi/models/edi_backend.py
@@ -21,9 +21,10 @@ class EDIBackend(models.Model):
 
     Backends can be organized with types.
 
-    The backend should be responsible for generating export records.
+    The backend should be responsible for managing records.
     For each record it can generate or parse their values
-    depending on their direction (incoming, outgoing).
+    depending on their direction (incoming, outgoing)
+    and send or receive them automatically depending on their state.
     """
 
     _name = "edi.backend"

--- a/edi/models/edi_backend.py
+++ b/edi/models/edi_backend.py
@@ -17,7 +17,12 @@ _logger = logging.getLogger(__name__)
 
 
 def _get_exception_msg(exc):
-    return exc.name if hasattr(exc, "name") else repr(exc)
+    if hasattr(exc, "name"):
+        # Odoo exc
+        return exc.name
+    elif hasattr(exc, "args") and isinstance(exc.args[0], str):
+        return exc.args[0]
+    return repr(exc)
 
 
 class EDIBackend(models.Model):

--- a/edi/models/edi_backend.py
+++ b/edi/models/edi_backend.py
@@ -143,11 +143,11 @@ class EDIBackend(models.Model):
 
     def _create_record_prepare_values(self, type_code, values):
         res = values.copy()  # do not pollute original dict
-        export_type = self.env["edi.exchange.type"].search(
+        exchange_type = self.env["edi.exchange.type"].search(
             self._get_exchange_type_domain(type_code), limit=1
         )
-        export_type.ensure_one()
-        res["type_id"] = export_type.id
+        exchange_type.ensure_one()
+        res["type_id"] = exchange_type.id
         res["backend_id"] = self.id
         return res
 

--- a/edi/models/edi_backend.py
+++ b/edi/models/edi_backend.py
@@ -123,8 +123,8 @@ class EDIBackend(models.Model):
         return candidates
 
     def _get_component_conf_for_record(self, exchange_record, key):
-        adv_settings = exchange_record.type_id.advanced_settings
-        return adv_settings.get("components", {}).get(key, {})
+        settings = exchange_record.type_id.get_settings()
+        return settings.get("components", {}).get(key, {})
 
     @property
     def exchange_record_model(self):

--- a/edi/models/edi_backend.py
+++ b/edi/models/edi_backend.py
@@ -16,6 +16,10 @@ from ..exceptions import EDIValidationError
 _logger = logging.getLogger(__name__)
 
 
+def _get_exception_msg(exc):
+    return exc.name if hasattr(exc, "name") else repr(exc)
+
+
 class EDIBackend(models.Model):
     """Generic backend to control EDI exchanges.
 
@@ -199,7 +203,7 @@ class EDIBackend(models.Model):
             try:
                 self._validate_data(exchange_record, output)
             except EDIValidationError as err:
-                error = repr(err)
+                error = _get_exception_msg(err)
                 state = "validate_error"
                 message = exchange_record._exchange_status_message("validate_ko")
                 exchange_record.update(
@@ -264,7 +268,7 @@ class EDIBackend(models.Model):
         except self._swallable_exceptions() as err:
             if self.env.context.get("_edi_send_break_on_error"):
                 raise
-            error = repr(err)
+            error = _get_exception_msg(err)
             state = "output_error_on_send"
             message = exchange_record._exchange_status_message("send_ko")
             res = False
@@ -416,7 +420,7 @@ class EDIBackend(models.Model):
         except self._swallable_exceptions() as err:
             if self.env.context.get("_edi_receive_break_on_error"):
                 raise
-            error = repr(err)
+            error = _get_exception_msg(err)
             state = "input_processed_error"
             res = False
         else:
@@ -464,14 +468,14 @@ class EDIBackend(models.Model):
                 exchange_record._set_file_content(content)
                 self._validate_data(exchange_record)
         except EDIValidationError as err:
-            error = repr(err)
+            error = _get_exception_msg(err)
             state = "validate_error"
             message = exchange_record._exchange_status_message("validate_ko")
             res = False
         except self._swallable_exceptions() as err:
             if self.env.context.get("_edi_receive_break_on_error"):
                 raise
-            error = repr(err)
+            error = _get_exception_msg(err)
             state = "input_receive_error"
             message = exchange_record._exchange_status_message("receive_ko")
             res = False

--- a/edi/models/edi_backend.py
+++ b/edi/models/edi_backend.py
@@ -159,6 +159,16 @@ class EDIBackend(models.Model):
             ("backend_id", "=", self.id),
         ]
 
+    def _get_job_delay_params(self, exchange_record):
+        params = {}
+        channel = exchange_record.type_id.job_channel_id
+        if channel:
+            params["channel"] = channel.complete_name
+        return params
+
+    def _delay_action(self, rec):
+        return self.with_delay(**self._get_job_delay_params(rec))
+
     def exchange_generate(self, exchange_record, store=True, force=False, **kw):
         """Generate output content for given exchange record.
 
@@ -329,7 +339,7 @@ class EDIBackend(models.Model):
             len(new_records),
         )
         for rec in new_records:
-            self.with_delay().exchange_generate(rec)
+            self._delay_action(rec).exchange_generate(rec)
 
         if skip_send:
             return
@@ -342,7 +352,7 @@ class EDIBackend(models.Model):
         )
         for rec in pending_records:
             if rec.edi_exchange_state == "output_pending":
-                self.with_delay().exchange_send(rec)
+                self._delay_action(rec).exchange_send(rec)
             else:
                 # TODO: run in job as well?
                 self._exchange_output_check_state(rec)
@@ -523,7 +533,7 @@ class EDIBackend(models.Model):
             len(pending_records),
         )
         for rec in pending_records:
-            self.with_delay().exchange_receive(rec)
+            self._delay_action(rec).exchange_receive(rec)
 
         pending_process_records = self.exchange_record_model.search(
             self._input_pending_process_records_domain()
@@ -533,7 +543,7 @@ class EDIBackend(models.Model):
             len(pending_process_records),
         )
         for rec in pending_process_records:
-            self.with_delay().exchange_process(rec)
+            self._delay_action(rec).exchange_process(rec)
 
         # TODO: test it!
         self._exchange_check_ack_needed(pending_process_records)
@@ -561,7 +571,7 @@ class EDIBackend(models.Model):
             len(ack_pending_records),
         )
         for rec in ack_pending_records:
-            self.with_delay().exchange_create_ack_record(rec)
+            self._delay_action(rec).exchange_create_ack_record(rec)
 
     def exchange_create_ack_record(self, exchange_record):
         ack_type = exchange_record.type_id.ack_type_id

--- a/edi/models/edi_exchange_record.py
+++ b/edi/models/edi_exchange_record.py
@@ -168,12 +168,14 @@ class EDIExchangeRecord(models.Model):
             output_string = bytes(output_string, encoding)
         self[field_name] = base64.b64encode(output_string)
 
-    def _get_file_content(self, field_name="exchange_file"):
-        """Handy method to no have to convert b64 back and forth."""
+    def _get_file_content(self, field_name="exchange_file", binary=True):
+        """Handy method to not have to convert b64 back and forth."""
         self.ensure_one()
         if not self[field_name]:
             return ""
-        return base64.b64decode(self[field_name]).decode()
+        if binary:
+            return base64.b64decode(self[field_name]).decode()
+        return self[field_name]
 
     def name_get(self):
         result = []

--- a/edi/models/edi_exchange_record.py
+++ b/edi/models/edi_exchange_record.py
@@ -91,6 +91,10 @@ class EDIExchangeRecord(models.Model):
     ack_received_on = fields.Datetime(
         string="ACK received on", related="ack_exchange_id.exchanged_on"
     )
+    retryable = fields.Boolean(
+        compute="_compute_retryable",
+        help="The record state can be rolled back manually in case of failure.",
+    )
 
     _sql_constraints = [
         ("identifier_uniq", "unique(identifier)", "The identifier must be unique."),
@@ -150,6 +154,18 @@ class EDIExchangeRecord(models.Model):
 
     def needs_ack(self):
         return self.type_id.ack_type_id and not self.ack_exchange_id
+
+    _rollback_state_mapping = {
+        # From: to
+        "output_error_on_send": "output_pending",
+        "output_sent_and_error": "output_pending",
+        "input_receive_error": "input_pending",
+        "input_processed_error": "input_received",
+    }
+
+    def _compute_retryable(self):
+        for rec in self:
+            rec.retryable = rec.edi_exchange_state in self._rollback_state_mapping
 
     @property
     def record(self):
@@ -239,6 +255,23 @@ class EDIExchangeRecord(models.Model):
     def action_exchange_process(self):
         self.ensure_one()
         return self.backend_id.exchange_process(self)
+
+    def action_retry(self):
+        for rec in self:
+            rec._retry_exchange_action()
+
+    def _retry_exchange_action(self):
+        """Move back to precedent state to retry exchange action if failed."""
+        if not self.retryable:
+            return False
+        new_state = self._rollback_state_mapping[self.edi_exchange_state]
+        fname = "edi_exchange_state"
+        self[fname] = new_state
+        display_state = self._fields[fname].convert_to_export(self[fname], self)
+        self.message_post(
+            body=_("Action retry: state moved back to '%s'") % display_state
+        )
+        return True
 
     def action_open_related_record(self):
         self.ensure_one()

--- a/edi/models/edi_exchange_record.py
+++ b/edi/models/edi_exchange_record.py
@@ -32,11 +32,7 @@ class EDIExchangeRecord(models.Model):
     backend_id = fields.Many2one(comodel_name="edi.backend", required=True)
     model = fields.Char(index=True, required=False, readonly=True)
     res_id = fields.Many2oneReference(
-        string="Record ID",
-        index=True,
-        required=False,
-        readonly=True,
-        model_field="model",
+        string="Record", index=True, required=False, readonly=True, model_field="model",
     )
     exchange_file = fields.Binary(attachment=True)
     exchange_filename = fields.Char(
@@ -186,11 +182,10 @@ class EDIExchangeRecord(models.Model):
     def name_get(self):
         result = []
         for rec in self:
-            dt = fields.Datetime.to_string(rec.exchanged_on) if rec.exchanged_on else ""
             rec_name = rec.identifier
             if rec.res_id and rec.model:
                 rec_name = rec.record.display_name
-            name = "[{}] {} {}".format(rec.type_id.name, rec_name, dt)
+            name = "[{}] {}".format(rec.type_id.name, rec_name)
             result.append((rec.id, name))
         return result
 

--- a/edi/models/edi_exchange_record.py
+++ b/edi/models/edi_exchange_record.py
@@ -95,6 +95,9 @@ class EDIExchangeRecord(models.Model):
         compute="_compute_retryable",
         help="The record state can be rolled back manually in case of failure.",
     )
+    exchange_file_auto_generate = fields.Boolean(
+        related="type_id.exchange_file_auto_generate"
+    )
 
     _sql_constraints = [
         ("identifier_uniq", "unique(identifier)", "The identifier must be unique."),
@@ -256,6 +259,14 @@ class EDIExchangeRecord(models.Model):
         self.ensure_one()
         return self.backend_id.exchange_process(self)
 
+    def action_exchange_receive(self):
+        self.ensure_one()
+        return self.backend_id.exchange_receive(self)
+
+    def action_exchange_generate(self):
+        self.ensure_one()
+        return self.backend_id.exchange_generate(self)
+
     def action_retry(self):
         for rec in self:
             rec._retry_exchange_action()
@@ -286,7 +297,7 @@ class EDIExchangeRecord(models.Model):
         self.ensure_one()
         if not self.related_exchange_ids:
             return {}
-        action = self.env.ref("edi_oca.act_open_edi_exchange_record_view").read()[0]
+        action = self.env.ref("edi.act_open_edi_exchange_record_view").read()[0]
         action["domain"] = [("id", "in", self.related_exchange_ids.ids)]
         return action
 

--- a/edi/models/edi_exchange_type.py
+++ b/edi/models/edi_exchange_type.py
@@ -116,6 +116,9 @@ class EDIExchangeType(models.Model):
     def _load_advanced_settings(self):
         return yaml.safe_load(self.advanced_settings_edit or "") or {}
 
+    def get_settings(self):
+        return self.advanced_settings
+
     @api.constrains("backend_id", "backend_type_id")
     def _check_backend(self):
         for rec in self:

--- a/edi/models/edi_exchange_type.py
+++ b/edi/models/edi_exchange_type.py
@@ -26,17 +26,15 @@ class EDIExchangeType(models.Model):
     _description = "EDI Exchange Type"
 
     backend_id = fields.Many2one(
-        string="EDI backend", comodel_name="edi.backend", ondelete="set null",
+        string="Backend", comodel_name="edi.backend", ondelete="set null",
     )
     backend_type_id = fields.Many2one(
-        string="EDI Backend type",
+        string="Backend type",
         comodel_name="edi.backend.type",
         required=True,
         ondelete="restrict",
     )
-    job_channel_id = fields.Many2one(
-        comodel_name="queue.job.channel",
-    )
+    job_channel_id = fields.Many2one(comodel_name="queue.job.channel",)
     name = fields.Char(required=True)
     code = fields.Char(required=True)
     direction = fields.Selection(

--- a/edi/models/edi_exchange_type.py
+++ b/edi/models/edi_exchange_type.py
@@ -34,6 +34,9 @@ class EDIExchangeType(models.Model):
         required=True,
         ondelete="restrict",
     )
+    job_channel_id = fields.Many2one(
+        comodel_name="queue.job.channel",
+    )
     name = fields.Char(required=True)
     code = fields.Char(required=True)
     direction = fields.Selection(

--- a/edi/tests/test_backend_base.py
+++ b/edi/tests/test_backend_base.py
@@ -4,6 +4,8 @@
 
 from freezegun import freeze_time
 
+from odoo.addons.queue_job.job import DelayableRecordset
+
 from .common import EDIBackendCommonTestCase
 
 
@@ -57,3 +59,26 @@ class EDIBackendTestCase(EDIBackendCommonTestCase):
         self.assertEqual(
             candidates, ["my.special.send", "output.send"],
         )
+
+    def test_delay_action_init(self):
+        vals = {
+            "model": self.partner._name,
+            "res_id": self.partner.id,
+        }
+        record = self.backend.create_record("test_csv_input", vals)
+        parent_channel = self.env["queue.job.channel"].create(
+            {
+                "name": "parent_test_chan",
+                "parent_id": self.env.ref("queue_job.channel_root").id,
+            }
+        )
+        channel = self.env["queue.job.channel"].create(
+            {"name": "test_chan", "parent_id": parent_channel.id}
+        )
+        self.exchange_type_in.job_channel_id = channel
+        # re-enable job delayed feature
+        backend = self.backend.with_context(test_queue_job_no_delay=None)
+        delayed = backend._delay_action(record)
+        self.assertTrue(isinstance(delayed, DelayableRecordset))
+        self.assertEqual(delayed.recordset, self.backend)
+        self.assertEqual(delayed.channel, "root.parent_test_chan.test_chan")

--- a/edi/tests/test_backend_output.py
+++ b/edi/tests/test_backend_output.py
@@ -64,7 +64,7 @@ class EDIBackendTestCase(EDIBackendCommonComponentRegistryTestCase):
             [
                 {
                     "edi_exchange_state": "output_error_on_send",
-                    "exchange_error": "ValueError('OOPS! Something went wrong :(',)",
+                    "exchange_error": "OOPS! Something went wrong :(",
                 }
             ],
         )

--- a/edi/tests/test_backend_process.py
+++ b/edi/tests/test_backend_process.py
@@ -57,7 +57,7 @@ class EDIBackendTestCase(EDIBackendCommonComponentRegistryTestCase):
             [
                 {
                     "edi_exchange_state": "input_processed_error",
-                    "exchange_error": "ValueError('OOPS! Something went wrong :(',)",
+                    "exchange_error": "OOPS! Something went wrong :(",
                 }
             ],
         )

--- a/edi/tests/test_backend_validate.py
+++ b/edi/tests/test_backend_validate.py
@@ -59,7 +59,12 @@ class EDIBackendTestCase(EDIBackendCommonComponentRegistryTestCase):
         self.assertTrue(FakeInputValidate.check_called_for(self.record_in))
         self.assertRecordValues(
             self.record_in,
-            [{"edi_exchange_state": "validate_error", "exchange_error": repr(exc)}],
+            [
+                {
+                    "edi_exchange_state": "validate_error",
+                    "exchange_error": "Data seems wrong!",
+                }
+            ],
         )
 
     def test_generate_validate_record(self):
@@ -79,5 +84,10 @@ class EDIBackendTestCase(EDIBackendCommonComponentRegistryTestCase):
         self.assertTrue(FakeOutputValidate.check_called_for(self.record_out))
         self.assertRecordValues(
             self.record_out,
-            [{"edi_exchange_state": "validate_error", "exchange_error": repr(exc)}],
+            [
+                {
+                    "edi_exchange_state": "validate_error",
+                    "exchange_error": "Data seems wrong!",
+                }
+            ],
         )

--- a/edi/views/edi_exchange_record_views.xml
+++ b/edi/views/edi_exchange_record_views.xml
@@ -27,12 +27,18 @@
                         name="action_open_related_record"
                         type="object"
                         string="Related record"
+                        attrs="{'invisible': [('res_id', '=', False)]}"
                     />
+                    <!-- FIXME: this `invisible` domain does not work -->
                     <button
                         name="action_open_related_exchanges"
                         type="object"
                         string="Related exchanges"
+                        attrs="{'invisible': [('related_exchange_ids', '=', False)]}"
                     />
+                    <!-- FIXME: colors are ignored...
+                    and can't find how they are supposed to work.
+                    Probably not supported at all. -->
                     <field
                         attrs="{'invisible': [('direction', '=', 'input')]}"
                         name="edi_exchange_state"
@@ -103,6 +109,7 @@
                             name="related_odoo_record"
                             string="Related record"
                             groups="base.group_no_one"
+                            attrs="{'invisible': [('res_id', '=', 0)]}"
                         >
                           <field name="res_id" />
                           <field name="model" />
@@ -116,7 +123,12 @@
                         >
                             <field name="exchange_error" />
                         </page>
-                        <page name="related_exchanges" string="Related exchanges">
+                        <!-- FIXME: this `invisible` domain does not work -->
+                        <page
+                            name="related_exchanges"
+                            string="Related exchanges"
+                            attrs="{'invisible': [('related_exchange_ids', '=', False), ('parent_id', '=', False)]}"
+                        >
                             <group name="rel_exchanges">
                               <field name="parent_id" />
                             </group>
@@ -133,6 +145,10 @@
                         </page>
                     </notebook>
                 </sheet>
+                <div class="oe_chatter">
+                    <field name="message_follower_ids" widget="mail_followers" />
+                    <field name="message_ids" widget="mail_thread" />
+                </div>
             </form>
         </field>
     </record>

--- a/edi/views/edi_exchange_record_views.xml
+++ b/edi/views/edi_exchange_record_views.xml
@@ -21,11 +21,45 @@
         <field name="model">edi.exchange.record</field>
         <field name="arch" type="xml">
             <form string="EDI Exchange Record">
+                <field name="direction" invisible="1" />
                 <header>
                     <button
                         name="action_open_related_record"
                         type="object"
                         string="Related record"
+                    />
+                    <button
+                        name="action_open_related_exchanges"
+                        type="object"
+                        string="Related exchanges"
+                    />
+                    <field
+                        attrs="{'invisible': [('direction', '=', 'input')]}"
+                        name="edi_exchange_state"
+                        widget="statusbar"
+                        statusbar_visible="new,validate_error,output_pending,output_error_on_send,output_sent,output_sent_and_processed,output_sent_and_error"
+                        statusbar_colors='{
+                          "validate_error": "red",
+                          "output_pending": "yellow",
+                          "output_error_on_send": "red",
+                          "output_sent": "green",
+                          "output_sent_and_processed": "green",
+                          "output_sent_and_error": "red",
+                        }'
+                    />
+                    <field
+                        attrs="{'invisible': [('direction', '=', 'output')]}"
+                        name="edi_exchange_state"
+                        widget="statusbar"
+                        statusbar_visible="new,validate_error,input_pending,input_received,input_receive_error,input_processed,input_processed_error"
+                        statusbar_colors='{
+                          "validate_error": "red",
+                          "input_pending": "yellow",
+                          "input_received": "green",
+                          "input_receive_error": "red",
+                          "input_processed": "green",
+                          "input_processed_error": "red"
+                        }'
                     />
                 </header>
                 <sheet>
@@ -35,34 +69,43 @@
                             <field name="name" />
                         </h1>
                         <h2>
-                            <label for="identifier" />
+                            <label for="identifier" class="oe_edit_only" />
                             <field name="identifier" />
                         </h2>
                         <h2>
-                            <label for="external_identifier" />
+                            <label for="external_identifier" class="oe_edit_only" />
                             <field name="external_identifier" />
                         </h2>
                     </div>
                     <group name="wrapper">
-                        <group name="main">
+                        <group name="config">
                             <field name="type_id" />
                             <field name="backend_id" />
+                        </group>
+                        <group name="status" string="Status">
                             <field name="exchanged_on" />
-                            <field name="edi_exchange_state" />
                             <field name="exchange_file" filename="exchange_filename" />
                             <field
                                 name="exchange_filename"
                                 attrs="{'invisible': [('exchange_file', '!=', False)]}"
                             />
-                            <field name="direction" invisible="1" />
                         </group>
-                        <!-- TODO: move to a page? -->
-                        <group name="related">
+                        <group
+                            name="ack"
+                            string="ACK"
+                            attrs="{'invisible': [('ack_expected', '!=', True)]}"
+                        >
+                            <field name="ack_expected" />
                             <field name="ack_exchange_id" />
                             <field name="ack_received_on" />
-                            <field name="parent_id" />
-                            <!-- TODO: add button to get to a list view in the header -->
-                            <field name="related_exchange_ids" />
+                        </group>
+                        <group
+                            name="related_odoo_record"
+                            string="Related record"
+                            groups="base.group_no_one"
+                        >
+                          <field name="res_id" />
+                          <field name="model" />
                         </group>
                     </group>
                     <notebook>
@@ -73,15 +116,20 @@
                         >
                             <field name="exchange_error" />
                         </page>
-                        <page
-                            name="config"
-                            string="Configuration"
-                            groups="base.group_no_one"
-                        >
-                            <group>
-                                <field name="res_id" />
-                                <field name="model" />
+                        <page name="related_exchanges" string="Related exchanges">
+                            <group name="rel_exchanges">
+                              <field name="parent_id" />
                             </group>
+                            <field name="related_exchange_ids" nolabel="1" colspan="4">
+                              <tree>
+                                <field name="name" />
+                                <field name="identifier" />
+                                <field name="type_id" />
+                                <field name="exchanged_on" />
+                                <field name="ack_received_on" />
+                                <field name="edi_exchange_state" />
+                              </tree>
+                            </field>
                         </page>
                     </notebook>
                 </sheet>

--- a/edi/views/edi_exchange_record_views.xml
+++ b/edi/views/edi_exchange_record_views.xml
@@ -22,6 +22,7 @@
         <field name="arch" type="xml">
             <form string="EDI Exchange Record">
                 <field name="direction" invisible="1" />
+                <field name="retryable" invisible="1" />
                 <header>
                     <button
                         name="action_open_related_record"
@@ -35,6 +36,12 @@
                         type="object"
                         string="Related exchanges"
                         attrs="{'invisible': [('related_exchange_ids', '=', False)]}"
+                    />
+                    <button
+                        name="action_retry"
+                        type="object"
+                        string="Retry"
+                        attrs="{'invisible': [('retryable', '=', False)]}"
                     />
                     <!-- FIXME: colors are ignored...
                     and can't find how they are supposed to work.

--- a/edi/views/edi_exchange_record_views.xml
+++ b/edi/views/edi_exchange_record_views.xml
@@ -23,59 +23,41 @@
             <form string="EDI Exchange Record">
                 <field name="direction" invisible="1" />
                 <field name="retryable" invisible="1" />
-                <header>
-                    <button
-                        name="action_open_related_record"
-                        type="object"
-                        string="Related record"
-                        attrs="{'invisible': [('res_id', '=', False)]}"
-                    />
-                    <!-- FIXME: this `invisible` domain does not work -->
-                    <button
-                        name="action_open_related_exchanges"
-                        type="object"
-                        string="Related exchanges"
-                        attrs="{'invisible': [('related_exchange_ids', '=', False)]}"
-                    />
-                    <button
-                        name="action_retry"
-                        type="object"
-                        string="Retry"
-                        attrs="{'invisible': [('retryable', '=', False)]}"
-                    />
-                    <!-- FIXME: colors are ignored...
-                    and can't find how they are supposed to work.
-                    Probably not supported at all. -->
-                    <field
-                        attrs="{'invisible': [('direction', '=', 'input')]}"
-                        name="edi_exchange_state"
-                        widget="statusbar"
-                        statusbar_visible="new,validate_error,output_pending,output_error_on_send,output_sent,output_sent_and_processed,output_sent_and_error"
-                        statusbar_colors='{
-                          "validate_error": "red",
-                          "output_pending": "yellow",
-                          "output_error_on_send": "red",
-                          "output_sent": "green",
-                          "output_sent_and_processed": "green",
-                          "output_sent_and_error": "red",
-                        }'
-                    />
-                    <field
-                        attrs="{'invisible': [('direction', '=', 'output')]}"
-                        name="edi_exchange_state"
-                        widget="statusbar"
-                        statusbar_visible="new,validate_error,input_pending,input_received,input_receive_error,input_processed,input_processed_error"
-                        statusbar_colors='{
-                          "validate_error": "red",
-                          "input_pending": "yellow",
-                          "input_received": "green",
-                          "input_receive_error": "red",
-                          "input_processed": "green",
-                          "input_processed_error": "red"
-                        }'
-                    />
-                </header>
+                <field name="exchange_file_auto_generate" invisible="1" />
+                <header />
                 <sheet>
+                    <div name="button_box" class="oe_button_box">
+                        <button
+                            name="action_exchange_generate"
+                            type="object"
+                            class="oe_stat_button"
+                            icon="fa-cubes"
+                            attrs="{'invisible': ['|', ('edi_exchange_state', '!=', 'new'), ('exchange_file_auto_generate', '=', True)]}"
+                            string="Generate"
+                        />
+                        <button
+                            name="action_retry"
+                            type="object"
+                            icon="fa-refresh"
+                            string="Retry"
+                            attrs="{'invisible': [('retryable', '=', False)]}"
+                        />
+                        <button
+                            name="action_open_related_record"
+                            type="object"
+                            icon="fa-share-square-o"
+                            string="Related record"
+                            attrs="{'invisible': [('res_id', '=', False)]}"
+                        />
+                        <!-- FIXME: this `invisible` domain does not work -->
+                        <button
+                            name="action_open_related_exchanges"
+                            type="object"
+                            icon="fa-sitemap"
+                            string="Related exchanges"
+                            attrs="{'invisible': [('related_exchange_ids', '=', False)]}"
+                        />
+                    </div>
                     <div class="oe_title">
                         <label for="name" class="oe_edit_only" />
                         <h1>
@@ -97,6 +79,7 @@
                         </group>
                         <group name="status" string="Status">
                             <field name="exchanged_on" />
+                            <field name="edi_exchange_state" />
                             <field name="exchange_file" filename="exchange_filename" />
                             <field
                                 name="exchange_filename"

--- a/edi/views/edi_exchange_type_views.xml
+++ b/edi/views/edi_exchange_type_views.xml
@@ -34,6 +34,7 @@
                             <field name="exchange_file_ext" />
                             <field name="exchange_file_auto_generate" />
                             <field name="ack_type_id" />
+                            <field name="job_channel_id" />
                         </group>
                     </group>
                     <group

--- a/edi/views/edi_exchange_type_views.xml
+++ b/edi/views/edi_exchange_type_views.xml
@@ -37,19 +37,34 @@
                             <field name="job_channel_id" />
                         </group>
                     </group>
-                    <group
-                        name="advanced_settings"
-                        groups="edi.group_edi_advanced_settings_manager"
-                    >
-                        <field name="advanced_settings_edit" widget="ace" />
-                        <field name="model_ids" widget="many2many_tags" />
-                        <field name="enable_domain" />
-                        <field
-                            name="enable_snippet"
-                            widget="ace"
-                            options="{'mode': 'python'}"
-                        />
-                    </group>
+                    <notebook>
+                        <page
+                            name="adv_settings"
+                            string="Advanced settings"
+                            groups="edi.group_edi_advanced_settings_manager"
+                        >
+                            <field
+                                name="advanced_settings_edit"
+                                widget="ace"
+                                colspan="4"
+                            />
+                        </page>
+                        <page
+                            name="model_rules"
+                            string="Model rules"
+                            groups="edi.group_edi_advanced_settings_manager"
+                        >
+                            <group>
+                                <field name="model_ids" widget="many2many_tags" />
+                                <field name="enable_domain" />
+                                <field
+                                    name="enable_snippet"
+                                    widget="ace"
+                                    options="{'mode': 'python'}"
+                                />
+                            </group>
+                        </page>
+                    </notebook>
                 </sheet>
             </form>
         </field>

--- a/edi_webservice/security/ir.model.access.csv
+++ b/edi_webservice/security/ir.model.access.csv
@@ -1,2 +1,3 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_webservice_backend_edi_manager,webservice_backend edi manager,webservice.model_webservice_backend,base_edi.group_edi_manager,1,1,1,1
+access_webservice_backend_user,webservice_backend user,webservice.model_webservice_backend,base.group_user,1,0,0,0


### PR DESCRIPTION
Some buttons are added to manage errors on Odoo or, even, not processed EDI exchange records (last commit)
+ backward port of https://github.com/OCA/edi/pull/448

@simahawk 