### PR TITLE
[15.0] [IMP] edi_storage_oca: add a common directory_path per backend

### DIFF
--- a/edi_storage_oca/components/base.py
+++ b/edi_storage_oca/components/base.py
@@ -36,9 +36,8 @@ class EDIStorageComponentMixin(AbstractComponent):
         """
         assert direction in ("input", "output")
         assert state in ("pending", "done", "error")
-        return PurePath(
-            (self.backend[direction + "_dir_" + state] or "").strip().rstrip("/")
-        )
+        path = self.backend._storage_full_path(self.backend[f"{direction}_dir_{state}"])
+        return PurePath((path or "").strip().rstrip("/"))
 
     def _remote_file_path(self, direction, state, filename):
         """Return remote file path by direction and state for give filename.

--- a/edi_storage_oca/models/edi_backend.py
+++ b/edi_storage_oca/models/edi_backend.py
@@ -12,8 +12,8 @@ _logger = logging.getLogger(__name__)
 
 
 class EDIBackend(models.Model):
-
-    _inherit = "edi.backend"
+    _name = "edi.backend"
+    _inherit = ["edi.backend", "server.env.mixin"]
 
     storage_id = fields.Many2one(
         string="Storage backend",
@@ -62,6 +62,12 @@ class EDIBackend(models.Model):
     )
 
     _storage_actions = ("check", "send", "receive")
+
+    @property
+    def _server_env_fields(self):
+        res = {"directory_path": {}}
+        res.update(super()._server_env_fields)
+        return res
 
     def _get_component_usage_candidates(self, exchange_record, key):
         candidates = super()._get_component_usage_candidates(exchange_record, key)

--- a/edi_storage_oca/readme/CONTRIBUTORS.rst
+++ b/edi_storage_oca/readme/CONTRIBUTORS.rst
@@ -1,3 +1,4 @@
 * Simone Orsi <simahawk@gmail.com>
 * Foram Shah <foram.shah@initos.com>
 * Lois Rilo <lois.rilo@forgeflow.com>
+* Iván Todorovich <ivan.todorovich@camptocamp.com>

--- a/edi_storage_oca/tests/test_components_base.py
+++ b/edi_storage_oca/tests/test_components_base.py
@@ -27,6 +27,30 @@ class EDIStorageComponentTestCase(TestEDIStorageBase):
         with self.assertRaises(AssertionError):
             self.checker._remote_file_path("input", "WHATEVER", "foo.csv")
 
+    def test_remote_file_path_with_directory_path(self):
+        self.backend.write(
+            {
+                "directory_path": "demo",
+                "input_dir_pending": "in/pending",
+                "input_dir_done": "in/done",
+                "input_dir_error": "in/error",
+                "output_dir_pending": "out/pending",
+                "output_dir_done": "out/done",
+                "output_dir_error": "out/error",
+            }
+        )
+        to_test = (
+            (("input", "pending", "foo.csv"), "demo/in/pending/foo.csv"),
+            (("input", "done", "foo.csv"), "demo/in/done/foo.csv"),
+            (("input", "error", "foo.csv"), "demo/in/error/foo.csv"),
+            (("output", "pending", "foo.csv"), "demo/out/pending/foo.csv"),
+            (("output", "done", "foo.csv"), "demo/out/done/foo.csv"),
+            (("output", "error", "foo.csv"), "demo/out/error/foo.csv"),
+        )
+        for _args, expected in to_test:
+            path_obj = self.checker._remote_file_path(*_args)
+            self.assertEqual(path_obj.as_posix(), expected)
+
     def test_get_remote_file(self):
         with mock.patch(STORAGE_BACKEND_MOCK_PATH + ".get") as mocked:
             self.checker._get_remote_file("pending")

--- a/edi_storage_oca/tests/test_edi_storage_listener.py
+++ b/edi_storage_oca/tests/test_edi_storage_listener.py
@@ -53,8 +53,13 @@ class EDIBackendTestCase(EDIBackendCommonComponentRegistryTestCase):
             self.record.action_exchange_process()
             storage, from_dir_str, to_dir_str, filename = self.fake_move_args
             self.assertEqual(storage, self.backend.storage_id)
-            self.assertEqual(from_dir_str, self.backend.input_dir_pending)
-            self.assertEqual(to_dir_str, self.backend.input_dir_done)
+            self.assertEqual(
+                from_dir_str,
+                self.backend._storage_full_path(self.backend.input_dir_pending),
+            )
+            self.assertEqual(
+                to_dir_str, self.backend._storage_full_path(self.backend.input_dir_done)
+            )
             self.assertEqual(filename, self.record.exchange_filename)
 
     def test_02_process_record_with_error(self):
@@ -66,6 +71,12 @@ class EDIBackendTestCase(EDIBackendCommonComponentRegistryTestCase):
             ).action_exchange_process()
             storage, from_dir_str, to_dir_str, filename = self.fake_move_args
             self.assertEqual(storage, self.backend.storage_id)
-            self.assertEqual(from_dir_str, self.backend.input_dir_pending)
-            self.assertEqual(to_dir_str, self.backend.input_dir_error)
+            self.assertEqual(
+                from_dir_str,
+                self.backend._storage_full_path(self.backend.input_dir_pending),
+            )
+            self.assertEqual(
+                to_dir_str,
+                self.backend._storage_full_path(self.backend.input_dir_error),
+            )
             self.assertEqual(filename, self.record.exchange_filename)

--- a/edi_storage_oca/views/edi_backend_views.xml
+++ b/edi_storage_oca/views/edi_backend_views.xml
@@ -8,12 +8,19 @@
                 <page name="storage_config" string="Storage">
                     <group name="storage_config">
                         <field name="storage_id" />
-                        <field name="input_dir_pending" />
-                        <field name="input_dir_done" />
-                        <field name="input_dir_error" />
-                        <field name="output_dir_pending" />
-                        <field name="output_dir_done" />
-                        <field name="output_dir_error" />
+                        <field name="directory_path" />
+                    </group>
+                    <group name="storage_dir">
+                        <group name="storage_dir_input" string="Input paths">
+                            <field name="input_dir_pending" string="Pending" />
+                            <field name="input_dir_done" string="Done" />
+                            <field name="input_dir_error" string="Error" />
+                        </group>
+                        <group name="storage_dir_output" string="Output paths">
+                            <field name="output_dir_pending" string="Pending" />
+                            <field name="output_dir_done" string="Done" />
+                            <field name="output_dir_error" string="Error" />
+                        </group>
                     </group>
                 </page>
             </notebook>


### PR DESCRIPTION
And make it configurable through server env.

This gives more flexibility to configure paths through env.

Previous to this commit, the only way to do that was by configuring the `storage.backend.directory_path`, but then it means we can't reuse the `storage.backend` for multiple `edi.backend` records if their relative paths don't share the same root.. 

It's usage is optional.