### PR TITLE
[FIX] Removed PyPDF2 library from external dependencies

### DIFF
--- a/account_invoice_download_ovh/__manifest__.py
+++ b/account_invoice_download_ovh/__manifest__.py
@@ -12,7 +12,7 @@
     "maintainers": ["alexis-via"],
     "website": "https://github.com/OCA/edi",
     "depends": ["account_invoice_download"],
-    "external_dependencies": {"python": ["requests", "ovh"]},
+    "external_dependencies": {"python": ["ovh"]},
     "data": [
         "wizard/ovh_api_credentials_view.xml",
         "views/account_invoice_download_config.xml",

--- a/base_ubl/__manifest__.py
+++ b/base_ubl/__manifest__.py
@@ -10,6 +10,5 @@
     "author": "Akretion,Onestein,Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/edi",
     "depends": ["uom_unece", "account_tax_unece", "base_vat", "pdf_helper"],
-    "external_dependencies": {"python": ["PyPDF2"]},
     "installable": True,
 }

--- a/pdf_helper/__manifest__.py
+++ b/pdf_helper/__manifest__.py
@@ -15,5 +15,4 @@
     "depends": [
         "base",
     ],
-    "external_dependencies": {"python": ["PyPDF2"]},
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,4 @@ pdfplumber
 phonenumbers
 pyyaml
 regex
-requests
 xmlschema

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@ invoice2data
 ovh
 pdfplumber
 phonenumbers
-PyPDF2
 pyyaml
 regex
 requests


### PR DESCRIPTION
    In the requirement file of odoo/odoo the library is pinned to version 1.26.0
    (https://github.com/odoo/odoo/commit/021de21e8cdcf35276c945d8070d04435fa1a19c),
    if library is unpinned, it is forced to install the current version, which
    generates the following error when running odoo:

    AttributeError: module 'PyPDF2' has no attribute 'filters'