### PR TITLE
[14.0] account_invoice_import: Set a specific journal

### DIFF
--- a/account_invoice_import/models/account_invoice_import_config.py
+++ b/account_invoice_import/models/account_invoice_import_config.py
@@ -50,6 +50,13 @@ class AccountInvoiceImportConfig(models.Model):
     account_analytic_id = fields.Many2one(
         "account.analytic.account", string="Analytic Account", check_company=True
     )
+    journal_id = fields.Many2one(
+        "account.journal",
+        string="Force Purchase Journal",
+        check_company=True,
+        domain="[('company_id', '=', company_id), ('type', '=', 'purchase')]",
+        help="If empty, Odoo will use the first purchase journal.",
+    )
     label = fields.Char(
         string="Force Description", help="Force supplier invoice line description"
     )
@@ -104,6 +111,7 @@ class AccountInvoiceImportConfig(models.Model):
         vals = {
             "invoice_line_method": self.invoice_line_method,
             "account_analytic": self.account_analytic_id or False,
+            "journal": self.journal_id or False,
         }
         if self.invoice_line_method == "1line_no_product":
             vals["account"] = self.account_id

--- a/account_invoice_import/readme/CONFIGURE.rst
+++ b/account_invoice_import/readme/CONFIGURE.rst
@@ -1,7 +1,7 @@
 Go to the form view of the suppliers and configure it with the following parameters:
 
 * Individual/Company: *Company*
-* the *TIN* (i.e. VAT number) is set (the VAT number is used by default when searching the supplier in the Odoo partner database)
+* the *VAT Number* (this field is used by default when searching the supplier in the Odoo partner database)
 * in the *Accounting* tab, create one or several *Invoice Import Configurations*.
 
 You can configure a mail gateway to import invoices from an email:

--- a/account_invoice_import/tests/test_invoice_import.py
+++ b/account_invoice_import/tests/test_invoice_import.py
@@ -5,9 +5,9 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 import mock
+
 from odoo import fields
 from odoo.tests.common import SavepointCase
-from odoo.tools import float_compare
 
 
 class TestInvoiceImport(SavepointCase):
@@ -154,7 +154,6 @@ class TestInvoiceImport(SavepointCase):
             )
             self.assertEqual(inv.journal_id.id, self.pur_journal2.id)
 
-
     def test_import_out_invoice(self):
         parsed_inv = {
             "type": "out_invoice",
@@ -187,7 +186,6 @@ class TestInvoiceImport(SavepointCase):
                 .with_company(self.company.id)
                 .create_invoice(parsed_inv, import_config)
             )
-            prec = inv.currency_id.rounding
             self.assertFalse(inv.currency_id.compare_amounts(inv.amount_untaxed, 30.66))
             self.assertFalse(inv.currency_id.compare_amounts(inv.amount_total, 30.97))
             self.assertEqual(

--- a/account_invoice_import/views/account_invoice_import_config.xml
+++ b/account_invoice_import/views/account_invoice_import_config.xml
@@ -47,6 +47,7 @@
                             name="label"
                             attrs="{'invisible': [('invoice_line_method', 'not in', ('1line_no_product', '1line_static_product'))]}"
                         />
+                        <field name="journal_id" />
                     </group>
                 </sheet>
             </form>
@@ -59,8 +60,19 @@
                 <field name="sequence" widget="handle" />
                 <field name="partner_id" />
                 <field name="name" />
-                <field name="company_id" groups="base.group_multi_company" />
+                <field
+                    name="company_id"
+                    groups="base.group_multi_company"
+                    optional="show"
+                />
                 <field name="invoice_line_method" />
+                <field
+                    name="account_analytic_id"
+                    groups="analytic.group_analytic_accounting"
+                    optional="show"
+                />
+                <field name="label" optional="hide" />
+                <field name="journal_id" optional="hide" />
             </tree>
         </field>
     </record>
@@ -86,6 +98,17 @@
                         name="invoice_line_method_groupby"
                         string="Method for Invoice Line"
                         context="{'group_by': 'invoice_line_method'}"
+                    />
+                    <filter
+                        name="account_analytic_groupby"
+                        string="Analytic Account"
+                        context="{'group_by': 'account_analytic_id'}"
+                        groups="analytic.group_analytic_accounting"
+                    />
+                    <filter
+                        name="journal_groupby"
+                        string="Force Purchase Journal"
+                        context="{'group_by': 'journal_id'}"
                     />
                 </group>
             </search>

--- a/account_invoice_import/wizard/account_invoice_import.py
+++ b/account_invoice_import/wizard/account_invoice_import.py
@@ -1056,15 +1056,21 @@ class AccountInvoiceImport(models.TransientModel):
                 # select first tax line
                 if mline.tax_line_id and not company_cur.is_zero(mline.amount_currency):
                     has_tax_line = True
-                    new_amount_currency = inv_cur.round(
-                        mline.amount_currency + diff_tax_amount
-                    )
+                    if mline.currency_id.compare_amounts(mline.amount_currency, 0) >= 0:
+                        new_amount_currency = inv_cur.round(
+                            mline.amount_currency + diff_tax_amount
+                        )
+                    else:
+                        new_amount_currency = inv_cur.round(
+                            mline.amount_currency - diff_tax_amount
+                        )
                     invoice.message_post(
                         body=_(
-                            "The tax amount has been forced to %s "
-                            "(amount computed by Odoo was: %s)."
+                            "The <b>tax amount</b> for tax %s has been <b>forced</b> "
+                            "to %s (amount computed by Odoo was: %s)."
                         )
                         % (
+                            mline.tax_line_id.display_name,
                             format_amount(
                                 self.env, new_amount_currency, invoice.currency_id
                             ),


### PR DESCRIPTION
You can now set a specific journal, either via the
account.invoice.import.config or by the pivot dict.
Fix setting invoice_date_due via pivot dict.
Improve multi-company handling in tests.
Add test for setting journal via pivot dict.
Add more checks in test.