### PR TITLE
[FIX][14.0] account_invoice_import_simple_pdf: use fix version of dateparser

### DIFF
--- a/account_invoice_import_simple_pdf/__manifest__.py
+++ b/account_invoice_import_simple_pdf/__manifest__.py
@@ -14,7 +14,7 @@
     "depends": ["account_invoice_import"],
     # "excludes": ["account_invoice_import_invoice2data"],
     "external_dependencies": {
-        "python": ["pdfplumber", "regex", "dateparser"],
+        "python": ["pdfplumber", "regex", "dateparser==1.1.1"],
         "deb": ["libmupdf-dev", "mupdf", "mupdf-tools", "poppler-utils"],
     },
     "data": [

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 # generated from manifests external_dependencies
-dateparser
 dateparser==1.1.1
 factur-x
 invoice2data


### PR DESCRIPTION
FIX #569

Prevent double requirements in the requirements.txt file 