### PR TITLE
[10.0] account_invoice_ubl : Add support for non vat taxes in Peppol BIS Billing 3.0

### DIFF
--- a/account_invoice_ubl/README.rst
+++ b/account_invoice_ubl/README.rst
@@ -45,6 +45,7 @@ Contributors
 ------------
 
 * Alexis de Lattre <alexis.delattre@akretion.com>
+* Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 
 Maintainer
 ----------

--- a/account_invoice_ubl/models/account_invoice.py
+++ b/account_invoice_ubl/models/account_invoice.py
@@ -79,9 +79,8 @@ class AccountInvoice(models.Model):
                 mimeCode="application/pdf", filename=filename)
             ctx = self._context.copy()
             ctx['no_embedded_ubl_xml'] = True
-            pdf_inv = self.pool['report'].get_pdf(
-                self._cr, self._uid, [self.id], 'account.report_invoice',
-                context=ctx)
+            pdf_inv = self.env["report"].get_pdf(
+                [self.id], "account.report_invoice")
             binary_node.text = pdf_inv.encode('base64')
 
     def _ubl_add_legal_monetary_total(self, parent_node, ns, version='2.1'):

--- a/base_ubl/models/ubl.py
+++ b/base_ubl/models/ubl.py
@@ -371,7 +371,7 @@ class BaseUbl(models.AbstractModel):
                     item, ns['cac'] + 'StandardItemIdentification')
                 std_identification_id = etree.SubElement(
                     std_identification, ns['cbc'] + 'ID',
-                    schemeAgencyID='6', schemeID='GTIN')
+                    schemeAgencyID='6', schemeID='0160')  # GTIN = 0160
                 std_identification_id.text = product.barcode
             # I'm not 100% sure, but it seems that ClassifiedTaxCategory
             # contains the taxes of the product without taking into
@@ -652,9 +652,14 @@ class BaseUbl(models.AbstractModel):
         return {}
 
     def ubl_parse_product(self, line_node, ns):
+        # GTIN schemeID is 0160
         barcode_xpath = line_node.xpath(
-            "cac:Item/cac:StandardItemIdentification/cbc:ID[@schemeID='GTIN']",
+            "cac:Item/cac:StandardItemIdentification/cbc:ID[@schemeID='0160']",
             namespaces=ns)
+        if not barcode_xpath:
+            barcode_xpath = line_node.xpath(
+                "cac:Item/cac:StandardItemIdentification/cbc:ID[@schemeID='GTIN']",
+                namespaces=ns)
         code_xpath = line_node.xpath(
             "cac:Item/cac:SellersItemIdentification/cbc:ID", namespaces=ns)
         product_dict = {


### PR DESCRIPTION
* [FIX] account_invoice_ubl: Fix embedded pdf report - Fix the call to generate the embedded pdf report
* [FIX] base_ubl: schemeID for GTIN is 0160
*  [FIX] account_invoice_ubl: Support non-VAT taxes
While Odoo allows to define taxes other than VAT, the Peppol BIS Billing 3.0 does not allow taxes that are non VAT. To solve this, those taxes not subject to VAT are converted as a global extra charge exempt of VAT.
* [FIX] Compute properly the line unit price
* [ADD] Support line discount (and triple discount). The discount is declared in a new line section as AllowanceCharge.
* [FIX] The base unit price is for 1 Unit. In case of tax included in the price, the base unit price must be for the total quantity to prevent rounding issue.
* [FIX] Credit Note: a credit note must follow the CreditNote schema and not the InvoiceSchema

I will fwd this to the other versions after reviews

@alexis-via @thomaspaulb @lmignon 


