### PR TITLE
[14.0] Fix account_invoice_export resend button visibility

### DIFF
--- a/account_invoice_export/views/account_move.xml
+++ b/account_invoice_export/views/account_move.xml
@@ -23,7 +23,7 @@
                     name="export_invoice"
                     string="Resend eBill"
                     type="object"
-                    attrs="{'invisible':['|', '|', '|', ('send_through_http', '=', False), ('state', '!=', 'posted'), '|', ('invoice_export_confirmed', '=', True), ('invoice_exported', '=', False), ('move_type', 'not in', ('out_invoice', 'out_refund'))]}"
+                    attrs="{'invisible':['|', '|', '|', ('send_through_http', '=', False), ('state', '!=', 'posted'), ('invoice_exported', '=', False), ('move_type', 'not in', ('out_invoice', 'out_refund'))]}"
                     context="{'resend_ebill': True}"
                     groups="base.group_user"
                     class="oe_highlight"


### PR DESCRIPTION
The resend button was not displayed when needed.
Looks like some parts of a commit on 13 missing.