### PR TITLE
[14.0] endpoint_route_handler important fixes

### DIFF
--- a/endpoint/tests/test_endpoint.py
+++ b/endpoint/tests/test_endpoint.py
@@ -171,10 +171,9 @@ class TestEndpoint(CommonEndpoint):
             }
         )
         registry = endpoint._endpoint_registry
-        route = endpoint.route
         endpoint.unlink()
-        self.assertTrue(registry.routing_update_required())
-        self.assertIn(route, [x.rule for x in registry._rules_to_drop])
+        http_id = self.env["ir.http"]._endpoint_make_http_id()
+        self.assertTrue(registry.routing_update_required(http_id))
 
     def test_archiving(self):
         endpoint = self.endpoint.copy(
@@ -188,9 +187,12 @@ class TestEndpoint(CommonEndpoint):
         )
         self.assertTrue(endpoint.active)
         registry = endpoint._endpoint_registry
-        route = endpoint.route
-        self.assertTrue(registry.routing_update_required())
-        self.assertIn(route, [x.rule for x in registry._rules_to_load])
+        http_id = self.env["ir.http"]._endpoint_make_http_id()
+        fake_2nd_http_id = id(2)
+        registry.ir_http_track(http_id)
+        self.assertFalse(registry.routing_update_required(http_id))
+        self.assertFalse(registry.routing_update_required(fake_2nd_http_id))
+
         endpoint.active = False
-        self.assertIn(route, [x.rule for x in registry._rules_to_drop])
-        self.assertTrue(registry.routing_update_required())
+        self.assertTrue(registry.routing_update_required(http_id))
+        self.assertFalse(registry.routing_update_required(fake_2nd_http_id))

--- a/endpoint/tests/test_endpoint.py
+++ b/endpoint/tests/test_endpoint.py
@@ -175,3 +175,22 @@ class TestEndpoint(CommonEndpoint):
         endpoint.unlink()
         self.assertTrue(registry.routing_update_required())
         self.assertIn(route, [x.rule for x in registry._rules_to_drop])
+
+    def test_archiving(self):
+        endpoint = self.endpoint.copy(
+            {
+                "route": "/enable-disable/this",
+                "request_method": "POST",
+                "request_content_type": "text/plain",
+                "auth_type": "public",
+                "exec_as_user_id": self.env.user.id,
+            }
+        )
+        self.assertTrue(endpoint.active)
+        registry = endpoint._endpoint_registry
+        route = endpoint.route
+        self.assertTrue(registry.routing_update_required())
+        self.assertIn(route, [x.rule for x in registry._rules_to_load])
+        endpoint.active = False
+        self.assertIn(route, [x.rule for x in registry._rules_to_drop])
+        self.assertTrue(registry.routing_update_required())

--- a/endpoint/tests/test_endpoint_controller.py
+++ b/endpoint/tests/test_endpoint_controller.py
@@ -40,6 +40,13 @@ class EndpointHttpCase(HttpCase):
         response = self.url_open("/demo/one/new")
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.content, b"ok")
+        # Archive it
+        endpoint.active = False
+        response = self.url_open("/demo/one/new")
+        self.assertEqual(response.status_code, 404)
+        endpoint.active = True
+        response = self.url_open("/demo/one/new")
+        self.assertEqual(response.status_code, 200)
 
     def test_call2(self):
         response = self.url_open("/demo/as_demo_user")

--- a/endpoint_route_handler/registry.py
+++ b/endpoint_route_handler/registry.py
@@ -36,7 +36,7 @@ class EndpointRegistry:
 
     def add_or_update_rule(self, key, rule, force=False):
         existing = self._mapping.get(key)
-        if not existing:
+        if not existing or force:
             self._mapping[key] = rule
             self._rules_to_load.append(rule)
             self._routing_update_required = True
@@ -50,7 +50,7 @@ class EndpointRegistry:
             return True
 
     def drop_rule(self, key):
-        existing = self._mapping.get(key)
+        existing = self._mapping.pop(key, None)
         if not existing:
             return False
         # Override and set as to be updated

--- a/endpoint_route_handler/tests/common.py
+++ b/endpoint_route_handler/tests/common.py
@@ -49,4 +49,5 @@ class CommonEndpoint(SavepointCase):
             for k, v in request_attrs.items():
                 setattr(mocked_request, k, v)
             mocked_request.make_response = lambda data, **kw: data
+            mocked_request.registry._init_modules = set()
             yield mocked_request

--- a/endpoint_route_handler/tests/test_endpoint.py
+++ b/endpoint_route_handler/tests/test_endpoint.py
@@ -53,8 +53,7 @@ class TestEndpoint(CommonEndpoint):
                 return "ok"
 
         endpoint_handler = partial(TestController()._do_something, new_route.route)
-        with self._get_mocked_request() as req:
-            req.registry._init_modules = set()
+        with self._get_mocked_request():
             new_route._register_controller(endpoint_handler=endpoint_handler)
             # Ensure the routing rule is registered
             rmap = self.env["ir.http"].routing_map()
@@ -62,7 +61,7 @@ class TestEndpoint(CommonEndpoint):
         # Ensure is updated when needed
         new_route.route += "/new"
         new_route._refresh_endpoint_data()
-        with self._get_mocked_request() as req:
+        with self._get_mocked_request():
             new_route._register_controller(endpoint_handler=endpoint_handler)
             rmap = self.env["ir.http"].routing_map()
             self.assertNotIn("/my/test/route", [x.rule for x in rmap._rules])
@@ -77,8 +76,7 @@ class TestEndpoint(CommonEndpoint):
                 return "ok"
 
         endpoint_handler = TestController()._do_something
-        with self._get_mocked_request() as req:
-            req.registry._init_modules = set()
+        with self._get_mocked_request():
             new_route._register_controller(endpoint_handler=endpoint_handler)
             # Ensure the routing rule is registered
             rmap = self.env["ir.http"].routing_map()

--- a/endpoint_route_handler/tests/test_endpoint_controller.py
+++ b/endpoint_route_handler/tests/test_endpoint_controller.py
@@ -28,6 +28,7 @@ class EndpointHttpCase(HttpCase):
 
     def tearDown(self):
         EndpointRegistry.wipe_registry_for(self.env.cr.dbname)
+        self.env["ir.http"]._clear_routing_map()
         super().tearDown()
 
     def _make_new_route(self, register=True, **kw):


### PR DESCRIPTION
From commit history:
```
* endpoint_route_handler: fix archive/unarchive

When an endpoint is archived it must be dropped.
When it's unarchive it must be restored.

* endpoint_route_handler: fix multi env handling

Routing maps are generated **per env**
which means that every new env will have its own routing map
attached to `ir.http` registry class.

This is not desired (as per core Odoo comment)
but it's like this today :/

Hence, before this change, the routing map could be mis-aligned
across different envs leading to random responses for custom endpoints.

This refactoring simplifies a lot the handling of the rules
leaving to std `_generate_routing_rules` the duty to yield rules
and to `routing_map` to generate them for the new route map.

EndpointRegistry memory consumption is improved too
thanks to smaller data to store and to the usage of __slots__.

```