### PR TITLE
[12.0][REM] requirements.txt: Remove PyPDF2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-PyPDF2
 phonenumbers
 invoice2data
 factur-x


### PR DESCRIPTION
PyPDF2 already is in the requirements of Odoo base and fixed to version 1.26.0. This fixes https://github.com/odoo/odoo/issues/92595