### PR TITLE
[14.0][FIX] edi_endpoint_oca: add missing oca dependency

### DIFF
--- a/oca_dependencies.txt
+++ b/oca_dependencies.txt
@@ -1,3 +1,4 @@
 # See https://github.com/OCA/odoo-community.org/blob/master/website/Contribution/CONTRIBUTING.rst#oca_dependencies-txt
 community-data-files
 reporting-engine
+web-api


### PR DESCRIPTION
I just have have added the missing web-api to oca_depency to have endpoint module.

Related to this issue: https://github.com/OCA/edi/issues/712