### PR TITLE
[14.0] edi: add quick exec option by type

### DIFF
--- a/edi_oca/models/edi_exchange_record.py
+++ b/edi_oca/models/edi_exchange_record.py
@@ -220,10 +220,27 @@ class EDIExchangeRecord(models.Model):
     @api.model
     def create(self, vals):
         vals["identifier"] = self._get_identifier()
-        return super().create(vals)
+        rec = super().create(vals)
+        if rec._quick_exec_enabled():
+            rec._execute_next_action()
+        return rec
 
     def _get_identifier(self):
         return self.env["ir.sequence"].next_by_code("edi.exchange")
+
+    def _quick_exec_enabled(self):
+        if self.env.context.get("edi__skip_quick_exec"):
+            return False
+        return self.type_id.quick_exec
+
+    def _execute_next_action(self):
+        # The backend already knows how to handle records
+        # according to their direction and status.
+        # Let it decide.
+        if self.type_id.direction == "output":
+            self.backend_id._check_output_exchange_sync(record_ids=self.ids)
+        else:
+            self.backend_id._check_input_exchange_sync(record_ids=self.ids)
 
     @api.constrains("backend_id", "type_id")
     def _constrain_backend(self):
@@ -309,6 +326,8 @@ class EDIExchangeRecord(models.Model):
         self.message_post(
             body=_("Action retry: state moved back to '%s'") % display_state
         )
+        if self._quick_exec_enabled():
+            self._execute_next_action()
         return True
 
     def action_open_related_record(self):

--- a/edi_oca/models/edi_exchange_record.py
+++ b/edi_oca/models/edi_exchange_record.py
@@ -174,6 +174,7 @@ class EDIExchangeRecord(models.Model):
         "input_processed_error": "input_received",
     }
 
+    @api.depends("edi_exchange_state")
     def _compute_retryable(self):
         for rec in self:
             rec.retryable = rec.edi_exchange_state in self._rollback_state_mapping

--- a/edi_oca/models/edi_exchange_type.py
+++ b/edi_oca/models/edi_exchange_type.py
@@ -129,6 +129,11 @@ class EDIExchangeType(models.Model):
         help="Automatically display a button on related models' form."
         # TODO: "Button settings can be configured via advanced settings."
     )
