### PR TITLE
[14.0] sale_order_import: _parse_xml handle NotImplementedError

### DIFF
--- a/sale_order_import/wizard/sale_order_import.py
+++ b/sale_order_import/wizard/sale_order_import.py
@@ -101,7 +101,7 @@ class SaleOrderImport(models.TransientModel):
             return xml_root, error_msg
         try:
             self.parse_xml_order(xml_root, detect_doc_type=True)
-        except UserError:
+        except (UserError, NotImplementedError):
             error_msg = _("Unsupported XML document")
         return xml_root, error_msg
 


### PR DESCRIPTION
When no handler is defined for the given document
NotImplementedError could be raised.

Handle this case properly when parsing.