### PR TITLE
[14.0] edi: drop ack record auto create

### DIFF
--- a/edi_oca/models/edi_backend.py
+++ b/edi_oca/models/edi_backend.py
@@ -381,8 +381,6 @@ class EDIBackend(models.Model):
                 # TODO: run in job as well?
                 self._exchange_output_check_state(rec)
 
-        self._exchange_check_ack_needed(pending_records)
-
     def _output_new_records_domain(self, record_ids=None):
         """Domain for output records needing output content generation."""
         domain = [
@@ -577,9 +575,6 @@ class EDIBackend(models.Model):
         for rec in pending_process_records:
             rec.with_delay().action_exchange_process()
 
-        # TODO: test it!
-        self._exchange_check_ack_needed(pending_process_records)
-
     def _input_pending_records_domain(self, record_ids=None):
         domain = [
             ("backend_id", "=", self.id),
@@ -601,15 +596,6 @@ class EDIBackend(models.Model):
         if record_ids:
             domain.append(("id", "in", record_ids))
         return domain
-
-    def _exchange_check_ack_needed(self, pending_records):
-        ack_pending_records = pending_records.filtered(lambda x: x.needs_ack())
-        _logger.info(
-            "EDI Exchange output sync: found %d records needing ack record.",
-            len(ack_pending_records),
-        )
-        for rec in ack_pending_records:
-            rec.with_delay().exchange_create_ack_record()
 
     def _find_existing_exchange_records(
         self, exchange_type, extra_domain=None, count_only=False

--- a/edi_oca/tests/test_edi_backend_cron.py
+++ b/edi_oca/tests/test_edi_backend_cron.py
@@ -75,8 +75,6 @@ class EDIBackendTestCase(EDIBackendCommonComponentRegistryTestCase):
                 rec._get_file_content(), FakeOutputGenerator._call_key(rec)
             )
             self.assertTrue(FakeOutputSender.check_called_for(rec))
-            # TODO: test better?
-            self.assertTrue(rec.ack_exchange_id)
 
     @mute_logger(*LOGGERS)
     def test_exchange_generate_output_ready_auto_send(self):
@@ -94,6 +92,3 @@ class EDIBackendTestCase(EDIBackendCommonComponentRegistryTestCase):
         self.assertTrue(FakeOutputGenerator.check_not_called_for(self.record1))
         self.assertTrue(FakeOutputSender.check_not_called_for(self.record1))
         self.assertTrue(FakeOutputChecker.check_called_for(self.record1))
-
-        # TODO: test better?
-        self.assertTrue(self.record1.ack_exchange_id)


### PR DESCRIPTION
Creating the ack was kind of... an hack :)

When I added this behavior we didn't have yet the storage machinery that looks automatically for a new file.
Also for webservices seems not relevant since we can configure endpoints that can create the ack when needed.

All in all, I don't think this feature is needed.
Worse, it adds some overhead when a record gets created and can generate write conflicts when exchanges are processed immediately overlapping with the creation of the ack record.

@etobella @LoisRForgeFlow can you please check if this is something you still need?
If yes, I can deprecate it and make it optional (maybe w/ a flag off by default on the type or on the backend).