### PR TITLE
8.0 FIX pin invoice2data to 0.3.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-invoice2data
+invoice2data>=0.2.74,<=0.3.4
   # Invoice2data new requires a recent version of pdftotext from https://poppler.freedesktop.org/releases.html
   # and the version below doesn't work any more
   #- wget -P /tmp http://public.akretion.com/pdftotext-3.04


### PR DESCRIPTION
MAKE 8.0 GREEN AGAIN

With Invoice2data 0.3.6 we have syntax incompatible with a python 2.7 like here

https://github.com/invoice-x/invoice2data/blob/1adb49cb74b17e1dd278886ee4c432ed2dcaf443/src/invoice2data/extract/invoice_template.py#L69
