### PR TITLE
[14.0] edi_webservice: fix tests

### DIFF
--- a/edi_webservice_oca/demo/edi_backend.xml
+++ b/edi_webservice_oca/demo/edi_backend.xml
@@ -6,6 +6,9 @@
         <field name="protocol">http</field>
         <field name="url">https://foo.test/{endpoint}</field>
         <field name="content_type">application/xml</field>
+        <field name="auth_type">user_pwd</field>
+        <field name="username">user</field>
+        <field name="password">pwd</field>
     </record>
     <record id="demo_edi_backend_type" model="edi.backend.type">
         <field name="name">Demo backend type ws</field>

--- a/edi_webservice_oca/tests/test_backend.py
+++ b/edi_webservice_oca/tests/test_backend.py
@@ -16,6 +16,9 @@ class TestEdiWebService(EDIBackendCommonTestCase):
                 "url": "http://localhost.demo.odoo/",
                 "content_type": "application/xml",
                 "tech_name": "demo_ws",
+                "auth_type": "user_pwd",
+                "username": "user",
+                "password": "pwd",
             }
         )
         vals = {


### PR DESCRIPTION
'webservice' now requires auth params to be set.