### PR TITLE
[14.0] edi_oca: avoid ghost exchange records

### DIFF
--- a/edi_oca/models/edi_exchange_record.py
+++ b/edi_oca/models/edi_exchange_record.py
@@ -423,8 +423,8 @@ class EDIExchangeRecord(models.Model):
             count=False,
             access_rights_uid=access_rights_uid,
         )
-        if self.env.is_superuser():
-            # rules do not apply for the superuser
+        if self.env.is_system():
+            # rules do not apply to group "Settings"
             return len(ids) if count else ids
 
         if not ids:

--- a/edi_oca/tests/test_security.py
+++ b/edi_oca/tests/test_security.py
@@ -159,6 +159,33 @@ class TestEDIExchangeRecordSecurity(EDIBackendCommonTestCase):
             .search_count([("id", "=", exchange_record.id)]),
         )
 
+    def test_search_no_record(self):
+        # Consumer record no longer exists:
+        #  exchange_record is hidden in search
+        exchange_record = self.create_record()
+        exchange_record.res_id = -1
+        self.user.write({"groups_id": [(4, self.group.id)]})
+        self.assertEqual(
+            0,
+            self.env["edi.exchange.record"]
+            .with_user(self.user)
+            .search_count([("id", "=", exchange_record.id)]),
+        )
+
+    def test_search_no_record_admin(self):
+        # Consumer record no longer exists:
+        #  user with group "Settings" has access
+        exchange_record = self.create_record()
+        exchange_record.res_id = -1
+        admin_group = self.env.ref("base.group_system")
+        self.user.write({"groups_id": [(4, admin_group.id)]})
+        self.assertEqual(
+            1,
+            self.env["edi.exchange.record"]
+            .with_user(self.user)
+            .search_count([("id", "=", exchange_record.id)]),
+        )
+
     @mute_logger("odoo.addons.base.models.ir_model")
     def test_no_group_no_write(self):
         exchange_record = self.create_record()


### PR DESCRIPTION
Unrestricted access to admin users (group "Settings")

Having exchange records with non-existent `res_id` does not happen normally.

Main use case is during testing phase, when related records can be deleted for cleaning.
I've proposed PR with minimal change: to be able to retrieve/delete these records when needed (group Admin).