### PR TITLE
[14.0] sale_order_import: accept default order data via ctx

### DIFF
--- a/sale_order_import/tests/test_order_import.py
+++ b/sale_order_import/tests/test_order_import.py
@@ -58,3 +58,10 @@ class TestOrderImport(TestCommon):
         self.wiz_model.update_order_lines(parsed_order_up, order, "pricelist")
         self.assertEqual(len(order.order_line), 2)
         self.assertEqual(int(order.order_line[0].product_uom_qty), 3)
+
+    def test_order_import_default_so_vals(self):
+        default = {"client_order_ref": "OVERRIDE"}
+        order = self.wiz_model.with_context(
+            sale_order_import__default_vals=dict(order=default)
+        ).create_order(self.parsed_order, "pricelist")
+        self.assertEqual(order.client_order_ref, "OVERRIDE")

--- a/sale_order_import/wizard/sale_order_import.py
+++ b/sale_order_import/wizard/sale_order_import.py
@@ -267,6 +267,11 @@ class SaleOrderImport(models.TransientModel):
                 product, uom, so_vals, line, price_source
             )
             so_vals["order_line"].append((0, 0, line_vals))
+
+        defaults = self.env.context.get("sale_order_import__default_vals", {}).get(
+            "order", {}
+        )
+        so_vals.update(defaults)
         return so_vals
 
     def _validate_currency(self, partner, currency):
@@ -477,6 +482,11 @@ class SaleOrderImport(models.TransientModel):
         for k, v in import_line.items():
             if k not in vals and k in solo._fields:
                 vals[k] = v
+
+        defaults = self.env.context.get("sale_order_import__default_vals", {}).get(
+            "lines", {}
+        )
+        vals.update(defaults)
         return vals
 
     def _prepare_order_line_get_company_id(self, order):


### PR DESCRIPTION
You can now pass 'sale_order_import__default_vals' key in the ctx to pass order values down the stack.