### PR TITLE
[15.0] edi_storage: path configurable by type and param

### DIFF
--- a/edi_storage_oca/components/base.py
+++ b/edi_storage_oca/components/base.py
@@ -1,10 +1,13 @@
 # Copyright 2020 ACSONE
+# Copyright 2022 Camptocamp
 # @author: Simone Orsi <simahawk@gmail.com>
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
-
+import logging
 from pathlib import PurePath
 
 from odoo.addons.component.core import AbstractComponent
+
+_logger = logging.getLogger(__file__)
 
 
 class EDIStorageComponentMixin(AbstractComponent):
@@ -48,7 +51,21 @@ class EDIStorageComponentMixin(AbstractComponent):
         :param filename: string for file name
         :return: PurePath object
         """
+        _logger.warning(
+            "Call of deprecated function `_remote_file_path`. "
+            "Please use `_get_remote_file_path` instead.",
+        )
         return self._dir_by_state(direction, state) / filename.strip("/ ")
+
+    def _get_remote_file_path(self, state, filename=None):
+        """Retrieve remote path for current exchange record."""
+        filename = filename or self.exchange_record.exchange_filename
+        direction = self.exchange_record.direction
+        directory = self._dir_by_state(direction, state).as_posix()
+        path = self.exchange_record.type_id._storage_fullpath(
+            directory=directory, filename=filename
+        )
+        return path
 
     def _get_remote_file(self, state, filename=None, binary=False):
         """Get file for current exchange_record in the given destination state.
