### PR TITLE
[14.0] Add sale_order_packaging_import

### DIFF
--- a/base_business_document_import/models/business_document_import.py
+++ b/base_business_document_import/models/business_document_import.py
@@ -985,25 +985,9 @@ class BusinessDocumentImport(models.AbstractModel):
                 # used for to_remove
                 existing_lines_dict[product]["import"] = True
                 oline = existing_lines_dict[product]["line"]
-                res["to_update"][oline] = {}
-                if float_compare(
-                    iline["qty"],
-                    existing_lines_dict[product]["qty"],
-                    precision_digits=qty_precision,
-                ):
-                    res["to_update"][oline]["qty"] = [
-                        existing_lines_dict[product]["qty"],
-                        iline["qty"],
-                    ]
-                if "price_unit" in iline and float_compare(
-                    iline["price_unit"],
-                    existing_lines_dict[product]["price_unit"],
-                    precision_digits=price_precision,
-                ):
-                    res["to_update"][oline]["price_unit"] = [
-                        existing_lines_dict[product]["price_unit"],
-                        iline["price_unit"],
-                    ]
+                res["to_update"][oline] = self._prepare_order_line_update_values(
+                    existing_lines_dict[product], iline, qty_precision, price_precision
+                )
             else:
                 res["to_add"].append(
                     {"product": product, "uom": uom, "import_line": iline}
@@ -1015,6 +999,27 @@ class BusinessDocumentImport(models.AbstractModel):
                 else:
                     res["to_remove"] = exiting_dict["line"]
         return res
+
+    def _prepare_order_line_update_values(
+        self, existing_line, iline, qty_precision, price_precision
+    ):
+        values = {}
+        if float_compare(
+            iline["qty"],
+            existing_line["qty"],
+            precision_digits=qty_precision,
+        ):
+            values["qty"] = [existing_line["qty"], iline["qty"]]
+        if "price_unit" in iline and float_compare(
+            iline["price_unit"],
+            existing_line["price_unit"],
+            precision_digits=price_precision,
+        ):
+            values["price_unit"] = [
+                existing_line["price_unit"],
+                iline["price_unit"],
+            ]
+        return values
 
     def _prepare_account_speed_dict(self):
         company_id = self._context.get("force_company") or self.env.company.id

--- a/sale_order_import/wizard/sale_order_import.py
+++ b/sale_order_import/wizard/sale_order_import.py
@@ -553,6 +553,7 @@ class SaleOrderImport(models.TransientModel):
                             )
                         )
                         write_vals["price_unit"] = new_price_unit
+                write_vals.update(self._prepare_update_order_line_vals(cdict))
             if write_vals:
                 oline.write(write_vals)
         if compare_res["to_remove"]:
@@ -587,6 +588,10 @@ class SaleOrderImport(models.TransientModel):
                 % (len(compare_res["to_add"]), ", ".join(to_create_label))
             )
         return True
+
+    def _prepare_update_order_line_vals(self, change_dict):
+        # Allows other module to update some fields on the line
+        return {}
 
     def update_order_button(self):
         self.ensure_one()

--- a/sale_order_packaging_import/__init__.py
+++ b/sale_order_packaging_import/__init__.py
@@ -1,0 +1,2 @@
+from . import models
+from . import wizard

--- a/sale_order_packaging_import/__manifest__.py
+++ b/sale_order_packaging_import/__manifest__.py
@@ -1,0 +1,20 @@
+# Copyright 2022 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+{
+    "name": "Sale Order Packaging Import",
+    "version": "14.0.1.0.0",
+    "category": "Sales Management",
+    "license": "AGPL-3",
+    "summary": "Import the packaging on the sale order line",
+    "author": "Camptocamp SA,Odoo Community Association (OCA)",
+    "website": "https://github.com/OCA/edi",
+    "depends": [
+        "sale_stock",
+        "sale_order_import",
+        # OCA sale-workflow
+        "sale_order_line_packaging_qty",
+    ],
+    "development_status": "Alpha",
+    "installable": True,
+}

