### PR TITLE
[13.0][FIX] edi: remove span inside anchor to fix exchange record navigation

### DIFF
--- a/edi/templates/exchange_chatter_msg.xml
+++ b/edi/templates/exchange_chatter_msg.xml
@@ -13,7 +13,7 @@
                     t-att-data-oe-model="exchange_record._name"
                     t-att-data-oe-id="exchange_record.id"
                 >
-                    <span t-field="exchange_record.name" />
+                    <t t-esc="exchange_record.name" />
                 </a>
             </span>
             <br />


### PR DESCRIPTION
By adding the span element, the navigation is not performed correctly and the anchor just redirects to '#'.