### PR TITLE
[14.0][FIX] remove PyPDF2 dependency.

### DIFF
--- a/base_ubl/__manifest__.py
+++ b/base_ubl/__manifest__.py
@@ -10,6 +10,6 @@
     "author": "Akretion,Onestein,Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/edi",
     "depends": ["uom_unece", "account_tax_unece", "base_vat", "pdf_helper"],
-    "external_dependencies": {"python": ["PyPDF2"]},
+    "external_dependencies": {"python": ["PyPDF2<=1.28.4"]},
     "installable": True,
 }

--- a/pdf_helper/__manifest__.py
+++ b/pdf_helper/__manifest__.py
@@ -15,5 +15,5 @@
     "depends": [
         "base",
     ],
-    "external_dependencies": {"python": ["PyPDF2"]},
+    "external_dependencies": {"python": ["PyPDF2<=1.28.4"]},
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ invoice2data
 ovh
 pdfplumber
 phonenumbers
-PyPDF2
+PyPDF2<=1.28.4
 pyyaml
 regex
 requests


### PR DESCRIPTION
PyPDF2 dependency is already included in odoo CE requirements.

Forward port of https://github.com/OCA/edi/pull/601