### PR TITLE
[REF] account_e-invoice_generate : do not exclude odoo modules, to avoid runboat failing

### DIFF
--- a/account_e-invoice_generate/__manifest__.py
+++ b/account_e-invoice_generate/__manifest__.py
@@ -12,7 +12,6 @@
     'author': 'Akretion,Odoo Community Association (OCA)',
     'website': 'https://github.com/OCA/edi',
     'depends': ['account'],
-    'excludes': ['account_facturx'],
     'data': [
         'views/res_config_settings.xml',
     ],


### PR DESCRIPTION
Ref : https://github.com/OCA/l10n-france/pull/348

in new runboat workflow it is not possible to excludes modules. 

I propose to remove the excludes key in v12. 

note : the excludes key has been removed in V14. (a simple text in written in ``INSTALL.rst`` file to mention the incompability.)

https://github.com/OCA/edi/commit/5bbe32c393ea634f5302b1b2f857ed71412ed7ac#diff-088676fd4df173919ef4de5a3e183389c83de6614fdfc2d5b0ef1cb56853c04aL15 