@@ -57,8 +74,7 @@ class EDIStorageComponentMixin(AbstractComponent):
         :param filename: custom file name, exchange_record filename used by default
         :return: remote file content as string
         """
-        filename = filename or self.exchange_record.exchange_filename
-        path = self._remote_file_path(self.exchange_record.direction, state, filename)
+        path = self._get_remote_file_path(state, filename=filename)
         try:
             # TODO: support match via pattern (eg: filename-prefix-*)
             # otherwise is impossible to retrieve input files and acks

--- a/edi_storage_oca/components/listener.py
+++ b/edi_storage_oca/components/listener.py
@@ -34,9 +34,15 @@ class EdiStorageListener(Component):
         res = False
         if record.direction == "input" and storage:
             file = record.exchange_filename
-            pending_dir = record.backend_id.input_dir_pending
-            done_dir = record.backend_id.input_dir_done
-            error_dir = record.backend_id.input_dir_error
+            pending_dir = record.type_id._storage_fullpath(
+                record.backend_id.input_dir_pending
+            ).as_posix()
+            done_dir = record.type_id._storage_fullpath(
+                record.backend_id.input_dir_done
+            ).as_posix()
+            error_dir = record.type_id._storage_fullpath(
+                record.backend_id.input_dir_error
+            ).as_posix()
             if not done_dir:
                 return res
             res = self._move_file(storage, pending_dir, done_dir, file)
@@ -52,8 +58,12 @@ class EdiStorageListener(Component):
         res = False
         if record.direction == "input" and storage:
             file = record.exchange_filename
-            pending_dir = record.backend_id.input_dir_pending
-            error_dir = record.backend_id.input_dir_error
+            pending_dir = record.type_id._storage_fullpath(
+                record.backend_id.input_dir_pending
+            ).as_posix()
+            error_dir = record.type_id._storage_fullpath(
+                record.backend_id.input_dir_error
+            ).as_posix()
             if error_dir:
                 res = self._move_file(storage, pending_dir, error_dir, file)
         return res

--- a/edi_storage_oca/components/receive.py
+++ b/edi_storage_oca/components/receive.py
@@ -14,8 +14,6 @@ class EDIStorageReceiveComponent(Component):
     _usage = "storage.receive"
 
     def receive(self):
-        direction = self.exchange_record.direction
-        filename = self.exchange_record.exchange_filename
-        path = self._remote_file_path(direction, "pending", filename)
+        path = self._get_remote_file_path("pending")
         filedata = self.storage.get(path.as_posix())
         return filedata

--- a/edi_storage_oca/components/send.py
+++ b/edi_storage_oca/components/send.py
@@ -23,11 +23,8 @@ class EDIStorageSendComponent(Component):
         if not result:
             # all good here
             return True
-
-        direction = self.exchange_record.direction
-        filename = self.exchange_record.exchange_filename
         filedata = self.exchange_record.exchange_file
-        path = self._remote_file_path(direction, "pending", filename)
+        path = self._get_remote_file_path("pending")
         self.storage.add(path.as_posix(), filedata, binary=False)
         # TODO: delegate this to generic storage backend
         # except paramiko.ssh_exception.AuthenticationException:

--- a/edi_storage_oca/models/edi_backend.py
+++ b/edi_storage_oca/models/edi_backend.py
@@ -145,16 +145,24 @@ class EDIBackend(models.Model):
         return record.identifier
 
     def _storage_get_input_filenames(self, exchange_type):
+        full_input_dir_pending = exchange_type._storage_fullpath(
+            self.input_dir_pending
+        ).as_posix()
         if not exchange_type.exchange_filename_pattern:
-            # If there is not patter, return everything
-            return self.storage_id.list_files(self.input_dir_pending)
+            # If there is not pattern, return everything
+            filenames = [
+                x
+                for x in self.storage_id.list_files(full_input_dir_pending)
+                if x.strip("/")
+            ]
+            return filenames
 
         bits = [exchange_type.exchange_filename_pattern]
         if exchange_type.exchange_file_ext:
             bits.append(r"\." + exchange_type.exchange_file_ext)
         pattern = "".join(bits)
-        full_paths = self.storage_id.find_files(pattern, self.input_dir_pending)
-        pending_path_len = len(self.input_dir_pending)
+        full_paths = self.storage_id.find_files(pattern, full_input_dir_pending)
+        pending_path_len = len(full_input_dir_pending)
         return [p[pending_path_len:].strip("/") for p in full_paths]
 
     def _storage_new_exchange_record_vals(self, file_name):

--- a/edi_storage_oca/models/edi_exchange_type.py
+++ b/edi_storage_oca/models/edi_exchange_type.py
@@ -1,6 +1,8 @@
 # Copyright 2021 ForgeFlow S.L. (https://www.forgeflow.com)
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 
+from pathlib import PurePath
+
 from odoo import fields, models
 
 
@@ -19,3 +21,42 @@ class EDIExchangeType(models.Model):
         "the files to be fetched from the pending directory in the related "
         "storage. E.g: `.*my-type-[0-9]*.\\.csv`"
     )
+
+    def _storage_path(self):
+        """Retrieve specific path for current exchange type.
+
+        In your exchange type you can pass this config:
+
+            storage:
+                # simple string
+                path: path/to/file
+
+        Or
+
+            storage:
+                # name of the param containing the path
+                path_config_param: path/to/file
+
+        Thanks to the param you could even configure it by env.
+        """
+        self.ensure_one()
+        storage_settings = self.advanced_settings.get("storage", {})
+        path = storage_settings.get("path")
+        if path:
+            return PurePath(path)
+        path_config_param = storage_settings.get("path_config_param")
+        if path_config_param:
+            icp = self.env["ir.config_parameter"].sudo()
+            path = icp.get_param(path_config_param)
+            if path:
+                return PurePath(path)
+
+    def _storage_fullpath(self, directory=None, filename=None):
+        self.ensure_one()
+        path_prefix = self._storage_path()
+        path = PurePath((directory or "").strip().rstrip("/"))
+        if path_prefix:
+            path = path_prefix / path
+        if filename:
+            path = path / filename.strip("/")
+        return path

--- a/edi_storage_oca/tests/__init__.py
+++ b/edi_storage_oca/tests/__init__.py
@@ -2,3 +2,4 @@ from . import test_edi_backend_storage
 from . import test_components_base
 from . import test_component_match
 from . import test_edi_storage_listener
+from . import test_exchange_type

--- a/edi_storage_oca/tests/test_components_base.py
+++ b/edi_storage_oca/tests/test_components_base.py
@@ -18,14 +18,16 @@ class EDIStorageComponentTestCase(TestEDIStorageBase):
             (("output", "error", "foo.csv"), "demo_out/error/foo.csv"),
         )
         for _args, expected in to_test:
-            path_obj = self.checker._remote_file_path(*_args)
+            direction, state, filename = _args
+            if direction == "input":
+                checker = self.checker_input
+            else:
+                checker = self.checker
+            path_obj = checker._get_remote_file_path(state, filename)
             self.assertEqual(path_obj.as_posix(), expected)
 
         with self.assertRaises(AssertionError):
-            self.checker._remote_file_path("WHATEVER", "error", "foo.csv")
-
-        with self.assertRaises(AssertionError):
-            self.checker._remote_file_path("input", "WHATEVER", "foo.csv")
+            self.checker_input._get_remote_file_path("WHATEVER", "foo.csv")
 
     def test_get_remote_file(self):
         with mock.patch(STORAGE_BACKEND_MOCK_PATH + ".get") as mocked:

--- a/edi_storage_oca/tests/test_exchange_type.py
+++ b/edi_storage_oca/tests/test_exchange_type.py
@@ -1,0 +1,67 @@
+# Copyright 2022 Camptocamp SA (https://www.camptocamp.com).
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+from odoo.addons.edi_oca.tests.common import EDIBackendCommonTestCase
+
+
+class EDIExchangeTypeTestCase(EDIBackendCommonTestCase):
+    def _check_test_storage_fullpath(self, wanted_fullpath, directory, filename):
+        fullpath = self.exchange_type_out._storage_fullpath(directory, filename)
+        self.assertEqual(fullpath.as_posix(), wanted_fullpath)
+
+    def _do_test_storage_fullpath(self, prefix=""):
+        # Test with no directory and no filename
+        wanted_fullpath = prefix or "."
+        self._check_test_storage_fullpath(wanted_fullpath, None, None)
+
+        # Test with directory
+        directory = "test_directory"
+        wanted_fullpath = f"{prefix}/{directory}" if prefix else directory
+        self._check_test_storage_fullpath(wanted_fullpath, directory, None)
+
+        # Test with filename
+        filename = "test_filename.csv"
+        wanted_fullpath = f"{prefix}/{filename}" if prefix else filename
+        self._check_test_storage_fullpath(wanted_fullpath, None, filename)
+
+        # Test with directory and filename
+        wanted_fullpath = (
+            f"{prefix}/{directory}/{filename}" if prefix else f"{directory}/{filename}"
+        )
+        self._check_test_storage_fullpath(wanted_fullpath, directory, filename)
+
+    def test_storage_fullpath(self):
+        """
+        Test storage fullpath defined into advanced settings.
+        Example of pattern:
+          storage:
+            # simple string
+            path: path/to/file
+            # name of the param containing the path
+            path_config_param: path/to/file
+        """
+
+        # Test without any prefix
+        self._do_test_storage_fullpath()
+
+        # Force path on advanced settings
+        prefix = "prefix/path"
+        self.exchange_type_out.advanced_settings_edit = f"""
+        storage:
+            path: {prefix}
+        """
+        self._do_test_storage_fullpath(prefix=prefix)
+
+        # Force path on advanced settings using config param, but not defined
+        self.exchange_type_out.advanced_settings_edit = """
+        storage:
+            path_config_param: prefix_path_config_param
+        """
+        self._do_test_storage_fullpath()
+
+        # Define config param
+        prefix = "prefix/path/by/config/param"
+        self.env["ir.config_parameter"].sudo().set_param(
+            "prefix_path_config_param", prefix
+        )
+        self._do_test_storage_fullpath(prefix=prefix)


### PR DESCRIPTION
Backported on https://github.com/OCA/edi/pull/578

By setting specific storage path on exchange type advanced settings, we
can configure specific path for each exchange type (input or output).

Path can also be configured by config parameters to allow to easily set
different values depending of the environment.