### PR TITLE
[14.0] Fix account_invoice_export wrong assignment

### DIFF
--- a/account_invoice_export/models/account_move.py
+++ b/account_invoice_export/models/account_move.py
@@ -53,7 +53,6 @@ class AccountMove(models.Model):
                     # The chatter of the invoice need to be updated, when the job fails
                     self.with_env(new_env).log_error_sending_invoice(values)
             raise
-        self.invoice_send = True
         self.log_success_sending_invoice()
         return res
 


### PR DESCRIPTION
This `invoice_send` field does not exist (anymore ?)