### PR TITLE
[14.0] Add sale_order_import_ubl_line_customer_ref

### DIFF
--- a/sale_order_import_ubl_customer_free_ref/__manifest__.py
+++ b/sale_order_import_ubl_customer_free_ref/__manifest__.py
@@ -1,10 +1,13 @@
+# Copyright 2022 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+
 {
     "name": "Sale Order UBL Import Customer Free Ref",
     "version": "14.0.1.1.0",
     "category": "Sales Management",
     "license": "AGPL-3",
     "summary": "Extract CustomerReference from sale UBL",
-    "author": "Camptocamp SA, Odoo Community Association (OCA)",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/edi",
     "depends": ["sale_order_import_ubl", "sale_order_customer_free_ref"],
     "installable": True,

--- a/sale_order_import_ubl_customer_free_ref/wizard/sale_order_import.py
+++ b/sale_order_import_ubl_customer_free_ref/wizard/sale_order_import.py
@@ -1,6 +1,5 @@
-# © 2016-2017 Akretion (Alexis de Lattre <alexis.delattre@akretion.com>)
-# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
-
+# Copyright 2022 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
 
 from odoo import api, models
 from odoo.osv.expression import AND

--- a/sale_order_import_ubl_line_customer_ref/README.rst
+++ b/sale_order_import_ubl_line_customer_ref/README.rst
@@ -1,0 +1,1 @@
+bot, please!

--- a/sale_order_import_ubl_line_customer_ref/__init__.py
+++ b/sale_order_import_ubl_line_customer_ref/__init__.py
@@ -1,0 +1,1 @@
+from . import wizard

--- a/sale_order_import_ubl_line_customer_ref/__manifest__.py
+++ b/sale_order_import_ubl_line_customer_ref/__manifest__.py
@@ -1,0 +1,17 @@
+# Copyright 2022 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+{
+    "name": "Sale Order UBL Import - Import order line customer ref",
+    "version": "14.0.1.0.0",
+    "category": "Sales Management",
+    "license": "AGPL-3",
+    "summary": "Extract specific customer reference for each order line",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
+    "website": "https://github.com/OCA/edi",
+    # NOTE: the dependency on *ubl is probably not mandatory
+    # but that's the only module ATM providing a value for `note`
+    # and since at this time the module is tested only with UBL we leave it like this.
+    "depends": ["sale_order_import_ubl", "sale_stock_line_customer_ref"],
+    "installable": True,
+    "auto_install": True,
+}

