### PR TITLE
[14.0] base_ubl: allow to skip taxes on items

### DIFF
--- a/base_ubl/models/ubl.py
+++ b/base_ubl/models/ubl.py
@@ -433,7 +433,8 @@ class BaseUbl(models.AbstractModel):
                 taxes = product.taxes_id
             else:
                 taxes = product.supplier_taxes_id
-            if taxes:
+            skip_taxes = self.env.context.get("ubl_add_item__skip_taxes")
+            if taxes and not skip_taxes:
                 for tax in taxes:
                     self._ubl_add_tax_category(
                         tax,


### PR DESCRIPTION
In certain cases taxes are not fundamental for an exchange. You can now easily skip them w/ a ctx key.