### PR TITLE
[14.0] Add edi_party_data_oca

### DIFF
--- a/edi_party_data_oca/README.rst
+++ b/edi_party_data_oca/README.rst
@@ -1,0 +1,1 @@
+wait for the bot

--- a/edi_party_data_oca/__init__.py
+++ b/edi_party_data_oca/__init__.py
@@ -1,0 +1,2 @@
+from . import components
+from . import models

--- a/edi_party_data_oca/__manifest__.py
+++ b/edi_party_data_oca/__manifest__.py
@@ -1,0 +1,20 @@
+# Copyright 2022 Camptocamp SA
+# @author: Simone Orsi <simahawk@gmail.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+{
+    "name": "EDI Party data",
+    "summary": """
+    Allow to configure and retrieve party information for EDI exchanges.
+    """,
+    "version": "14.0.1.0.0",
+    "development_status": "Alpha",
+    "license": "AGPL-3",
+    "website": "https://github.com/OCA/edi",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
+    "maintainers": ["simahawk"],
+    "depends": ["edi_oca", "partner_identification"],
+    "data": [
+        "views/edi_exchange_type_views.xml",
+    ],
+}

--- a/edi_party_data_oca/components/__init__.py
+++ b/edi_party_data_oca/components/__init__.py
@@ -1,0 +1,2 @@
+from . import common
+from . import party_data

--- a/edi_party_data_oca/components/common.py
+++ b/edi_party_data_oca/components/common.py
@@ -1,0 +1,72 @@
+# Copyright 2022 Camptocamp SA
+# @author: Simone Orsi <simahawk@gmail.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.tools import DotDict
+
+from odoo.addons.component.core import AbstractComponent
+
+
+class EDIExchangePartyDataMixin(AbstractComponent):
+    """Abstract component mixin provide partner data for exchanges."""
+
+    _name = "edi.party.data.mixin"
+    _inherit = "edi.component.mixin"
+    _collection = "edi.backend"
+    _usage = "edi.party.data"
+
+    def __init__(self, work_context):
+        super().__init__(work_context)
+        self.partner = self._get_partner()
+        self.allowed_id_categories = self.exchange_record.type_id.id_category_ids
+
+    def _get_partner(self):
+        # Hook here to define different logic to lookup for the partner
+        # based on current partner (eg: pick the parent).
+        return self.work.partner
+
+    def get_party(self):
+        """Return party information.
+
+        Requires a res.partner to be passed via work context.
+
+        :return: odoo.tools.DotDict
+        """
+        return self._party_from_partner()
+
+    def _party_from_partner(self, **kw):
+        # NB: for UBL this should probably replace `base.ubl._ubl_get_party_identification`
+        # which does nothing today.
+        party = DotDict(
+            name=self._get_name(),
+            identifiers=self._get_identifiers(),
+            # TODO: is this only for UBL?
+            endpoint=self._get_endpoint(),
+        )
+        party.update(kw)
+        return party
+
+    def _get_name(self):
+        return self.partner.name
+
+    def _get_endpoint(self):
+        return {}
+
+    def _get_identifiers(self):
+        identifiers = self.partner.id_numbers.filtered(
+            lambda x: self._filter_id_number(x)
+        )
+        return [self._get_indentity(x) for x in identifiers]
+
+    def _filter_id_number(self, id_number):
+        if self.allowed_id_categories:
+            return id_number.category_id in self.allowed_id_categories
+        return True
+
+    def _get_indentity(self, id_number):
+        return DotDict(
+            attrs={
+                "schemeID": id_number.category_id.code,
+            },
+            value=id_number.name,
+        )

--- a/edi_party_data_oca/components/party_data.py
+++ b/edi_party_data_oca/components/party_data.py
@@ -1,0 +1,12 @@
+# Copyright 2022 Camptocamp SA
+# @author: Simone Orsi <simahawk@gmail.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.addons.component.core import Component
+
+
+class EDIPartyData(Component):
+    """Default component to lookup for party information."""
+
+    _name = "edi.party.data"
+    _inherit = "edi.party.data.mixin"

--- a/edi_party_data_oca/models/__init__.py
+++ b/edi_party_data_oca/models/__init__.py
@@ -1,0 +1,1 @@
+from . import edi_exchange_type

--- a/edi_party_data_oca/models/edi_exchange_type.py
+++ b/edi_party_data_oca/models/edi_exchange_type.py
@@ -1,0 +1,16 @@
+# Copyright 2022 Camptocamp SA
+# @author Simone Orsi <simahawk@gmail.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class EDIExchangeType(models.Model):
+
+    _inherit = "edi.exchange.type"
+
+    id_category_ids = fields.Many2many(
+        string="ID categories",
+        comodel_name="res.partner.id_category",
+        help="Allowed ID categories to be used to generate parties information.",
+    )