--- a/sale_order_import_ubl_line_customer_ref/__manifest__.py
+++ b/sale_order_import_ubl_line_customer_ref/__manifest__.py
@@ -2,7 +2,7 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
 {
     "name": "Sale Order UBL Import - Import order line customer ref",
-    "version": "14.0.1.0.0",
+    "version": "14.0.1.0.1",
     "category": "Sales Management",
     "license": "AGPL-3",
     "summary": "Extract specific customer reference for each order line",

--- a/sale_order_import_ubl_line_customer_ref/readme/CONTRIBUTORS.rst
+++ b/sale_order_import_ubl_line_customer_ref/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Simone Orsi <simone.orsi@camptocamp.com>

--- a/sale_order_import_ubl_line_customer_ref/readme/DESCRIPTION.rst
+++ b/sale_order_import_ubl_line_customer_ref/readme/DESCRIPTION.rst
@@ -1,0 +1,5 @@
+This is a glue module between `sale_order_import_ubl` and `sale_stock_line_customer_ref`.
+It extracts customer references for specific lines from the XML received.
+
+Since there's no specific element for customer reference in the UBL line,
+the module will look into `cac:OrderLine/cac:Item/cbc:Note` for a string prefixed with `customer_ref:`.

--- a/sale_order_import_ubl_line_customer_ref/tests/__init__.py
+++ b/sale_order_import_ubl_line_customer_ref/tests/__init__.py
@@ -1,0 +1,3 @@
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from . import test_order_line_customer_ref

--- a/sale_order_import_ubl_line_customer_ref/tests/test_order_line_customer_ref.py
+++ b/sale_order_import_ubl_line_customer_ref/tests/test_order_line_customer_ref.py
@@ -1,0 +1,71 @@
+# Copyright 2022 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+from odoo.tests.common import SavepointCase
+
+
+class TestOrderLineCustomerRef(SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
+        cls.product = cls.env["product.product"].create(
+            {
+                "name": "Test customer_ref 1",
+                "barcode": "prod1",
+            }
+        )
+        cls.product2 = cls.env["product.product"].create(
+            {
+                "name": "Test customer_ref 2",
+                "barcode": "prod2",
+            }
+        )
+        cls.customer_ref1 = "#customer1"
+        cls.customer_ref2 = "#customer2"
+        cls.customer_ref3 = "#customer3"
+        cls.parsed_order = {
+            "partner": {"email": "johnny.glamour@example.com"},
+            "lines": [
+                {
+                    "product": {"barcode": "prod1"},
+                    "qty": 1,
+                    "uom": {"unece_code": "C62"},
+                    "note": "customer_ref: " + cls.customer_ref1,
+                },
+                {
+                    "product": {"barcode": "prod1"},
+                    "qty": 1,
+                    "uom": {"unece_code": "C62"},
+                    "note": "customer_ref: " + cls.customer_ref2,
+                },
+                {
+                    "product": {"barcode": "prod2"},
+                    "qty": 4,
+                    "uom": {"unece_code": "C62"},
+                    "note": "customer_ref: " + cls.customer_ref3,
+                },
+            ],
+            "chatter_msg": [],
+            "doc_type": "rfq",
+        }
+        cls.soi = cls.env["sale.order.import"]
+
+    def test_customer_ref_parsing(self):
+        self.assertEqual(self.soi._get_order_line_customer_ref({}), "")
+        self.assertEqual(self.soi._get_order_line_customer_ref({"note": ""}), "")
+        self.assertEqual(self.soi._get_order_line_customer_ref({"note": "bla bla"}), "")
+        self.assertEqual(
+            self.soi._get_order_line_customer_ref({"note": "customer_ref:abc"}), "abc"
+        )
+        self.assertEqual(
+            self.soi._get_order_line_customer_ref(
+                {"note": "bla bla\ncustomer_ref:abc"}
+            ),
+            "abc",
+        )
+
+    def test_order_line_customer_ref(self):
+        order = self.soi.create_order(self.parsed_order, "pricelist")
+        for i, line in enumerate(order.order_line, start=1):
+            self.assertEqual(line.customer_ref, getattr(self, f"customer_ref{i}"))

--- a/sale_order_import_ubl_line_customer_ref/wizard/__init__.py
+++ b/sale_order_import_ubl_line_customer_ref/wizard/__init__.py
@@ -1,0 +1,1 @@
+from . import sale_order_import

--- a/sale_order_import_ubl_line_customer_ref/wizard/sale_order_import.py
+++ b/sale_order_import_ubl_line_customer_ref/wizard/sale_order_import.py
@@ -1,0 +1,39 @@
+# Copyright 2022 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+
+from odoo import api, models
+
+
+class SaleOrderImport(models.TransientModel):
+    _inherit = "sale.order.import"
+
+    @api.model
+    def _prepare_create_order_line(
+        self, product, uom, order, import_line, price_source
+    ):
+        vals = super()._prepare_create_order_line(
+            product, uom, order, import_line, price_source
+        )
+        if not vals.get("customer_ref"):
+            customer_ref = self._get_order_line_customer_ref(import_line)
+            if customer_ref:
+                vals["customer_ref"] = customer_ref
+        return vals
+
+    def _prepare_update_order_line_vals(self, change_dict):
+        vals = super()._prepare_update_order_line_vals(change_dict)
+        customer_ref = self._get_order_line_customer_ref(vals)
+        if customer_ref:
+            vals["customer_ref"] = customer_ref
+        return vals
+
+    def _get_order_line_customer_ref(self, vals):
+        """Extrapolate customer ref from cac:Item/cbc:Note"""
+        customer_ref = ""
+        note = vals.get("note", "").strip()
+        if note:
+            for line in note.splitlines():
+                if "customer_ref:" in line:
+                    customer_ref = line.replace("customer_ref:", "").strip()
+                    break
+        return customer_ref

--- a/setup/sale_order_import_ubl_line_customer_ref/odoo/addons/sale_order_import_ubl_line_customer_ref
+++ b/setup/sale_order_import_ubl_line_customer_ref/odoo/addons/sale_order_import_ubl_line_customer_ref
@@ -1,0 +1,1 @@
+../../../../sale_order_import_ubl_line_customer_ref

--- a/setup/sale_order_import_ubl_line_customer_ref/setup.py
+++ b/setup/sale_order_import_ubl_line_customer_ref/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
This is a glue module between `sale_order_import_ubl` and `sale_stock_line_customer_ref`.
It extracts customer references for specific lines from the XML received.

Since there's no specific element for customer reference in the UBL line,
the module will look into `cac:OrderLine/cac:Item/cbc:Note` for a string prefixed with `customer_ref:`.

Depends on:

- [x] https://github.com/OCA/sale-workflow/pull/2262

ref: cos-3795