### PR TITLE
[FIX] sale_order_import_ubl_http: pre-commit issue

### DIFF
--- a/sale_order_import_ubl_http/tests/test_sale_order_import_endpoint.py
+++ b/sale_order_import_ubl_http/tests/test_sale_order_import_endpoint.py
@@ -9,7 +9,7 @@ from odoo import tools
 from odoo.exceptions import UserError
 from odoo.tests.common import SingleTransactionCase
 
-from odoo.addons.sale_order_import_ubl_http.controllers.main import ImportController
+from ..controllers.main import ImportController
 
 
 class TestSaleOrderImportEndpoint(SingleTransactionCase):


### PR DESCRIPTION
In pre-commit for https://github.com/OCA/edi/pull/323 we ran into:

```
sale_order_import_ubl_http/tests/test_sale_order_import_endpoint.py:12: [W7950(odoo-addons-relative-import), ] Same Odoo module absolute import. You should use relative import with "." instead of "openerp.addons.sale_order_import_ubl_http"
```

Which makes it turn red. This fixes that issue.