+    quick_exec = fields.Boolean(
+        string="Quick execution",
+        help="When active, records of this type will be processed immediately "
+        "without waiting for the cron to pass by.",
+    )
 
     _sql_constraints = [
         (

--- a/edi_oca/tests/__init__.py
+++ b/edi_oca/tests/__init__.py
@@ -11,3 +11,4 @@ from . import test_backend_validate
 from . import test_consumer_mixin
 from . import test_edi_backend_cron
 from . import test_security
+from . import test_quick_exec

--- a/edi_oca/tests/test_quick_exec.py
+++ b/edi_oca/tests/test_quick_exec.py
@@ -1,0 +1,108 @@
+# Copyright 2022 Camptocamp SA
+# @author: Simone Orsi <simahawk@gmail.com>
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+import base64
+
+import mock
+
+from .common import EDIBackendCommonComponentRegistryTestCase
+from .fake_components import (
+    FakeInputProcess,
+    FakeOutputChecker,
+    FakeOutputGenerator,
+    FakeOutputSender,
+)
+
+LOGGERS = ("odoo.addons.edi_oca.models.edi_backend", "odoo.addons.queue_job.delay")
+
+
+class EDIQuickExecTestCase(EDIBackendCommonComponentRegistryTestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls._build_components(
+            cls,
+            FakeOutputGenerator,
+            FakeOutputSender,
+            FakeOutputChecker,
+            FakeInputProcess,
+        )
+        cls.partner2 = cls.env.ref("base.res_partner_10")
+        cls.partner3 = cls.env.ref("base.res_partner_12")
+
+    def setUp(self):
+        super().setUp()
+        FakeOutputGenerator.reset_faked()
+        FakeOutputSender.reset_faked()
+        FakeOutputChecker.reset_faked()
+        FakeInputProcess.reset_faked()
+
+    def test_quick_exec_on_create_no_call(self):
+        vals = {
+            "model": self.partner._name,
+            "res_id": self.partner.id,
+        }
+        model = self.env["edi.exchange.record"]
+        # quick exec is off, we should not get any call
+        with mock.patch.object(type(model), "_execute_next_action") as mocked:
+            record0 = self.backend.create_record("test_csv_output", vals)
+            mocked.assert_not_called()
+            self.assertEqual(record0.edi_exchange_state, "new")
+        # enabled but bypassed
+        self.exchange_type_out.exchange_file_auto_generate = True
+        self.exchange_type_out.quick_exec = True
+        with mock.patch.object(type(model), "_execute_next_action") as mocked:
+            record0 = self.backend.with_context(
+                edi__skip_quick_exec=True
+            ).create_record("test_csv_output", vals)
+            # quick exec is off, we should not get any call
+            mocked.assert_not_called()
+            self.assertEqual(record0.edi_exchange_state, "new")
+
+    def test_quick_exec_on_create_out(self):
+        self.exchange_type_out.exchange_file_auto_generate = True
+        self.exchange_type_out.quick_exec = True
+        vals = {
+            "model": self.partner._name,
+            "res_id": self.partner.id,
+        }
+        record0 = self.backend.create_record("test_csv_output", vals)
+        # File generated and sent!
+        self.assertEqual(record0.edi_exchange_state, "output_sent")
+        self.assertTrue(FakeOutputGenerator.check_called_for(record0))
+        self.assertEqual(
+            record0._get_file_content(), FakeOutputGenerator._call_key(record0)
+        )
+
+    def test_quick_exec_on_create_in(self):
+        self.exchange_type_in.quick_exec = True
+        vals = {
+            "model": self.partner._name,
+            "res_id": self.partner.id,
+            "exchange_file": base64.b64encode(b"1234"),
+            "edi_exchange_state": "input_received",
+        }
+        record0 = self.backend.create_record("test_csv_input", vals)
+        self.assertEqual(record0.edi_exchange_state, "input_processed")
+        self.assertTrue(FakeInputProcess.check_called_for(record0))
+
+    def test_quick_exec_on_retry(self):
+        self.exchange_type_in.quick_exec = True
+        vals = {
+            "model": self.partner._name,
+            "res_id": self.partner.id,
+            "edi_exchange_state": "input_processed_error",
+            "exchange_file": base64.b64encode(b"1234"),
+        }
+        record0 = self.backend.with_context(edi__skip_quick_exec=True).create_record(
+            "test_csv_input", vals
+        )
+        self.assertEqual(record0.edi_exchange_state, "input_processed_error")
+        self.assertTrue(record0.retryable)
+        # get record w/ a clean context
+        record0 = self.backend.exchange_record_model.browse(record0.id)
+        record0.action_retry()
+        # The file has been rolled back and processed right away
+        self.assertEqual(record0.edi_exchange_state, "input_processed")
+        self.assertTrue(FakeInputProcess.check_called_for(record0))

--- a/edi_oca/tests/test_record.py
+++ b/edi_oca/tests/test_record.py
@@ -3,6 +3,7 @@
 # @author: Simone Orsi <simahawk@gmail.com>
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 
+import mock
 from freezegun import freeze_time
 
 from odoo import exceptions, fields
@@ -195,6 +196,9 @@ class EDIRecordTestCase(EDIBackendCommonTestCase):
         self.assertFalse(record0.retryable)
         record0.edi_exchange_state = "output_error_on_send"
         self.assertTrue(record0.retryable)
-        record0.action_retry()
+        with mock.patch.object(type(record0), "_execute_next_action") as mocked:
+            record0.action_retry()
+            # quick exec is off, we should not get any call
+            mocked.assert_not_called()
         self.assertEqual(record0.edi_exchange_state, "output_pending")
         self.assertFalse(record0.retryable)

--- a/edi_oca/tests/test_record.py
+++ b/edi_oca/tests/test_record.py
@@ -185,3 +185,16 @@ class EDIRecordTestCase(EDIBackendCommonTestCase):
         )
         ack2 = record0.exchange_create_ack_record()
         self.assertEqual(record0.ack_exchange_id, ack2)
+
+    def test_retry(self):
+        vals = {
+            "model": self.partner._name,
+            "res_id": self.partner.id,
+        }
+        record0 = self.backend.create_record("test_csv_output", vals)
+        self.assertFalse(record0.retryable)
+        record0.edi_exchange_state = "output_error_on_send"
+        self.assertTrue(record0.retryable)
+        record0.action_retry()
+        self.assertEqual(record0.edi_exchange_state, "output_pending")
+        self.assertFalse(record0.retryable)

--- a/edi_oca/views/edi_exchange_type_views.xml
+++ b/edi_oca/views/edi_exchange_type_views.xml
@@ -38,6 +38,7 @@
                             <field name="ack_type_id" />
                             <field name="ack_for_type_ids" widget="many2many_tags" />
                             <field name="job_channel_id" />
+                            <field name="quick_exec" />
                         </group>
                     </group>
                     <notebook>

--- a/edi_storage_oca/models/edi_backend.py
+++ b/edi_storage_oca/models/edi_backend.py
@@ -168,8 +168,10 @@ class EDIBackend(models.Model):
     def _storage_new_exchange_record_vals(self, file_name):
         return {"exchange_filename": file_name, "edi_exchange_state": "input_pending"}
 
-    def _check_output_exchange_sync(self, skip_send=False, skip_sent=True):
+    def _check_output_exchange_sync(self, **kw):
         # Do not skip sent records when dealing w/ storage related exchanges,
         # because we want to update the file state
         # depending on where they are in the external folder.
-        return super()._check_output_exchange_sync(skip_sent=not self.storage_id)
+        if self.storage_id:
+            kw["skip_sent"] = False
+        return super()._check_output_exchange_sync(**kw)


### PR DESCRIPTION
Allow scheduling jobs immediately based on type configuration.
Very often you want an action to be executed right away.
You still get a job, meaning that the action is not sync
but the job will be scheduled immediately
instead of waiting for the cron to run.

Plus fix `retryable` flag. See atomic commits for details.