### PR TITLE
[IMP] toggle for multiple exchange with the same filename

### DIFF
--- a/edi_storage_oca/__manifest__.py
+++ b/edi_storage_oca/__manifest__.py
@@ -19,6 +19,7 @@
         "data/queue_job_function_data.xml",
         "security/ir_model_access.xml",
         "views/edi_backend_views.xml",
+        "views/edi_exchange_type_views.xml",
     ],
     "demo": ["demo/edi_backend_demo.xml"],
 }

--- a/edi_storage_oca/models/edi_backend.py
+++ b/edi_storage_oca/models/edi_backend.py
@@ -132,12 +132,13 @@ class EDIBackend(models.Model):
     def _storage_create_record_if_missing(self, exchange_type, remote_file_name):
         """Create a new exchange record for given type and file name if missing."""
         file_name = os.path.basename(remote_file_name)
-        extra_domain = [("exchange_filename", "=", file_name)]
-        existing = self._find_existing_exchange_records(
-            exchange_type, extra_domain=extra_domain, count_only=True
-        )
-        if existing:
-            return
+        if exchange_type.exchange_file_forbid_duplicated:
+            extra_domain = [("exchange_filename", "=", file_name)]
+            existing = self._find_existing_exchange_records(
+                exchange_type, extra_domain=extra_domain, count_only=True
+            )
+            if existing:
+                return
         record = self.create_record(
             exchange_type.code, self._storage_new_exchange_record_vals(file_name)
         )

--- a/edi_storage_oca/models/edi_exchange_type.py
+++ b/edi_storage_oca/models/edi_exchange_type.py
@@ -19,3 +19,9 @@ class EDIExchangeType(models.Model):
         "the files to be fetched from the pending directory in the related "
         "storage. E.g: `.*my-type-[0-9]*.\\.csv`"
     )
+
+    exchange_file_forbid_duplicated = fields.Boolean(
+        default=True,
+        help="Create new echange only if no other exchange "
+        "with the same filename already exist.",
+    )

--- a/edi_storage_oca/views/edi_exchange_type_views.xml
+++ b/edi_storage_oca/views/edi_exchange_type_views.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+    <record id="edi_exchange_view_form" model="ir.ui.view">
+        <field name="model">edi.exchange.type</field>
+        <field name="inherit_id" ref="edi_oca.edi_exchange_type_view_form" />
+        <field name="arch" type="xml">
+            <xpath
+                expr="//field[@name='exchange_file_auto_generate']"
+                position="before"
+            >
+               <field
+                    name="exchange_file_forbid_duplicated"
+                    attrs="{'invisible': [('direction', '!=', 'input')]}"
+                />
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Some partner provide a file with the same name everytime,
I propose to add a boolean on the exchange type to allow for multiple exchange with the same filename.
 