### PR TITLE
[14.0] Add module edi_bank_statement_import

### DIFF
--- a/edi_bank_statement_import/README.rst
+++ b/edi_bank_statement_import/README.rst
@@ -1,0 +1,1 @@
+wait for the bot ;)

--- a/edi_bank_statement_import/__init__.py
+++ b/edi_bank_statement_import/__init__.py
@@ -1,0 +1,1 @@
+from . import components

--- a/edi_bank_statement_import/__manifest__.py
+++ b/edi_bank_statement_import/__manifest__.py
@@ -1,0 +1,17 @@
+# Copyright 2021 AGEPoly - Téo Goddet
+# @author: Téo Goddet <teo.goddet@gmail.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+{
+    "name": "EDI Bank statement import",
+    "summary": """Plug account_statement_import into EDI machinery.""",
+    "version": "14.0.1.0.0",
+    "development_status": "Alpha",
+    "license": "AGPL-3",
+    "website": "https://github.com/OCA/edi",
+    "author": "AGEPoly,Odoo Community Association (OCA)",
+    "maintainers": ["TeoGoddet"],
+    "depends": ["edi_oca", "account_statement_import"],
+    "data": ["data/data.xml"],
+    "auto_install": True,
+}

--- a/edi_bank_statement_import/components/__init__.py
+++ b/edi_bank_statement_import/components/__init__.py
@@ -1,0 +1,1 @@
+from . import process

--- a/edi_bank_statement_import/components/process.py
+++ b/edi_bank_statement_import/components/process.py
@@ -1,0 +1,92 @@
+# Copyright 2021 AGEPoly - Téo Goddet
+# @author: Téo Goddet <teo.goddet@gmail.>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+import base64
+
+from odoo import _, api
+
+from odoo.addons.component.core import Component
+
+
+# TODO: add tests
+class EDIExchangeBankStatementInput(Component):
+    """Process bank statements."""
+
+    _name = "edi.input.bank.statement.process"
+    _inherit = "edi.component.input.mixin"
+    _usage = "input.process.bank.statement"
+
+    def __init__(self, work_context):
+        super().__init__(work_context)
+        self.settings = self.type_settings.get("bank_statement", {})
+
+    def process(self):
+        wiz = self._setup_wizard()
+        result = {
+            "statement_ids": [],
+            "notifications": [],
+        }
+
+        file_data = base64.b64decode(wiz.statement_file)
+        wiz.import_single_file(file_data, result)
+
+        return self._handle_result(result["statement_ids"], wiz.statement_filename)
+
+    def _handle_result(self, statement_ids, filename):
+        if not statement_ids:
+            self.exchange_record.sudo().message_post(
+                body=_(
+                    "You have already imported this file (%s) or this file "
+                    "only contains already imported transactions."
+                )
+                % filename
+            )
+            return True
+
+        if len(statement_ids) == 1:
+            self._handle_single_result(self.exchange_record, statement_ids[0])
+            return True
+        else:
+            for statement_id in statement_ids:
+
+                child_exchange = self.exchange_record.create(
+                    {
+                        "identifier": "%s_%s"
+                        % (self.exchange_record.identifier, statement_id),
+                        "type_id": self.exchange_record.type_id.id,
+                        "backend_id": self.exchange_record.backend_id.id,
+                        "edi_exchange_state": "input_processed",
+                        "parent_id": self.exchange_record.id,
+                    }
+                )
+                self._handle_single_result(child_exchange, statement_id)
+                self.exchange_record.sudo().message_post(
+                    body=_("Multiple Bank Statements created (See child exchanges)")
+                )
+            return True
+
+    @api.model
+    def _handle_single_result(self, exchange_record, statement_id):
+        statement = self.env["account.bank.statement"].browse(statement_id)
+        if self._statement_should_be_confirmed():
+            statement.button_post()
+        exchange_record.sudo().message_post(
+            body=_("Bank Statement %s created") % statement.name
+        )
+        exchange_record.sudo()._set_related_record(statement)
+
+    def _setup_wizard(self):
+        """Init a `account.statement.import` instance for current record."""
+        wiz_ctx = self.settings.get("wiz_ctx", {})
+
+        wiz_model = "account.statement.import"
+        wiz_vals = {
+            "statement_filename": self.exchange_record.exchange_filename,
+            "statement_file": self.exchange_record._get_file_content(binary=False),
+        }
+        wiz = self.env[wiz_model].with_context(wiz_ctx).sudo().create(wiz_vals)
+
+        return wiz
+
+    def _statement_should_be_confirmed(self):
+        return self.settings.get("auto_post", False)

