### PR TITLE
[14.0] edi_oca: avoid backend mismatch

### DIFF
--- a/edi_oca/models/edi_backend.py
+++ b/edi_oca/models/edi_backend.py
@@ -178,8 +178,10 @@ class EDIBackend(models.Model):
         return [
             ("code", "=", code),
             "|",
-            ("backend_type_id", "=", self.backend_type_id.id),
             ("backend_id", "=", self.id),
+            "&",
+            ("backend_type_id", "=", self.backend_type_id.id),
+            ("backend_id", "=", False),
         ]
 
     def _delay_action(self, rec):

--- a/edi_oca/tests/test_exchange_type.py
+++ b/edi_oca/tests/test_exchange_type.py
@@ -23,6 +23,25 @@ class EDIExchangeTypeTestCase(EDIBackendCommonTestCase):
             self.exchange_type_out_ack.ack_for_type_ids.ids,
         )
 
+    def test_same_code_same_backend(self):
+        with self.assertRaises(Exception) as err:
+            self.exchange_type_in.copy({"code": "test_csv_input"})
+        err_msg = err.exception.args[0]
+        self.assertTrue(
+            err_msg.startswith("duplicate key value violates unique constraint")
+        )
+
+    def test_same_code_different_backend(self):
+        new_backend = self.backend.copy()
+        new_type = self.exchange_type_in.copy(
+            {"backend_id": new_backend.id, "code": "test_csv_input"}
+        )
+        self.assertEqual(new_type.code, self.exchange_type_in.code)
+        self.assertEqual(
+            new_type.backend_type_id, self.exchange_type_in.backend_type_id
+        )
+        self.assertNotEqual(new_type.backend_id, self.exchange_type_in.backend_id)
+
     def test_advanced_settings(self):
         settings = """
         components:

--- a/edi_oca/tests/test_record.py
+++ b/edi_oca/tests/test_record.py
@@ -46,6 +46,22 @@ class EDIRecordTestCase(EDIBackendCommonTestCase):
                 err.exception.name, "Exchange state must respect direction!"
             )
 
+    def test_record_same_type_code(self):
+        # Two record.exchange.type sharing same code "test_csv_input"
+        # Record should be created with the right backend
+        new_backend = self.backend.copy()
+        self.exchange_type_in.copy(
+            {"backend_id": new_backend.id, "code": "test_csv_input"}
+        )
+        vals = {
+            "model": self.partner._name,
+            "res_id": self.partner.id,
+        }
+        rec1 = self.backend.create_record("test_csv_input", vals)
+        rec2 = new_backend.create_record("test_csv_input", vals)
+        self.assertEqual(rec1.backend_id, self.backend)
+        self.assertEqual(rec2.backend_id, new_backend)
+
     def test_record_exchange_date(self):
         vals = {
             "model": self.partner._name,


### PR DESCRIPTION
Two `edi.exchange.type` can share same `code`, provided that they are not configured on same `edi.backend`.