### PR TITLE
[14.0][IMP] business_document_import Usability improvement for multiline product imports

### DIFF
--- a/base_business_document_import/models/business_document_import.py
+++ b/base_business_document_import/models/business_document_import.py
@@ -600,9 +600,7 @@ class BusinessDocumentImport(models.AbstractModel):
                 and len(sinfo.product_tmpl_id.product_variant_ids) == 1
             ):
                 return sinfo.product_tmpl_id.product_variant_ids[0]
-        raise self.user_error_wrap(
-            "_match_product",
-            product_dict,
+        chatter_msg.append(
             _(
                 "Odoo couldn't find any product corresponding to the "
                 "following information extracted from the business document:\n"
@@ -616,6 +614,7 @@ class BusinessDocumentImport(models.AbstractModel):
                 seller and seller.name or "",
             ),
         )
+        return None
 
     @api.model
     def _match_product_search(self, product_dict):

--- a/base_business_document_import/tests/test_business_document_import.py
+++ b/base_business_document_import/tests/test_business_document_import.py
@@ -164,12 +164,10 @@ class TestBaseBusinessDocumentImport(TransactionCase):
         )
         self.assertEqual(res, product1)
         raise_test = True
-        try:
-            bdio._match_product(product_dict, [], seller=False)
-            raise_test = False
-        except Exception:
-            pass
         self.assertTrue(raise_test)
+        chatter = []
+        bdio._match_product(product_dict, chatter_msg=chatter, seller=False)
+        self.assertGreaterEqual(len(chatter), 1)
 
     def test_match_uom(self):
         bdio = self.env["business.document.import"]


### PR DESCRIPTION
Be less strict on product matching.
If one line fails to match a product, the whole (invoice) import fails.
This is unwanted in a professional environment when importing files with a lot of lines is very common.

Also it was too strict as it did not support the import of lines without any products.
Example, line notes and section headers.

This PR changes the behavior.
Instead of throwing an user error and stopping the import, an chatter message is displayed that not all products could automatically be matched.
This is in line with how uom imports are being handled.
The user can manually adjust the lines with the feedback he received from the chatter.