### PR TITLE
[FIX/IMP] delivery priority informations for UBL

### DIFF
--- a/base_ubl/models/ubl.py
+++ b/base_ubl/models/ubl.py
@@ -734,25 +734,24 @@ class BaseUbl(models.AbstractModel):
     @api.model
     def ubl_parse_delivery(self, delivery_node, ns):
         party_xpath = delivery_node.xpath("cac:DeliveryParty", namespaces=ns)
-        if party_xpath:
-            partner_dict = self.ubl_parse_party(party_xpath[0], ns)
+        delivery_location_address_xpath = delivery_node.xpath(
+            "cac:DeliveryLocation/cac:Address", namespaces=ns
+        )
+        delivery_address_xpath = delivery_node.xpath(
+            "cac:DeliveryAddress", namespaces=ns
+        )
+        if delivery_location_address_xpath:
+            partner_dict = self.ubl_parse_address(
+                delivery_location_address_xpath[0], ns
+            )
         else:
             partner_dict = {}
-        postal_xpath = delivery_node.xpath(
-            "cac:DeliveryParty/cac:PostalAddress", namespaces=ns
-        )
-        if not postal_xpath:
-            delivery_address_xpath = delivery_node.xpath(
-                "cac:DeliveryLocation/cac:Address", namespaces=ns
-            )
-            if not delivery_address_xpath:
-                delivery_address_xpath = delivery_node.xpath(
-                    "cac:DeliveryAddress", namespaces=ns
-                )
             if delivery_address_xpath:
                 partner_dict.update(
                     self.ubl_parse_address(delivery_address_xpath[0], ns)
                 )
+        if party_xpath:
+            partner_dict = {**self.ubl_parse_party(party_xpath[0], ns), **partner_dict}
         return partner_dict
 
     @api.model


### PR DESCRIPTION
Use case : 
- The company has 2 warehouses at different addresses
- The company makes a purchase order for warehouse B with purchase_order_ubl and sends it to the vendor
- The vendor imports the purchase order as a sale order with sale_order_import_ubl

Wrong Behavior : 
- The shipping address is the company address. It should be the warehouse B.

NB : I did also a PR in Odoo https://github.com/odoo/odoo/pull/95622 because 'purchase_stock' does not manage multi warehouses