### PR TITLE
[13.0][FIX] remove PyPDF2 dependency

### DIFF
--- a/base_business_document_import/__manifest__.py
+++ b/base_business_document_import/__manifest__.py
@@ -17,5 +17,4 @@
         "account_tax_unece",
         "uom_unece",
     ],
-    "external_dependencies": {"python": ["PyPDF2"]},
 }

--- a/base_ubl/__manifest__.py
+++ b/base_ubl/__manifest__.py
@@ -10,6 +10,5 @@
     "author": "Akretion,Onestein,Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/edi",
     "depends": ["uom_unece", "account_tax_unece", "base_vat"],
-    "external_dependencies": {"python": ["PyPDF2"]},
     "installable": True,
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 factur-x
 lxml
-PyPDF2
 pyyaml
 xmlschema


### PR DESCRIPTION
PyPDF2 dependency is already included in odoo CE requirements. See https://github.com/odoo/odoo/blob/13.0/requirements.txt#L31

This problem has been detected when this week PyPDF2 2.0.0 was released, since the version was not pinned in this repository, the latest 2.0.0 was installed, however this new version is not supported by odoo and gives errors