--- a/sale_order_packaging_import/models/__init__.py
+++ b/sale_order_packaging_import/models/__init__.py
@@ -1,0 +1,1 @@
+from . import business_document_import

--- a/sale_order_packaging_import/models/business_document_import.py
+++ b/sale_order_packaging_import/models/business_document_import.py
@@ -1,0 +1,34 @@
+# Copyright 2022 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+from odoo import models
+
+
+class BusinessDocumentImport(models.AbstractModel):
+    _inherit = "business.document.import"
+
+    def _prepare_order_line_update_values(
+        self, existing_line, iline, qty_precision, price_precision
+    ):
+        values = super()._prepare_order_line_update_values(
+            existing_line, iline, qty_precision, price_precision
+        )
+        product = existing_line.get("product")
+        packaging = None
+        packaging_code = iline["product"].get("barcode")
+        oline = existing_line.get("line")
+        if packaging_code:
+            packaging = product.packaging_ids.filtered(
+                lambda pack: pack.barcode == packaging_code
+            )
+            if packaging:
+                qty = packaging.qty * iline["qty"]
+                if qty != oline.product_uom_qty:
+                    values["qty"] = [oline.product_uom_qty, qty]
+                elif "qty" in values.keys():
+                    values.pop("qty")
+        if packaging and packaging != oline.product_packaging:
+            values["packaging"] = [oline.product_packaging.id, packaging.id]
+        elif not packaging and oline.product_packaging:
+            values["packaging"] = [oline.product_packaging.id, False]
+        return values

--- a/sale_order_packaging_import/readme/CONTRIBUTORS.rst
+++ b/sale_order_packaging_import/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Thierry Ducrest <thierry.ducrest@camptocamp.com>

--- a/sale_order_packaging_import/readme/DESCRIPTION.rst
+++ b/sale_order_packaging_import/readme/DESCRIPTION.rst
@@ -1,0 +1,7 @@
+This module extends the `sale_order_import` module to help on importing
+the packaging information into the sales order line.
+
+If for a sale line the product is detected by the code on one of its packaging,
+then this corresponding packaging will be set on the order line.
+Also the quantity received during the import will be set as the quantity of
+packaging and not as the product quantity on the line.

--- a/sale_order_packaging_import/tests/__init__.py
+++ b/sale_order_packaging_import/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_order_line_packaging_import