--- a/edi_party_data_oca/readme/CONFIGURE.rst
+++ b/edi_party_data_oca/readme/CONFIGURE.rst
@@ -1,0 +1,4 @@
+On the exchange type form, find the field "ID categories"
+and set the categories allowed for that exchange type.
+
+If not set, *all the IDs* of the partner will be exposed.

--- a/edi_party_data_oca/readme/CONTRIBUTORS.rst
+++ b/edi_party_data_oca/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Simone Orsi <simone.orsi@camptocamp.com>

--- a/edi_party_data_oca/readme/DESCRIPTION.rst
+++ b/edi_party_data_oca/readme/DESCRIPTION.rst
@@ -1,0 +1,9 @@
+Technical module for the EDI suite module to retrieve data for parties of an exchange.
+
+This module provides default component
+and a mixin to be used for registering new components for specific backends.
+
+It's based on `partner_identification`
+so that the party information will include allowed ID numbers for a given exchange.
+
+You can configure which ID number categories are allowed on the exchange type.

--- a/edi_party_data_oca/readme/USAGE.rst
+++ b/edi_party_data_oca/readme/USAGE.rst
@@ -1,0 +1,7 @@
+An handy util method is to retrive the component::
+
+    from odoo.addons.edi_party_data_oca.utils import get_party_data_component
+
+    component = get_party_data_component(exchange_record, partner)
+
+    data = component.get_party()

--- a/edi_party_data_oca/tests/__init__.py
+++ b/edi_party_data_oca/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_party_data

