### PR TITLE
[FIX] remove pin version of dateparser

### DIFF
--- a/account_invoice_import_invoice2data/__manifest__.py
+++ b/account_invoice_import_invoice2data/__manifest__.py
@@ -16,8 +16,7 @@
     "external_dependencies": {
         "python": [
             "invoice2data",
-            # https://github.com/OCA/edi/issues/544
-            "dateparser==1.1.1",
+            "dateparser",
         ],
         "deb": ["poppler-utils"],
     },

--- a/account_invoice_import_simple_pdf/__manifest__.py
+++ b/account_invoice_import_simple_pdf/__manifest__.py
@@ -14,7 +14,7 @@
     "depends": ["account_invoice_import"],
     # "excludes": ["account_invoice_import_invoice2data"],
     "external_dependencies": {
-        "python": ["pdfplumber", "regex", "dateparser==1.1.1"],
+        "python": ["pdfplumber", "regex", "dateparser"],
         "deb": ["libmupdf-dev", "mupdf", "mupdf-tools", "poppler-utils"],
     },
     "data": [

--- a/edi_pdf2data_oca/__manifest__.py
+++ b/edi_pdf2data_oca/__manifest__.py
@@ -11,7 +11,7 @@
     "website": "https://github.com/OCA/edi",
     "depends": ["edi_oca"],
     "external_dependencies": {
-        "python": ["dateparser==1.1.1"],
+        "python": ["dateparser"],
         "deb": ["poppler-utils"],
     },
     "maintainers": ["etobella"],

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # generated from manifests external_dependencies
-dateparser==1.1.1
+dateparser
 factur-x
 invoice2data
 ovh


### PR DESCRIPTION
Issue reported here https://github.com/OCA/edi/issues/544 is fixed in recent version of dateparser.
Fixed here I believe : https://github.com/scrapinghub/dateparser/issues/1045