--- a/edi_bank_statement_import/data/data.xml
+++ b/edi_bank_statement_import/data/data.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="edi_exchange_backend" model="edi.backend.type">
+        <field name="name">Bank Statement Backend Type</field>
+        <field name="code">bank_statement_backend_type</field>
+    </record>
+    <record id="edi_exchange_type" model="edi.exchange.type">
+        <field name="name">Bank Statement Import</field>
+        <field name="code">bank_statement_import</field>
+        <field name="backend_type_id" ref="edi_exchange_backend" />
+        <field name="direction">input</field>
+        <field name="exchange_file_ext">xml</field>
+        <field name="advanced_settings_edit">
+components:
+    process:
+        usage: input.process.bank.statement
+bank_statement:
+    auto_post: false
+    wiz_ctx:
+        foo: "bar"
+        default_sheet_mapping_id: 1
+        </field>
+    </record>
+</odoo>

--- a/edi_bank_statement_import/readme/CONTRIBUTORS.rst
+++ b/edi_bank_statement_import/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Téo Goddet <teo.goddet@gmail.com>

--- a/edi_bank_statement_import/readme/DESCRIPTION.rst
+++ b/edi_bank_statement_import/readme/DESCRIPTION.rst
@@ -1,0 +1,7 @@
+Plug bank_statement_import into EDI machinery.
+
+
+This module allows to use account_bank_statement_import to parse edi exchange (input).
+This allow you ro retrieve bank stazement from a any edi exchange backend (webservice, sftp, local filesystem, ...)
+
+TODO: shall we add an exchange type example as demo?

--- a/edi_bank_statement_import/readme/USAGE.rst
+++ b/edi_bank_statement_import/readme/USAGE.rst
@@ -1,0 +1,24 @@
+For each bank/bank account, you need to create an exchange type.
+
+On your exchange type, go to advanced settings and add the following::
+
+    [...]
+    components:
+        process:
+            usage: input.process.bank.statement
+
+
+You can decide if the statements should be posted::
+
+    [...]
+    bank_statement:
+        auto_post: true
+
+
+You may also specify some context for the bank statement import wizard::
+
+    [...]
+    bank_statement:
+        wiz_ctx:
+            foo: "bar"
+            default_sheet_mapping_id: 5

--- a/edi_bank_statement_import/tests/__init__.py
+++ b/edi_bank_statement_import/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_process

