### PR TITLE
[10.0][IMP] base_business_document_import: search for Bank Account without partner set on it

### DIFF
--- a/base_business_document_import/models/business_document_import.py
+++ b/base_business_document_import/models/business_document_import.py
@@ -281,6 +281,7 @@ class BusinessDocumentImport(models.AbstractModel):
             '|', ('company_id', '=', False),
             ('company_id', '=', company_id),
             ('sanitized_acc_number', '=', iban),
+            '|', ('partner_id', '=', False),
             ('partner_id', '=', partner.id),
             ])
         if bankaccounts:

--- a/base_business_document_import/models/business_document_import.py
+++ b/base_business_document_import/models/business_document_import.py
@@ -285,6 +285,8 @@ class BusinessDocumentImport(models.AbstractModel):
             ('partner_id', '=', partner.id),
             ])
         if bankaccounts:
+            if not bankaccounts[0].partner_id:
+                bankaccounts[0].partner_id = partner
             return bankaccounts[0]
         elif create_if_not_found:
             bank_id = False


### PR DESCRIPTION
Bank Accounts can exist without partners set on them, so at the moment if the search is performed we don't get the expected result => existing Bank Account without Partner
Constraint is applied and we get a noisy warning message though there is actually existing Bank Account.
```
Odoo Warning - Validation Error
Account Number must be unique
```
To fix this we need to include in search also results without partners. Similar condition is applied for `company_id` Checked on real database.