### PR TITLE
[14.0] account_invoice_import_simple_pdf: add apostrophe as thousand separator

### DIFF
--- a/account_invoice_import_simple_pdf/models/account_invoice_import_simple_pdf_fields.py
+++ b/account_invoice_import_simple_pdf/models/account_invoice_import_simple_pdf_fields.py
@@ -256,6 +256,9 @@ class AccountInvoiceImportSimplePdfFields(models.Model):
             pattern = self.regexp
         else:
             pattern = date_format
+            # Special case to support "1er Janvier 2022" or "July 5th, 2022"
+            if date_separator_char == chr(32) and "month" in pattern:
+                pattern = pattern.replace("dd", r"\d{1,2}\p{L}{0,2}")
             for src, dest in partner_config["date_format2regex"].items():
                 pattern = pattern.replace(src, dest)
 

--- a/account_invoice_import_simple_pdf/models/res_partner.py
+++ b/account_invoice_import_simple_pdf/models/res_partner.py
@@ -82,6 +82,7 @@ class ResPartner(models.Model):
             ("space", "space"),
             ("dot", "dot"),
             ("comma", "comma"),
+            ("apostrophe", "apostrophe"),
         ],
         string="Thousand Separator",
         help="If empty, Odoo will use the thousand separator configured on "
@@ -315,6 +316,7 @@ class ResPartner(models.Model):
             "dot": ".",
             "comma": ",",
             "space": chr(32),  # regular space
+            "apostrophe": "'",
             "none": "",
         }
         char2separator = {val: key for key, val in separator2char.items()}

--- a/account_invoice_import_simple_pdf/tests/test_invoice_import.py
+++ b/account_invoice_import_simple_pdf/tests/test_invoice_import.py
@@ -144,6 +144,11 @@ class TestInvoiceImport(TransactionCase):
                 "date_separator": "space",
                 "lang": "en",
             },
+            "july%s14th,%s2021": {
+                "date_format": "month-dd-y4",
+                "date_separator": "space",
+                "lang": "en",
+            },
         }
         for src, config in date_test.items():
             raw_text = "Debit 15.12\n%s\n12.99 Total" % src
@@ -178,6 +183,7 @@ class TestInvoiceImport(TransactionCase):
             "15 août 2021": "2021-08-15",
             "25 décembre 2021": "2021-12-25",  # use combining acute accent \u0301
             "15 août 2021": "2021-08-15",  # use combining circumflex accent \u0302
+            "1er février 2022": "2022-02-01",
         }
         self.date_field.write(
             {

--- a/account_invoice_import_simple_pdf/tests/test_invoice_import.py
+++ b/account_invoice_import_simple_pdf/tests/test_invoice_import.py
@@ -272,6 +272,12 @@ class TestInvoiceImport(TransactionCase):
                 "result": 99459.32,
                 "currency": "EUR",
             },
+            "42'888.99 CHF": {
+                "decimal_separator": "dot",
+                "thousand_separator": "apostrophe",
+                "result": 42888.99,
+                "currency": "CHF",
+            },
             "14%s459 XPF": {
                 "decimal_separator": "comma",
                 "thousand_separator": "space",


### PR DESCRIPTION
Add support for amounts such as 42'987,56 (apostrophe as thousand separator)
Add support for dates written as "July 14th, 2022" and "1er Janvier 2022"
Add unittests for these newly supported formats