--- a/edi_bank_statement_import/tests/test_process.py
+++ b/edi_bank_statement_import/tests/test_process.py
@@ -1,0 +1,148 @@
+# Copyright 2022 Téo Goddet
+# @author: Téo Goddet <teo.goddet@gmail.com>
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+import base64
+import textwrap
+
+import mock
+
+from odoo.addons.component.tests.common import SavepointComponentCase
+from odoo.addons.edi_oca.tests.common import EDIBackendTestMixin
+
+
+class TestProcessComponent(SavepointComponentCase, EDIBackendTestMixin):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.backend = cls._get_backend()
+        cls.exc_type = cls._create_exchange_type(
+            name="Test bank statement import",
+            code="test_bank_statement_import",
+            direction="input",
+            exchange_file_ext="xml",
+            exchange_filename_pattern="{record.identifier}-{type.code}-{dt}",
+            backend_id=cls.backend.id,
+            advanced_settings_edit=textwrap.dedent(
+                """
+            components:
+                process:
+                    usage: input.process.bank.statement
+            bank_statement:
+                wiz_ctx:
+                    random_key: custom
+            """
+            ),
+        )
+        cls.record = cls.backend.create_record("test_bank_statement_import", {})
+        cls.record._set_file_content(b"<fake><statement></statement></fake>")
+        cls.wiz_model = cls.env["account.statement.import"]
+
+    def test_lookup(self):
+        comp = self.backend._get_component(self.record, "process")
+        self.assertEqual(comp._name, "edi.input.bank.statement.process")
+
+    def test_wizard_setup(self):
+        comp = self.backend._get_component(self.record, "process")
+        wiz = comp._setup_wizard()
+
+        self.assertEqual(wiz._name, self.wiz_model._name)
+        self.assertEqual(wiz.env.context["random_key"], "custom")
+        self.assertEqual(
+            base64.b64decode(wiz.statement_file),
+            b"<fake><statement></statement></fake>",
+        )
+        self.assertEqual(wiz.statement_filename, self.record.exchange_filename)
+
+    def test_wizard_process(self):
+        comp = self.backend._get_component(self.record, "process")
+        mock1 = mock.patch.object(type(self.wiz_model), "import_single_file")
+        mock2 = mock.patch.object(type(comp), "_handle_result")
+        with mock1 as md_import_single_file, mock2 as md_handle_result:
+            comp.process()
+            md_import_single_file.assert_called()
+            md_handle_result.assert_called()
+
+    def test_no_statement(self):
+        comp = self.backend._get_component(self.record, "process")
+        result = comp._handle_result([], self.record.exchange_filename)
+
+        self.assertEqual(comp.exchange_record.res_id, False)
+        self.assertEqual(comp.exchange_record.model, False)
+        self.assertEqual(result, True)
+
+    def test_single_statement_result_and_auto_post(self):
+        statement = self.env["account.bank.statement"].create(
+            {
+                "name": "Test Statement",
+                "journal_id": self.env["account.journal"]
+                .search(
+                    [
+                        ("company_id", "=", self.env.user.company_id.id),
+                        ("type", "=", "bank"),
+                    ],
+                    limit=1,
+                )
+                .id,
+            }
+        )
+
+        self.record.type_id.advanced_settings_edit = textwrap.dedent(
+            """
+            components:
+                process:
+                    usage: input.process.bank.statement
+            bank_statement:
+                auto_post: true
+            """
+        )
+
+        comp = self.backend._get_component(self.record, "process")
+        comp._handle_result([statement.id], self.record.exchange_filename)
+
+        self.assertEqual(comp.exchange_record.res_id, statement.id)
+        self.assertEqual(comp.exchange_record.model, "account.bank.statement")
+        self.assertEqual(statement.state, "posted")
+
+    def test_multiple_statement_result_and_no_auto_post(self):
+        statement1 = self.env["account.bank.statement"].create(
+            {
+                "name": "Test Statement 1",
+                "journal_id": self.env["account.journal"]
+                .search(
+                    [
+                        ("company_id", "=", self.env.user.company_id.id),
+                        ("type", "=", "bank"),
+                    ],
+                    limit=1,
+                )
+                .id,
+            }
+        )
+        statement2 = self.env["account.bank.statement"].create(
+            {
+                "name": "Test Statement 2",
+                "journal_id": self.env["account.journal"]
+                .search(
+                    [
+                        ("company_id", "=", self.env.user.company_id.id),
+                        ("type", "=", "bank"),
+                    ],
+                    limit=1,
+                )
+                .id,
+            }
+        )
+
+        comp = self.backend._get_component(self.record, "process")
+        comp._handle_result(
+            [statement1.id, statement2.id], self.record.exchange_filename
+        )
+
+        self.assertEqual(len(comp.exchange_record.related_exchange_ids), 2)
+        for child_exch in comp.exchange_record.related_exchange_ids:
+            self.assertIn(child_exch.res_id, [statement1.id, statement2.id])
+            self.assertEqual(child_exch.model, "account.bank.statement")
+
+        self.assertEqual(statement1.state, "open")
+        self.assertEqual(statement2.state, "open")

--- a/setup/edi_bank_statement_import/odoo/addons/edi_bank_statement_import
+++ b/setup/edi_bank_statement_import/odoo/addons/edi_bank_statement_import
@@ -1,0 +1,1 @@
+../../../../edi_bank_statement_import/

--- a/setup/edi_bank_statement_import/setup.py
+++ b/setup/edi_bank_statement_import/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
This module plugs edi framework into account_statement_import from OCA/bank-statement-import
It allow to parse data retrieved trough the framework as bank statement.


It's heavily based on https://github.com/Noviat/account_ebics/blob/14.0/account_ebics/models/ebics_file.py and #451
