### PR TITLE
[14.0] edi_exchange_template_oca: fix xml_purge_nswrapper 

### DIFF
--- a/edi_exchange_template_oca/__manifest__.py
+++ b/edi_exchange_template_oca/__manifest__.py
@@ -1,14 +1,14 @@
 # Copyright 2020 ACSONE
-# @author: Simone Orsi <simahawk@gmail.com>
+# Copyright 2022 Camptocamp SA
+# @author Simone Orsi <simahawk@gmail.com>
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
-
 {
     "name": "EDI Exchange Template",
     "summary": """Allows definition of exchanges via templates.""",
     "version": "14.0.1.0.2",
     "development_status": "Beta",
     "license": "LGPL-3",
-    "author": "ACSONE,Odoo Community Association (OCA)",
+    "author": "ACSONE,Camptocamp,Odoo Community Association (OCA)",
     "maintainers": ["simahawk"],
     "website": "https://github.com/OCA/edi",
     "depends": ["edi_oca", "component"],

--- a/edi_exchange_template_oca/tests/__init__.py
+++ b/edi_exchange_template_oca/tests/__init__.py
@@ -1,1 +1,2 @@
 from . import test_edi_backend_output
+from . import test_nswrapper

--- a/edi_exchange_template_oca/tests/test_nswrapper.py
+++ b/edi_exchange_template_oca/tests/test_nswrapper.py
@@ -1,0 +1,58 @@
+# Copyright 2022 Camptocamp SA
+# @author Simone Orsi <simahawk@gmail.com>
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+from odoo.tests.common import SavepointCase
+from odoo.tools import pycompat
+
+from ..utils import xml_purge_nswrapper
+
+ORDER_RESP_WRAPPER_TMPL = """
+<OrderResponse
+    xmlns="urn:oasis:names:specification:ubl:schema:xsd:OrderResponse-2"
+    xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+    xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2"
+>
+    <cbc:UBLVersionID>2.2</cbc:UBLVersionID>
+{}
+</OrderResponse>
+"""
+
+XML1 = """
+    <nswrapper xmlns:foo="http://www.unece.org/cefact/Foo">
+        <foo:LovelyNamespacedElement />
+    </nswrapper>
+"""
+
+XML2 = """
+    <nswrapper
+            xmlns="urn:oasis:names:specification:ubl:schema:xsd:OrderResponse-2"
+            xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+            xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2"
+        >
+        <cac:Party>
+            <cbc:EndpointID>7302347231111</cbc:EndpointID>
+            <cac:PartyIdentification>
+                <cbc:ID>7300070011115</cbc:ID>
+            </cac:PartyIdentification>
+            <cac:PartyName>
+                <cbc:Name>Moderna Produkter AB</cbc:Name>
+            </cac:PartyName>
+        </cac:Party>
+    </nswrapper>
+"""
+
+
+class TestNSWrapper(SavepointCase):
+    maxDiff = None
+
+    def test_purge1(self):
+        res = xml_purge_nswrapper(XML1)
+        self.assertNotIn("nswrapper", pycompat.to_text(res))
+
+    def test_purge2(self):
+        res = xml_purge_nswrapper(XML2)
+        self.assertNotIn("nswrapper", pycompat.to_text(res))
+
+    def test_purge3(self):
+        res = xml_purge_nswrapper(ORDER_RESP_WRAPPER_TMPL.format(XML2))
+        self.assertNotIn("nswrapper", pycompat.to_text(res))

--- a/edi_exchange_template_oca/utils.py
+++ b/edi_exchange_template_oca/utils.py
@@ -25,8 +25,9 @@ def xml_purge_nswrapper(xml_content):
     if not (xml_content and xml_content.strip()):
         return xml_content
     root = etree.XML(xml_content)
-    # deeper elements come after, keep the root element at the end (if any)
-    for nswrapper in reversed(root.xpath("//nswrapper")):
+    # Deeper elements come after, keep the root element at the end (if any).
+    # Use `name()` because the real element could be namespaced on render.
+    for nswrapper in reversed(root.xpath("//*[name() = 'nswrapper']")):
         parent = nswrapper.getparent()
         if parent is None:
             # fmt:off

--- a/edi_exchange_template_oca/utils.py
+++ b/edi_exchange_template_oca/utils.py
@@ -1,3 +1,8 @@
+# Copyright 2020 ACSONE SA/NV
+# Copyright 2022 Camptocamp SA
+# @author Simone Orsi <simahawk@gmail.com>
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
 from lxml import etree
 
 from odoo.tools import pycompat


### PR DESCRIPTION
Use `name()` because the real element could be namespaced on render
leading to mismatch by element type.

Added tests which confirmed the issue.