### PR TITLE
[14.0] edi_endpoint: cross worker fix

### DIFF
--- a/edi_endpoint_oca/__manifest__.py
+++ b/edi_endpoint_oca/__manifest__.py
@@ -14,6 +14,7 @@
     "author": "Camptocamp,Odoo Community Association (OCA)",
     "depends": ["base_edi", "edi_oca", "endpoint"],
     "data": [
+        "data/server_action.xml",
         "security/ir.model.access.csv",
         "views/edi_backend_views.xml",
         "views/edi_endpoint_views.xml",

--- a/edi_endpoint_oca/data/server_action.xml
+++ b/edi_endpoint_oca/data/server_action.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo noupdate="1">
+        <record id="server_action_registry_sync" model="ir.actions.server">
+            <field name="name">Sync registry</field>
+            <field name="type">ir.actions.server</field>
+            <field name="model_id" ref="edi_endpoint_oca.model_edi_endpoint" />
+            <field name="binding_model_id" ref="edi_endpoint_oca.model_edi_endpoint" />
+            <field name="state">code</field>
+            <field name="code">
+records.filtered(lambda x: not x.registry_sync).write({"registry_sync": True})
+            </field>
+        </record>
+</odoo>

--- a/edi_endpoint_oca/migrations/14.0.1.3.0/post-migrate.py
+++ b/edi_endpoint_oca/migrations/14.0.1.3.0/post-migrate.py
@@ -1,0 +1,18 @@
+# Copyright 2022 Camptocamp SA (http://www.camptocamp.com)
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+import logging
+
+from odoo import SUPERUSER_ID, api
+
+_logger = logging.getLogger(__name__)
+
+
+def migrate(cr, version):
+    if not version:
+        return
+
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    domain = [("registry_sync", "=", False)]
+    env["edi.endpoint"].search(domain).write({"registry_sync": True})
+    _logger.info("Activate sync for existing EDI endpoints")

--- a/edi_endpoint_oca/models/edi_endpoint.py
+++ b/edi_endpoint_oca/models/edi_endpoint.py
@@ -1,14 +1,9 @@
 # Copyright 2021 Camptocamp SA
 # @author: Simone Orsi <simone.orsi@camptocamp.com>
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
-
-from functools import partial
-
 import werkzeug
 
 from odoo import _, api, exceptions, fields, models
-
-from ..controllers.main import EDIEndpointController
 
 
 class EDIEndpoint(models.Model):
@@ -18,7 +13,7 @@ class EDIEndpoint(models.Model):
     """
 
     _name = "edi.endpoint"
-    _inherit = "endpoint.mixin"
+    _inherit = ["endpoint.mixin", "endpoint.route.sync.mixin"]
     _description = "EDI Endpoint"
 
     _endpoint_route_prefix = "/edi"
@@ -74,5 +69,11 @@ class EDIEndpoint(models.Model):
         self._check_endpoint_ready(request=True)
         return super()._handle_request(request)
 
-    def _default_endpoint_handler(self):
-        return partial(EDIEndpointController().auto_endpoint, self.route)
+    def _default_endpoint_options_handler(self):
+        return {
+            "klass_dotted_path": (
+                "odoo.addons.edi_endpoint_oca.controllers.main.EDIEndpointController"
+            ),
+            "method_name": "auto_endpoint",
+            "default_pargs": (self.route,),
+        }

--- a/edi_endpoint_oca/tests/test_edi_endpoint_controller.py
+++ b/edi_endpoint_oca/tests/test_edi_endpoint_controller.py
@@ -5,22 +5,16 @@
 import os
 import unittest
 
-from odoo.tests.common import HttpCase
+from odoo.tests.common import HttpSavepointCase
 
 
 @unittest.skipIf(os.getenv("SKIP_HTTP_CASE"), "EDIEndpointHttpCase skipped")
-class EDIEndpointHttpCase(HttpCase):
-    def setUp(self):
-        super().setUp()
-        # I don't know why but  when test_edi_endpoint runs before these tests
-        # the rollback of the exception catched within the test `test_archive_check`
-        # make the controller lookup fail.
-        # Since the whole routing registry machinery is going to be refactored
-        # in https://github.com/OCA/edi/pull/633
-        # let's survive w/ this forced registration for now.
-        self.env.ref("edi_endpoint_oca.edi_endpoint_demo_1")._register_controllers(
-            init=True
-        )
+class EDIEndpointHttpCase(HttpSavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        # force sync for demo records
+        cls.env["edi.endpoint"].search([])._handle_registry_sync()
 
     def test_call1(self):
         response = self.url_open("/edi/demo/try")

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,3 +4,5 @@ responses
 # Python Dependencies
 PyYAML
 xmlunittest
+
+odoo14-addon-endpoint_route_handler @ git+https://github.com/OCA/web-api@refs/pull/3/head#subdirectory=setup/endpoint_route_handler


### PR DESCRIPTION
Former version of `endpoint_route_handler` had a major flaw:

routing rule registry was not properly shared across workers
forcing us to restart the instance to make sure all envs were inline w/ it.

This change adapts edi_endpoint_oca to the new version which contains
some refactoring.

Depends on:
- [ ] https://github.com/OCA/web-api/pull/3