### PR TITLE
[13.0] base_business_document_import: match product by packaging barcode too

### DIFF
--- a/base_business_document_import/models/business_document_import.py
+++ b/base_business_document_import/models/business_document_import.py
@@ -512,11 +512,22 @@ class BusinessDocumentImport(models.AbstractModel):
 
     @api.model
     def _match_product(self, product_dict, chatter_msg, seller=False):
-        """Example:
-        product_dict = {
-            'barcode': '5449000054227',
-            'code': 'COCA1L',
-            }
+        """Retrieve product.
+
+        Matching sequence:
+
+        1. ID
+        2. barcode
+        3. packaging barcode
+        4. default_code
+        5. seller code
+
+        :param product_dict: dictionary w/ product info.
+
+            Example: {'barcode': '5449000054227', 'code': 'COCA1L'}
+
+        :param chatter_msg: list of msgs to append to chatter (if any)
+        :param seller: optional product.supplierinfo record
         """
         ppo = self.env["product.product"]
         self._strip_cleanup_dict(product_dict)

--- a/base_business_document_import/models/business_document_import.py
+++ b/base_business_document_import/models/business_document_import.py
@@ -567,6 +567,7 @@ class BusinessDocumentImport(models.AbstractModel):
             domain = cdomain + [
                 "|",
                 ("barcode", "=", product_dict["barcode"]),
+                ("packaging_ids.barcode", "=", product_dict["barcode"]),
             ]
             product = product.search(domain, limit=1)
         if not product and product_dict.get("code"):

--- a/base_business_document_import/models/business_document_import.py
+++ b/base_business_document_import/models/business_document_import.py
@@ -524,43 +524,26 @@ class BusinessDocumentImport(models.AbstractModel):
             return product_dict["recordset"]
         if product_dict.get("id"):
             return ppo.browse(product_dict["id"])
-        company_id = self._context.get("force_company") or self.env.user.company_id.id
-        cdomain = ["|", ("company_id", "=", False), ("company_id", "=", company_id)]
-        if product_dict.get("barcode"):
-            product = ppo.search(
-                cdomain + [("barcode", "=", product_dict["barcode"])], limit=1
-            )
-            if product:
-                return product
-        if product_dict.get("code"):
-            product = ppo.search(
-                cdomain
+        product = self._match_product_search(product_dict)
+        if product:
+            return product
+        elif seller:
+            # WARNING: Won't work for multi-variant products
+            # because product.supplierinfo is attached to product template
+            sinfo = self.env["product.supplierinfo"].search(
+                self._match_company_domain()
                 + [
-                    "|",
-                    ("barcode", "=", product_dict["code"]),
-                    ("default_code", "=", product_dict["code"]),
+                    ("name", "=", seller.id),
+                    ("product_code", "=", product_dict["code"]),
                 ],
                 limit=1,
             )
-            if product:
-                return product
-            # WARNING: Won't work for multi-variant products
-            # because product.supplierinfo is attached to product template
-            if seller:
-                sinfo = self.env["product.supplierinfo"].search(
-                    cdomain
-                    + [
-                        ("name", "=", seller.id),
-                        ("product_code", "=", product_dict["code"]),
-                    ],
-                    limit=1,
-                )
-                if (
-                    sinfo
-                    and sinfo.product_tmpl_id.product_variant_ids
-                    and len(sinfo.product_tmpl_id.product_variant_ids) == 1
-                ):
-                    return sinfo.product_tmpl_id.product_variant_ids[0]
+            if (
+                sinfo
+                and sinfo.product_tmpl_id.product_variant_ids
+                and len(sinfo.product_tmpl_id.product_variant_ids) == 1
+            ):
+                return sinfo.product_tmpl_id.product_variant_ids[0]
         raise self.user_error_wrap(
             _(
                 "Odoo couldn't find any product corresponding to the "
@@ -575,6 +558,31 @@ class BusinessDocumentImport(models.AbstractModel):
                 seller and seller.name or "None",
             )
         )
+
+    @api.model
+    def _match_product_search(self, product_dict):
+        product = self.env["product.product"].browse()
+        cdomain = self._match_company_domain()
+        if product_dict.get("barcode"):
+            domain = cdomain + [
+                "|",
+                ("barcode", "=", product_dict["barcode"]),
+            ]
+            product = product.search(domain, limit=1)
+        if not product and product_dict.get("code"):
+            # TODO: this domain could be probably included in the former one
+            domain = cdomain + [
+                "|",
+                ("barcode", "=", product_dict["code"]),
+                ("default_code", "=", product_dict["code"]),
+            ]
+            product = product.search(domain, limit=1)
+        return product
+
+    @api.model
+    def _match_company_domain(self):
+        company_id = self._context.get("force_company") or self.env.user.company_id.id
+        return ["|", ("company_id", "=", False), ("company_id", "=", company_id)]
 
     @api.model
     def _match_currency(self, currency_dict, chatter_msg):

--- a/base_business_document_import/tests/test_business_document_import.py
+++ b/base_business_document_import/tests/test_business_document_import.py
@@ -130,14 +130,22 @@ class TestBaseBusinessDocumentImport(TransactionCase):
                         },
                     ),
                 ],
+                "packaging_ids": [(0, 0, {"name": "Big Pack", "barcode": "BIG-PACK"})],
             }
         )
+        # Match by code
         product_dict = {"code": "FURN_7777 "}
         res = bdio._match_product(product_dict, [])
         self.assertEqual(res, self.env.ref("product.product_delivery_01"))
+        # Match by barcode
         product_dict = {"barcode": "9782203121102"}
         res = bdio._match_product(product_dict, [])
         self.assertEqual(res, product1)
+        # Match by packaging barcode
+        product_dict = {"barcode": "BIG-PACK"}
+        res = bdio._match_product(product_dict, [])
+        self.assertEqual(res, product1)
+        # Match by seller
         product_dict = {"code": "TEST1242"}
         res = bdio._match_product(
             product_dict, [], seller=self.env.ref("base.res_partner_2")

--- a/sale_order_import_ubl/demo/demo_data.xml
+++ b/sale_order_import_ubl/demo/demo_data.xml
@@ -60,12 +60,18 @@
         <field name="uom_id" ref="uom.product_uom_litre" />
         <field name="uom_po_id" ref="uom.product_uom_litre" />
     </record>
+    <record id="product_packaging_pencil" model="product.packaging">
+        <field name="name">Multi Pack</field>
+        <field name="qty">10</field>
+        <field name="barcode">1122334455</field>
+    </record>
     <record id="product_pencil" model="product.product">
         <field name="name">Pensel 20 mm</field>
         <field name="description_sale">Very good pencils for red paint</field>
         <field name="default_code">SItemNo011</field>
         <field name="list_price">18</field>
         <field name="type">consu</field>
+        <field name="packaging_ids" eval="[(4, ref('product_packaging_pencil'))]" />
     </record>
     <!-- for tests/UBL-Order-2.0-Example.xml -->
     <record id="base.GBP" model="res.currency">

--- a/sale_order_import_ubl/tests/files/UBL-Order-2.1-Example.xml
+++ b/sale_order_import_ubl/tests/files/UBL-Order-2.1-Example.xml
@@ -381,7 +381,7 @@
                     <cbc:ID>SItemNo011</cbc:ID>
                 </cac:SellersItemIdentification>
                 <cac:StandardItemIdentification>
-                    <cbc:ID schemeAgencyID="6" schemeID="GTIN">123452340123</cbc:ID>
+                    <cbc:ID schemeAgencyID="6" schemeID="GTIN">1122334455</cbc:ID>
                 </cac:StandardItemIdentification>
                 <cac:AdditionalItemProperty>
                     <cbc:Name>Hair color</cbc:Name>

--- a/sale_order_import_ubl/tests/test_ubl_order_import.py
+++ b/sale_order_import_ubl/tests/test_ubl_order_import.py
@@ -10,17 +10,18 @@ from odoo.tools import file_open
 
 class TestUblOrderImport(TransactionCase):
     def test_ubl_order_import(self):
+        ref = self.env.ref
         tests = {
             "UBL-Order-2.1-Example.xml": {
                 "client_order_ref": "34",
                 "date_order": "2010-01-20",
-                "partner": self.env.ref("sale_order_import_ubl.svensson"),
-                "shipping_partner": self.env.ref(
-                    "sale_order_import_ubl.swedish_trucking"
-                ),
-                "invoicing_partner": self.env.ref("sale_order_import_ubl.karlsson"),
-                "currency": self.env.ref("base.SEK"),
+                "partner": ref("sale_order_import_ubl.svensson"),
+                "shipping_partner": ref("sale_order_import_ubl.swedish_trucking"),
+                "invoicing_partner": ref("sale_order_import_ubl.karlsson"),
+                "currency": ref("base.SEK"),
                 "commitment_date": "2010-02-26 18:00:00",
+                "products": ref("sale_order_import_ubl.product_red_paint")
+                + ref("sale_order_import_ubl.product_pencil"),
             },
             "UBL-Order-2.0-Example.xml": {
                 "client_order_ref": "AEG012345",
@@ -29,10 +30,12 @@ class TestUblOrderImport(TransactionCase):
                 "shipping_partner": self.env.ref("sale_order_import_ubl.iyt"),
                 "currency": self.env.ref("base.GBP"),
                 "commitment_date": "2010-02-26 00:00:00",
+                "products": ref("sale_order_import_ubl.product_beeswax"),
             },
             "UBL-RequestForQuotation-2.0-Example.xml": {
                 "partner": self.env.ref("sale_order_import_ubl.s_massiah"),
                 "shipping_partner": self.env.ref("sale_order_import_ubl.iyt"),
+                "products": ref("sale_order_import_ubl.product_beeswax"),
             },
             "UBL-RequestForQuotation-2.1-Example.xml": {
                 "partner": self.env.ref("sale_order_import_ubl.gentofte_kommune"),
@@ -40,6 +43,9 @@ class TestUblOrderImport(TransactionCase):
                 "shipping_partner": self.env.ref(
                     "sale_order_import_ubl.delivery_gentofte_kommune"
                 ),
+                "products": ref("product.product_product_25")
+                + ref("product.product_product_24")
+                + ref("product.product_product_9"),
             },
         }
         for filename, res in tests.items():
@@ -68,3 +74,12 @@ class TestUblOrderImport(TransactionCase):
                 )
             else:
                 self.assertFalse(so.commitment_date)
+
+            # NOTE: parsing products should be tested by base_ubl
+            # but ATM there's no test coverage there.
+            # This little test ensures that it works in this context at least.
+            if res.get("products"):
+                expected_ids = sorted(res["products"].ids)
+                self.assertEqual(
+                    sorted(so.order_line.mapped("product_id").ids), expected_ids
+                )

--- a/sale_order_import_ubl/tests/test_ubl_order_import.py
+++ b/sale_order_import_ubl/tests/test_ubl_order_import.py
@@ -5,10 +5,11 @@ import base64
 
 from odoo import fields
 from odoo.tests.common import TransactionCase
-from odoo.tools import file_open
+from odoo.tools import file_open, mute_logger
 
 
 class TestUblOrderImport(TransactionCase):
+    @mute_logger("odoo.addons.sale_order_import.wizard.sale_order_import")
     def test_ubl_order_import(self):
         ref = self.env.ref
         tests = {


### PR DESCRIPTION
The most important commit is

* [business_document_import: match product packaging fallback](https://github.com/OCA/edi/commit/4faf851cf8c4cd2682257747c380616dd0e63585)

which adds a fallback to match product by packaging barcode.

The others, are corollary changes. See atomic commits for details.