### PR TITLE
[15.0][FIX] edi_storage_oca: Fix errors with get done/failed directories

### DIFF
--- a/edi_storage_oca/components/base.py
+++ b/edi_storage_oca/components/base.py
@@ -1,10 +1,12 @@
 # Copyright 2020 ACSONE
 # @author: Simone Orsi <simahawk@gmail.com>
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
-
+import logging
 from pathlib import PurePath
 
 from odoo.addons.component.core import AbstractComponent
+
+_logger = logging.getLogger(__file__)
 
 
 class EDIStorageComponentMixin(AbstractComponent):
@@ -65,4 +67,19 @@ class EDIStorageComponentMixin(AbstractComponent):
             # (the date will never match)
             return self.storage.get(path.as_posix(), binary=binary)
         except FileNotFoundError:
+            _logger.info(
+                "Ignored FileNotFoundError when trying "
+                "to get file %s into path %s for state %s",
+                filename,
+                path,
+                state,
+            )
+            return None
+        except OSError:
+            _logger.info(
+                "Ignored OSError when trying to get file %s into path %s for state %s",
+                filename,
+                path,
+                state,
+            )
             return None


### PR DESCRIPTION
When trying to get done/failed directoris, if we don't found it on SFTP
server, we ignore the error.

Current implementation only ignore `FileNotFoundError`, but depending of
the SFTP server, we can have `OSError` instead of.

This PR allow to also ignore `OSError`.