### PR TITLE
[FIX] account_invoice_facturx fix wrong hs_code

### DIFF
--- a/account_invoice_facturx/models/account_move.py
+++ b/account_invoice_facturx/models/account_move.py
@@ -628,18 +628,16 @@ class AccountMove(models.Model):
                     product_charact, ns["ram"] + "Value"
                 )
                 product_charact_value.text = attrib_value
-            if (
-                hasattr(product, "hs_code_id")
-                and product.type in ("product", "consu")
-                and product.get_hs_code_recursively()
-            ):
-                product_classification = etree.SubElement(
-                    trade_product, ns["ram"] + "DesignatedProductClassification"
-                )
-                product_classification_code = etree.SubElement(
-                    product_classification, ns["ram"] + "ClassCode", listID="HS"
-                )
-                product_classification_code.text = product.hs_code_id.local_code
+            if hasattr(product, "hs_code_id") and product.type in ("product", "consu"):
+                hs_code = product.get_hs_code_recursively()
+                if hs_code:
+                    product_classification = etree.SubElement(
+                        trade_product, ns["ram"] + "DesignatedProductClassification"
+                    )
+                    product_classification_code = etree.SubElement(
+                        product_classification, ns["ram"] + "ClassCode", listID="HS"
+                    )
+                    product_classification_code.text = hs_code.local_code
             # origin_country_id and hs_code_id are provided
             # by the OCA module product_harmonized_system
             if (


### PR DESCRIPTION
@alexis-via
In case  that the hs_code have been found recursively, the invoice generation fail because we use the hs code from the product "product.hs_code_id.local_code"