### PR TITLE
[14.0] edi_sale_order_import: misc improvements

### DIFF
--- a/edi_oca/__manifest__.py
+++ b/edi_oca/__manifest__.py
@@ -8,7 +8,7 @@
     Define backends, exchange types, exchange records,
     basic automation and views for handling EDI exchanges.
     """,
-    "version": "14.0.1.8.2",
+    "version": "14.0.1.8.3",
     "website": "https://github.com/OCA/edi",
     "development_status": "Beta",
     "license": "LGPL-3",

--- a/edi_oca/templates/exchange_chatter_msg.xml
+++ b/edi_oca/templates/exchange_chatter_msg.xml
@@ -9,7 +9,7 @@
             <span class="edi-exchange-ref">
                 <strong>EDI exchange:</strong>
                 <a
-                    t-attf-href="/web#id={exchange_record.id}&amp;model={exchange_record._name}&amp;view_type=form"
+                    t-attf-href="/web#id=#{exchange_record.id}&amp;model=#{exchange_record._name}&amp;view_type=form"
                     t-att-data-oe-model="exchange_record._name"
                     t-att-data-oe-id="exchange_record.id"
                 >

--- a/edi_sale_order_import/__manifest__.py
+++ b/edi_sale_order_import/__manifest__.py
@@ -13,4 +13,5 @@
     "maintainers": ["simahawk"],
     "depends": ["edi_oca", "sale_order_import"],
     "auto_install": True,
+    "data": ["templates/exchange_chatter_msg.xml"],
 }

--- a/edi_sale_order_import/__manifest__.py
+++ b/edi_sale_order_import/__manifest__.py
@@ -5,7 +5,7 @@
 {
     "name": "EDI Sale order import",
     "summary": """Plug sale_order_import into EDI machinery.""",
-    "version": "14.0.1.0.1",
+    "version": "14.0.1.1.0",
     "development_status": "Alpha",
     "license": "AGPL-3",
     "website": "https://github.com/OCA/edi",

--- a/edi_sale_order_import/components/process.py
+++ b/edi_sale_order_import/components/process.py
@@ -49,7 +49,7 @@ class EDIExchangeSOInput(Component):
 
     @api.model
     def _get_default_price_source(self):
-        return "pricelist"
+        return self.settings.get("price_source", "pricelist")
 
     def _order_should_be_confirmed(self):
         return self.settings.get("confirm_order", False)

--- a/edi_sale_order_import/components/process.py
+++ b/edi_sale_order_import/components/process.py
@@ -8,8 +8,6 @@ from odoo.exceptions import UserError
 
 from odoo.addons.component.core import Component
 
-# TODO: add tests
-
 
 class EDIExchangeSOInput(Component):
     """Process sale orders."""
@@ -25,20 +23,19 @@ class EDIExchangeSOInput(Component):
     def process(self):
         wiz = self._setup_wizard()
         res = wiz.import_order_button()
-        action_xmlid = res["xml_id"]
-        # TODO: I don't really like that we have to check for the action.
-        # `sale.order.import` should be refactored w/ proper methods that are reusable.
-        if action_xmlid == "sale_order_import.sale_order_import_action":
-            raise UserError(_("Sales order has already been imported before"))
-        elif action_xmlid == "sale.action_quotations":
+        if wiz.state == "update" and wiz.sale_id:
+            order = wiz.sale_id
+            msg = _("Sales order has already been imported before")
+            self._handle_existing_order(order, msg)
+            raise UserError(msg)
+        else:
             order_id = res["res_id"]
             order = self.env["sale.order"].browse(order_id)
             if self._order_should_be_confirmed():
                 order.action_confirm()
             self.exchange_record.sudo()._set_related_record(order)
-            return _("Sales order {} created").format(order.name)
-        else:
-            raise UserError(_("Something went wrong with the importing wizard."))
+            return _("Sales order %s created") % order.name
+        raise UserError(_("Something went wrong with the importing wizard."))
 
     def _setup_wizard(self):
         """Init a `sale.order.import` instance for current record."""
@@ -56,3 +53,21 @@ class EDIExchangeSOInput(Component):
 
     def _order_should_be_confirmed(self):
         return self.settings.get("confirm_order", False)
+
+    def _handle_existing_order(self, order, message):
+        prev_record = self._get_previous_record(order)
+        self.exchange_record.message_post_with_view(
+            "edi_sale_order_import.message_already_imported",
+            values={
+                "order": order,
+                "prev_record": prev_record,
+                "message": message,
+                "level": "info",
+            },
+            subtype_id=self.env.ref("mail.mt_note").id,
+        )
+
+    def _get_previous_record(self, order):
+        return self.env["edi.exchange.record"].search(
+            [("model", "=", "sale.order"), ("res_id", "=", order.id)], limit=1
+        )

--- a/edi_sale_order_import/templates/exchange_chatter_msg.xml
+++ b/edi_sale_order_import/templates/exchange_chatter_msg.xml
@@ -14,7 +14,7 @@
             <span class="order-ref">
                 <strong>Order:</strong>
                 <a
-                    t-attf-href="/web#id={order.id}&amp;model={order._name}&amp;view_type=form"
+                    t-attf-href="/web#id=#{order.id}&amp;model=#{order._name}&amp;view_type=form"
                     t-att-data-oe-model="order._name"
                     t-att-data-oe-id="order.id"
                 >
@@ -25,7 +25,7 @@
             <span class="edi-exchange-ref" t-if="prev_record">
                 <strong>Previous record:</strong>
                 <a
-                    t-attf-href="/web#id={prev_record.id}&amp;model={prev_record._name}&amp;view_type=form"
+                    t-attf-href="/web#id=#{prev_record.id}&amp;model=#{prev_record._name}&amp;view_type=form"
                     t-att-data-oe-model="prev_record._name"
                     t-att-data-oe-id="prev_record.id"
                 >

--- a/edi_sale_order_import/templates/exchange_chatter_msg.xml
+++ b/edi_sale_order_import/templates/exchange_chatter_msg.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+    <template id="message_already_imported">
+        <t
+            t-set="message_color_klass"
+            t-value="{'error': 'text-danger', 'warning': 'text-warning'}"
+        />
+        <p t-attf-class="edi-exchange level-#{level}">
+            <span t-attf-class="exchange-message #{message_color_klass.get(level)}">
+                <strong>Message:</strong>
+                <span t-esc="message" />
+            </span>
+            <br />
+            <span class="order-ref">
+                <strong>Order:</strong>
+                <a
+                    t-attf-href="/web#id={order.id}&amp;model={order._name}&amp;view_type=form"
+                    t-att-data-oe-model="order._name"
+                    t-att-data-oe-id="order.id"
+                >
+                    <span t-field="order.display_name" />
+                </a>
+            </span>
+            <br />
+            <span class="edi-exchange-ref" t-if="prev_record">
+                <strong>Previous record:</strong>
+                <a
+                    t-attf-href="/web#id={prev_record.id}&amp;model={prev_record._name}&amp;view_type=form"
+                    t-att-data-oe-model="prev_record._name"
+                    t-att-data-oe-id="prev_record.id"
+                >
+                    <span t-field="prev_record.display_name" />
+                </a>
+            </span>
+        </p>
+    </template>
+</odoo>

--- a/edi_sale_order_import/tests/__init__.py
+++ b/edi_sale_order_import/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_process

--- a/edi_sale_order_import/tests/test_process.py
+++ b/edi_sale_order_import/tests/test_process.py
@@ -1,0 +1,127 @@
+# Copyright 2022 Camptocamp SA
+# @author: Simone Orsi <simahawk@gmail.com>
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+import base64
+import textwrap
+
+import mock
+
+from odoo import exceptions
+
+from odoo.addons.component.tests.common import SavepointComponentCase
+from odoo.addons.edi_oca.tests.common import EDIBackendTestMixin
+
+
+class TestProcessComponent(SavepointComponentCase, EDIBackendTestMixin):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.backend = cls._get_backend()
+        cls.exc_type = cls._create_exchange_type(
+            name="Test SO import",
+            code="test_so_import",
+            direction="input",
+            exchange_file_ext="xml",
+            exchange_filename_pattern="{record.identifier}-{type.code}-{dt}",
+            backend_id=cls.backend.id,
+            advanced_settings_edit=textwrap.dedent(
+                """
+            components:
+                process:
+                    usage: input.process.sale.order
+            sale_order_import:
+                wiz_ctx:
+                    random_key: custom
+            """
+            ),
+        )
+        cls.record = cls.backend.create_record("test_so_import", {})
+        cls.record._set_file_content(b"<fake><order></order></fake>")
+        cls.wiz_model = cls.env["sale.order.import"]
+
+    def test_lookup(self):
+        comp = self.backend._get_component(self.record, "process")
+        self.assertEqual(comp._name, "edi.input.sale.order.process")
+
+    def test_wizard_setup(self):
+        comp = self.backend._get_component(self.record, "process")
+        with mock.patch.object(
+            type(self.wiz_model), "order_file_change"
+        ) as md_onchange:
+            wiz = comp._setup_wizard()
+            self.assertEqual(wiz._name, self.wiz_model._name)
+            self.assertEqual(wiz.env.context["random_key"], "custom")
+            self.assertEqual(
+                base64.b64decode(wiz.order_file), b"<fake><order></order></fake>"
+            )
+            self.assertEqual(wiz.order_filename, self.record.exchange_filename)
+            self.assertEqual(wiz.price_source, "pricelist")
+            md_onchange.assert_called()
+
+    def test_settings(self):
+        self.exc_type.advanced_settings_edit = textwrap.dedent(
+            """
+            components:
+                process:
+                    usage: input.process.sale.order
+            sale_order_import:
+                price_source: order
+                confirm_order: true
+            """
+        )
+        comp = self.backend._get_component(self.record, "process")
+        self.assertEqual(comp._get_default_price_source(), "order")
+        self.assertTrue(comp._order_should_be_confirmed())
+
+    def test_existing_order(self):
+        order = self.env["sale.order"].create(
+            {"partner_id": self.env["res.partner"].search([], limit=1).id}
+        )
+        comp = self.backend._get_component(self.record, "process")
+        m1 = mock.patch.object(type(self.wiz_model), "order_file_change")
+        m2 = mock.patch.object(type(self.wiz_model), "import_order_button")
+        m3 = mock.patch.object(
+            type(self.wiz_model),
+            "sale_id",
+            new_callable=mock.PropertyMock,
+        )
+        m4 = mock.patch.object(
+            type(self.wiz_model),
+            "state",
+            new_callable=mock.PropertyMock,
+        )
+        rec_msgs = self.record.message_ids
+        # Simulate the wizard detected an existing order state
+        with m1 as md_onchange, m2 as md_btn, m3 as md_sale_id, m4 as md_state:
+            md_sale_id.return_value = order
+            md_state.return_value = "update"
+            with self.assertRaisesRegex(
+                exceptions.UserError, "Sales order has already been imported before"
+            ):
+                comp.process()
+                md_onchange.assert_called()
+                md_btn.assert_called()
+        new_msg = self.record.message_ids - rec_msgs
+        self.assertIn("Sales order has already been imported before", new_msg.body)
+        self.assertIn(
+            f"/web#id={order.id}&amp;model=sale.order&amp;view_type=form", new_msg.body
+        )
+
+    def test_new_order(self):
+        order = self.env["sale.order"].create(
+            {"partner_id": self.env["res.partner"].search([], limit=1).id}
+        )
+        comp = self.backend._get_component(self.record, "process")
+        mock1 = mock.patch.object(type(self.wiz_model), "order_file_change")
+        mock2 = mock.patch.object(type(self.wiz_model), "import_order_button")
+        self.assertFalse(self.record.record)
+        # Simulate the wizard detected an existing order state
+        with mock1 as md_onchange, mock2 as md_btn:
+            md_btn.return_value = {"res_id": order.id}
+            res = comp.process()
+            md_onchange.assert_called()
+            md_btn.assert_called()
+            self.assertEqual(res, f"Sales order {order.name} created")
+
+        self.assertEqual(self.record.record, order)


### PR DESCRIPTION
See atomic commits for details.
Most important change:

[edi_sale_order_import: improve result handling](https://github.com/OCA/edi/commit/f11a82a9f9f1870c89ad7c992621268c4644aa20) 

* stop using the action to check, use the state
* when order already exists post a msg w/ references
* fix translation for order created msg

**TODO**

- [x] add tests