### PR TITLE
[14.0] edi_party_data: use display_name by default

### DIFF
--- a/edi_party_data_oca/components/common.py
+++ b/edi_party_data_oca/components/common.py
@@ -47,7 +47,8 @@ class EDIExchangePartyDataMixin(AbstractComponent):
         return party
 
     def _get_name(self):
-        return self.partner.name
+        name_field = getattr(self.work, "party_data_name_field", "display_name")
+        return self.partner[name_field]
 
     def _get_endpoint(self):
         return {}

--- a/edi_party_data_oca/readme/CONFIGURE.rst
+++ b/edi_party_data_oca/readme/CONFIGURE.rst
@@ -1,4 +1,20 @@
+ID numbers selection
+~~~~~~~~~~~~~~~~~~~~
+
 On the exchange type form, find the field "ID categories"
 and set the categories allowed for that exchange type.
 
 If not set, *all the IDs* of the partner will be exposed.
+
+Name field
+~~~~~~~~~~
+
+On the exchange type form, modify the advanced settings
+so that the work context of the component that is used (eg: generate)
+contains `party_data_name_field`. For instance::
+
+    components:
+        generate:
+            usage: my.generate
+            work_ctx:
+                party_data_name_field: name


### PR DESCRIPTION
Use the full name of the partner by default to include parent name. This behavior can be tweaked w/ the work context key 'party_data_name_field'.

ref: cos-3786
