### PR TITLE
[14.0] Add lines management to create multiline invoices

### DIFF
--- a/account_invoice_import_invoice2data/tests/test_invoice_import.py
+++ b/account_invoice_import_invoice2data/tests/test_invoice_import.py
@@ -3,10 +3,13 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 import base64
+import logging
 
 from odoo import fields
 from odoo.tests.common import TransactionCase
 from odoo.tools import file_open, float_compare
+
+_logger = logging.getLogger(__name__)
 
 
 class TestInvoiceImport(TransactionCase):
@@ -27,7 +30,82 @@ class TestInvoiceImport(TransactionCase):
         )
         internet_product.supplier_taxes_id = [(6, 0, [frtax.id])]
 
-    def test_import_free_invoice(self):
+    def test_import_free_1line_invoice(self):
+        filename = "invoice_free_fiber_201507.pdf"
+        f = file_open("account_invoice_import_invoice2data/tests/pdf/" + filename, "rb")
+        pdf_file = f.read()
+        pdf_file_b64 = base64.b64encode(pdf_file)
+        wiz = self.env["account.invoice.import"].create(
+            {
+                "invoice_file": pdf_file_b64,
+                "invoice_filename": filename,
+            }
+        )
+        f.close()
+        wiz.import_invoice()
+        # Check result of invoice creation
+        invoices = self.env["account.move"].search(
+            [
+                ("state", "=", "draft"),
+                ("move_type", "=", "in_invoice"),
+                ("ref", "=", "562044387"),
+            ]
+        )
+        _logger.warning(len(self.env["account.move"].search([])))
+        self.assertEqual(len(invoices), 1)
+        inv = invoices[0]
+        self.assertEqual(inv.move_type, "in_invoice")
+        self.assertEqual(fields.Date.to_string(inv.invoice_date), "2015-07-02")
+        self.assertEqual(
+            inv.partner_id, self.env.ref("account_invoice_import_invoice2data.free")
+        )
+        self.assertEqual(inv.journal_id.type, "purchase")
+        self.assertEqual(float_compare(inv.amount_total, 29.99, precision_digits=2), 0)
+        self.assertEqual(
+            float_compare(inv.amount_untaxed, 24.99, precision_digits=2), 0
+        )
+        self.assertEqual(len(inv.invoice_line_ids), 1)
+        iline = inv.invoice_line_ids[0]
+        self.assertEqual(iline.name, "Fiber optic access at the main office")
+        self.assertEqual(
+            iline.product_id,
+            self.env.ref("account_invoice_import_invoice2data.internet_access"),
+        )
+        self.assertEqual(float_compare(iline.quantity, 1.0, precision_digits=0), 0)
+        self.assertEqual(float_compare(iline.price_unit, 24.99, precision_digits=2), 0)
+
+        # Prepare data for next test i.e. invoice update
+        # (we re-use the invoice created by the first import !)
+        inv.write(
+            {
+                "invoice_date": False,
+                "ref": False,
+            }
+        )
+
+        # New import with update of an existing draft invoice
+        wiz2 = self.env["account.invoice.import"].create(
+            {
+                "invoice_file": pdf_file_b64,
+                "invoice_filename": "invoice_free_fiber_201507.pdf",
+            }
+        )
+        action = wiz2.import_invoice()
+        self.assertEqual(action["res_model"], "account.invoice.import")
+        # Choose to update the existing invoice
+        wiz2.update_invoice()
+        invoices = self.env["account.move"].search(
+            [
+                ("state", "=", "draft"),
+                ("move_type", "=", "in_invoice"),
+                ("ref", "=", "562044387"),
+            ]
+        )
+        self.assertEqual(len(invoices), 1)
+        inv = invoices[0]
+        self.assertEqual(fields.Date.to_string(inv.invoice_date), "2015-07-02")
+
+    def test_import_free_nline_invoice(self):
         filename = "invoice_free_fiber_201507.pdf"
         f = file_open("account_invoice_import_invoice2data/tests/pdf/" + filename, "rb")
         pdf_file = f.read()


### PR DESCRIPTION
Multiline invoice creation is not supported yet.

I propose those modifications to accept multiline creation.

Invoice2data library accept format (with parser or not) to extract invoice line by line with regex.
the result is stored in "lines" field as json list.
I iterate over this list to prepare data for account_invoice_import submodule.