### PR TITLE
[13.0][IMP] edi_backend_partner: modify backend view

### DIFF
--- a/edi_backend_partner/views/edi_backend_views.xml
+++ b/edi_backend_partner/views/edi_backend_views.xml
@@ -7,7 +7,7 @@
         <field name="model">edi.backend</field>
         <field name="inherit_id" ref="edi.edi_backend_view_form" />
         <field name="arch" type="xml">
-            <field name="backend_type_id" position="after">
+            <field name="output_sent_processed_auto" position="after">
                 <field name="partner_id" />
             </field>
         </field>


### PR DESCRIPTION
Right now when configuring a partner for a backend it appears right next to the backend type when saving. Now the partner will be shown in the next line. 