### PR TITLE
[10.0][FIX] account_invoice_ubl: Replace old api with new api call for report.get_pdf()

### DIFF
--- a/account_invoice_ubl/models/account_invoice.py
+++ b/account_invoice_ubl/models/account_invoice.py
@@ -77,11 +77,9 @@ class AccountInvoice(models.Model):
             binary_node = etree.SubElement(
                 attach_node, ns['cbc'] + 'EmbeddedDocumentBinaryObject',
                 mimeCode="application/pdf", filename=filename)
-            ctx = self._context.copy()
-            ctx['no_embedded_ubl_xml'] = True
-            pdf_inv = self.pool['report'].get_pdf(
-                self._cr, self._uid, [self.id], 'account.report_invoice',
-                context=ctx)
+            pdf_inv = self.with_context(
+                no_embedded_ubl_xml=True
+            ).env['report'].get_pdf([self.id], 'account.report_invoice')
             binary_node.text = pdf_inv.encode('base64')
 
     def _ubl_add_legal_monetary_total(self, parent_node, ns, version='2.1'):


### PR DESCRIPTION
Whenever trying to produce an XML with embedded PDF, this error was returned:

`TypeError: unbound method get_pdf() must be called with report instance as first argument (got Cursor instance instead)`

This commit replaces the old api definition for calling `get_pdf()`, with the new api definition and resolves the error.