### PR TITLE
[14.0][FIX] edi: pin module version in requirements to overwrite it

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ invoice2data
 ovh
 pdfplumber
 phonenumbers
-PyPDF2
+PyPDF2==1.26.0
 pyyaml
 regex
 requests


### PR DESCRIPTION
Corrects #655 for 14.0