### PR TITLE
[14.0][IMP] oca_edi: child exchange compute file from parent

### DIFF
--- a/edi_oca/migrations/14.0.1.9.0/pre-migration.py
+++ b/edi_oca/migrations/14.0.1.9.0/pre-migration.py
@@ -1,0 +1,15 @@
+# Copyright 2022 Téo Goddet
+
+from openupgradelib import openupgrade
+
+_column_renames = {
+    "edi_exchange_record": [("exchange_file", "real_exchange_file")],
+}
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    if not openupgrade.column_exists(
+        env.cr, "edi_exchange_record", "real_exchange_file"
+    ):
+        openupgrade.rename_columns(env.cr, _column_renames)

--- a/edi_oca/models/edi_backend.py
+++ b/edi_oca/models/edi_backend.py
@@ -383,7 +383,7 @@ class EDIBackend(models.Model):
             ("type_id.exchange_file_auto_generate", "=", True),
             ("type_id.direction", "=", "output"),
             ("edi_exchange_state", "=", "new"),
-            ("exchange_file", "=", False),
+            ("has_exchange_file", "=", False),
         ]
 
     def _output_pending_records_domain(self):
@@ -567,7 +567,7 @@ class EDIBackend(models.Model):
             ("backend_id", "=", self.id),
             ("type_id.direction", "=", "input"),
             ("edi_exchange_state", "=", "input_pending"),
-            ("exchange_file", "=", False),
+            ("has_exchange_file", "=", False),
         ]
 
     def _input_pending_process_records_domain(self):


### PR DESCRIPTION
As discussed here : https://github.com/OCA/edi/pull/506#discussion_r793324325
When a child exchange has not an explicit file set, we compute it from the parents, it allow to handle cases where a single document exchange need to create multiple objects. (Such as multiple bank statement in a single xml file)