--- a/sale_order_packaging_import/tests/test_order_line_packaging_import.py
+++ b/sale_order_packaging_import/tests/test_order_line_packaging_import.py
@@ -1,0 +1,76 @@
+# Copyright 2022 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+from odoo.tests.common import SavepointCase
+
+
+class TestOrderLinePackagingImport(SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
+        cls.product = cls.env.ref("product.product_delivery_02")
+        cls.pack1 = cls.env["product.packaging"].create(
+            {
+                "name": "Pack Number One",
+                "barcode": "PACK001",
+                "product_id": cls.product.id,
+                "qty": 12,
+            }
+        )
+        cls.pack2 = cls.env["product.packaging"].create(
+            {
+                "name": "Pack Number Two",
+                "barcode": "PACK002",
+                "product_id": cls.product.id,
+                "qty": 3,
+            }
+        )
+        cls.parsed_order = {
+            "partner": {"email": "deco.addict82@example.com"},
+            "date": "2018-08-14",
+            "order_ref": "TEST1234",
+            "lines": [
+                {
+                    "product": {"barcode": "PACK001"},
+                    "qty": 2,
+                    "uom": {"unece_code": "C62"},
+                }
+            ],
+            "chatter_msg": [],
+            "doc_type": "rfq",
+        }
+        cls.soio = cls.env["sale.order.import"]
+
+    def test_order_line_packaging_import(self):
+        order = self.soio.create_order(self.parsed_order, "pricelist")
+        line = order.order_line[0]
+        self.assertEqual(line.product_packaging, self.pack1)
+        self.assertEqual(line.product_packaging_qty, 2)
+        self.assertEqual(line.product_uom_qty, 2 * 12)
+        # Change the quantity
+        self.parsed_order["lines"][0]["qty"] = 3
+        self.soio.update_order_lines(self.parsed_order, order, "pricelist")
+        self.assertEqual(line.product_uom_qty, 3 * 12)
+        self.assertEqual(line.product_packaging_qty, 3)
+        # Change the packaging and quantity
+        self.parsed_order["lines"][0]["qty"] = 5
+        self.parsed_order["lines"][0]["product"]["barcode"] = "PACK002"
+        self.soio.update_order_lines(self.parsed_order, order, "pricelist")
+        self.assertEqual(line.product_packaging, self.pack2)
+        self.assertEqual(line.product_uom_qty, 5 * 3)
+        self.assertEqual(line.product_packaging_qty, 5)
+        # Remove the packaging
+        self.parsed_order["lines"][0]["product"]["code"] = "FURN_8888"
+        self.parsed_order["lines"][0]["product"]["barcode"] = ""
+        self.soio.update_order_lines(self.parsed_order, order, "pricelist")
+        self.assertFalse(line.product_packaging)
+        self.assertEqual(line.product_uom_qty, 5)
+        self.assertEqual(line.product_packaging_qty, False)
+        # Add the packaging again
+        self.parsed_order["lines"][0]["qty"] = 1
+        self.parsed_order["lines"][0]["product"]["barcode"] = "PACK001"
+        self.soio.update_order_lines(self.parsed_order, order, "pricelist")
+        self.assertEqual(line.product_packaging, self.pack1)
+        self.assertEqual(line.product_uom_qty, 1 * 12)
+        self.assertEqual(line.product_packaging_qty, 1)

--- a/sale_order_packaging_import/wizard/__init__.py
+++ b/sale_order_packaging_import/wizard/__init__.py
@@ -1,0 +1,1 @@
+from . import sale_order_import

--- a/sale_order_packaging_import/wizard/sale_order_import.py
+++ b/sale_order_packaging_import/wizard/sale_order_import.py
@@ -1,0 +1,32 @@
+# Copyright 2022 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+from odoo import api, models
+
+
+class SaleOrderImport(models.TransientModel):
+    _inherit = "sale.order.import"
+
+    @api.model
+    def _prepare_create_order_line(
+        self, product, uom, order, import_line, price_source
+    ):
+        vals = super()._prepare_create_order_line(
+            product, uom, order, import_line, price_source
+        )
+        packaging_code = import_line["product"].get("barcode")
+        if packaging_code:
+            packaging = product.packaging_ids.filtered(
+                lambda pack: pack.barcode == packaging_code
+            )
+            if packaging:
+                vals["product_packaging"] = packaging.id
+                vals["product_uom_qty"] = 0
+                vals["product_packaging_qty"] = import_line["qty"]
+        return vals
+
+    def _prepare_update_order_line_vals(self, change_dict):
+        vals = super()._prepare_update_order_line_vals(change_dict)
+        if "packaging" in change_dict:
+            vals.update({"product_packaging": change_dict["packaging"][1]})
+        return vals

--- a/setup/sale_order_packaging_import/odoo/addons/sale_order_packaging_import
+++ b/setup/sale_order_packaging_import/odoo/addons/sale_order_packaging_import
@@ -1,0 +1,1 @@
+../../../../sale_order_packaging_import

--- a/setup/sale_order_packaging_import/setup.py
+++ b/setup/sale_order_packaging_import/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
This module extends the `sale_order_import` module to include on the sale order line
the import of the product packaging and uses the quantity imported has the
the packaging quantity.

Also two function hooks have been added on the depending modules