### PR TITLE
[IMP] edi: External identifier must be unique on a type and backend

### DIFF
--- a/edi/models/edi_exchange_record.py
+++ b/edi/models/edi_exchange_record.py
@@ -103,8 +103,8 @@ class EDIExchangeRecord(models.Model):
         ("identifier_uniq", "unique(identifier)", "The identifier must be unique."),
         (
             "external_identifier_uniq",
-            "unique(external_identifier)",
-            "The external_identifier must be unique.",
+            "unique(external_identifier, backend_id, type_id)",
+            "The external_identifier must be unique for a type and a backend.",
         ),
     ]
 


### PR DESCRIPTION
It might be possible to have the same external_identifier for different backends and types.

@simahawk