--- a/edi_party_data_oca/tests/test_party_data.py
+++ b/edi_party_data_oca/tests/test_party_data.py
@@ -1,0 +1,146 @@
+# Copyright 2022 Camptocamp SA
+# @author: Simone Orsi <simahawk@gmail.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.addons.edi_oca.tests.common import EDIBackendCommonComponentTestCase
+
+from ..utils import get_party_data_component
+
+
+class PartyDataTestCase(EDIBackendCommonComponentTestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.backend = cls.env.ref("edi_oca.demo_edi_backend")
+        cls.cat_model = cls.env["res.partner.id_category"]
+        cls.all_cat = cls.cat_model.browse()
+        for i in range(1, 4):
+            rec = cls.cat_model.create({"code": f"cat{i}", "name": f"Cat {i}"})
+            cls.all_cat += rec
+            setattr(cls, f"category{i}", rec)
+        for i in range(1, 4):
+            rec = cls.env["res.partner"].create(
+                {
+                    "name": f"Test Partner {i}",
+                    "id_numbers": [
+                        (
+                            0,
+                            0,
+                            {
+                                "name": f"{cat.code}-p{i}",
+                                "category_id": cat.id,
+                            },
+                        )
+                        for cat in cls.all_cat[i - 1 :]
+                    ],
+                }
+            )
+            setattr(cls, f"partner{i}", rec)
+
+        # No need for special file name gen
+        cls.exc_type = cls._create_exchange_type(
+            name="ID output test",
+            code="id_out_test",
+            direction="output",
+        )
+        cls.exc_record = cls.backend.create_record("id_out_test", {})
+
+    def _get_provider(self, partner):
+        return get_party_data_component(self.exc_record, partner)
+
+    def _make_expected_data(self, partner, number, allowed_codes=None, **kw):
+        data = {
+            "name": partner.name,
+            "identifiers": [
+                {"attrs": {"schemeID": "cat1"}, "value": f"cat1-p{number}"},
+                {"attrs": {"schemeID": "cat2"}, "value": f"cat2-p{number}"},
+                {"attrs": {"schemeID": "cat3"}, "value": f"cat3-p{number}"},
+            ],
+            "endpoint": {},
+        }
+        data.update(kw)
+        if allowed_codes:
+            data["identifiers"] = [
+                x
+                for x in data["identifiers"]
+                if x["attrs"]["schemeID"] in allowed_codes
+            ]
+        return data
+
+    def test_lookup(self):
+        provider = self._get_provider(self.partner1)
+        self.assertEqual(provider.partner, self.partner1)
+        self.assertFalse(provider.allowed_id_categories)
+
+    def test_data(self):
+        expected = (
+            (self.partner1, self._make_expected_data(self.partner1, 1)),
+            (
+                self.partner2,
+                self._make_expected_data(
+                    self.partner2, 2, allowed_codes=["cat2", "cat3"]
+                ),
+            ),
+            (
+                self.partner3,
+                self._make_expected_data(self.partner3, 3, allowed_codes=["cat3"]),
+            ),
+        )
+        for partner, expected_data in expected:
+            provider = self._get_provider(partner)
+            res = provider.get_party()
+            self.assertEqual(res, expected_data)
+
+    def test_data_limited_1(self):
+        self.exc_type.id_category_ids = self.category1
+        expected = (
+            (
+                self.partner1,
+                self._make_expected_data(self.partner1, 1, allowed_codes=["cat1"]),
+            ),
+            (self.partner2, self._make_expected_data(self.partner2, 2, identifiers=[])),
+            (self.partner3, self._make_expected_data(self.partner3, 3, identifiers=[])),
+        )
+        for partner, expected_data in expected:
+            provider = self._get_provider(partner)
+            res = provider.get_party()
+            self.assertEqual(res, expected_data)
+
+    def test_data_limited_2(self):
+        self.exc_type.id_category_ids = self.category2
+        expected = (
+            (
+                self.partner1,
+                self._make_expected_data(self.partner1, 1, allowed_codes=["cat2"]),
+            ),
+            (
+                self.partner2,
+                self._make_expected_data(self.partner2, 2, allowed_codes=["cat2"]),
+            ),
+            (self.partner3, self._make_expected_data(self.partner3, 3, identifiers=[])),
+        )
+        for partner, expected_data in expected:
+            provider = self._get_provider(partner)
+            res = provider.get_party()
+            self.assertEqual(res, expected_data)
+
+    def test_data_limited_3(self):
+        self.exc_type.id_category_ids = self.category3
+        expected = (
+            (
+                self.partner1,
+                self._make_expected_data(self.partner1, 1, allowed_codes=["cat3"]),
+            ),
+            (
+                self.partner2,
+                self._make_expected_data(self.partner2, 2, allowed_codes=["cat3"]),
+            ),
+            (
+                self.partner3,
+                self._make_expected_data(self.partner3, 3, allowed_codes=["cat3"]),
+            ),
+        )
+        for partner, expected_data in expected:
+            provider = self._get_provider(partner)
+            res = provider.get_party()
+            self.assertEqual(res, expected_data)

--- a/edi_party_data_oca/utils.py
+++ b/edi_party_data_oca/utils.py
@@ -1,0 +1,22 @@
+# Copyright 2022 Camptocamp SA
+# @author: Simone Orsi <simahawk@gmail.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+
+def get_party_data_component(exc_record, partner, work_ctx=None):
+    """Shortcut to retrieve party data component."""
+    work_ctx = work_ctx or {}
+    work_ctx.update({"exchange_record": exc_record, "partner": partner})
+    backend = exc_record.backend_id
+    # TODO: match_attrs normally comes w/ `backend._get_component`
+    # but ATM we cannot use it because the usage will be computed
+    # by `_get_component_usage_candidates` which does not consider explicit usage.
+    # We have 2 optins for improvements:
+    # 1. allow `_get_component` to receive an explicit usage
+    # 2. inject a new candidate in `_get_component_usage_candidates`
+    # equal to the key that is passed.
+    # @simahawk: I'd go for opt 1.
+    match_attrs = backend._component_match_attrs(exc_record, "data")
+    return backend._find_component(
+        backend._name, ["edi.party.data"], work_ctx=work_ctx, **match_attrs
+    )

--- a/edi_party_data_oca/views/edi_exchange_type_views.xml
+++ b/edi_party_data_oca/views/edi_exchange_type_views.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+    <record id="edi_exchange_type_view_form" model="ir.ui.view">
+        <field name="model">edi.exchange.type</field>
+        <field name="inherit_id" ref="edi_oca.edi_exchange_type_view_form" />
+        <field name="arch" type="xml">
+            <group name="config" position="after">
+                <group name="party_config">
+                    <field name="id_category_ids" widget="many2many_tags" />
+                </group>
+            </group>
+        </field>
+    </record>
+</odoo>

--- a/setup/edi_party_data_oca/odoo/addons/edi_party_data_oca
+++ b/setup/edi_party_data_oca/odoo/addons/edi_party_data_oca
@@ -1,0 +1,1 @@
+../../../../edi_party_data_oca

--- a/setup/edi_party_data_oca/setup.py
+++ b/setup/edi_party_data_oca/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
Technical module for the EDI suite module to retrieve data for parties of an exchange.

This module provides default component
and a mixin to be used for registering new components for specific backends.

It's based on `partner_identification`
so that the party information will include allowed ID numbers for a given exchange.

You can configure which ID number categories are allowed on the exchange type.


ref: cos-3752
