### PR TITLE
[FIX] edi_oca: Restore removed functions

### DIFF
--- a/edi_oca/data/job_function.xml
+++ b/edi_oca/data/job_function.xml
@@ -24,4 +24,25 @@
         <field name="method">exchange_create_ack_record</field>
         <field name="channel_id" ref="channel_edi_exchange" />
     </record>
+    <!-- TO be removed on 16.0 -->
+    <record id="job_edi_backend_record_generate" model="queue.job.function">
+        <field name="model_id" ref="model_edi_backend" />
+        <field name="method">exchange_generate</field>
+        <field name="channel_id" ref="channel_edi_exchange" />
+    </record>
+    <record id="job_edi_backend_record_send" model="queue.job.function">
+        <field name="model_id" ref="model_edi_backend" />
+        <field name="method">exchange_send</field>
+        <field name="channel_id" ref="channel_edi_exchange" />
+    </record>
+    <record id="job_edi_backend_record_receive" model="queue.job.function">
+        <field name="model_id" ref="model_edi_backend" />
+        <field name="method">exchange_receive</field>
+        <field name="channel_id" ref="channel_edi_exchange" />
+    </record>
+    <record id="job_edi_backend_record_process" model="queue.job.function">
+        <field name="model_id" ref="model_edi_backend" />
+        <field name="method">exchange_process</field>
+        <field name="channel_id" ref="channel_edi_exchange" />
+    </record>
 </odoo>

--- a/edi_oca/models/edi_backend.py
+++ b/edi_oca/models/edi_backend.py
@@ -179,6 +179,14 @@ class EDIBackend(models.Model):
             ("backend_id", "=", self.id),
         ]
 
+    def _delay_action(self, rec):
+        # TODO: Remove this on 16.0
+        _logger.warning(
+            "This function has been replaced by rec.with_delay(). "
+            "It will be removed on 16.0."
+        )
+        return self.with_delay(**rec._job_delay_params())
+
     def exchange_generate(self, exchange_record, store=True, force=False, **kw):
         """Generate output content for given exchange record.
 


### PR DESCRIPTION
We want to keep functionality on the same version. It is marked to remove for 16

#540 