### PR TITLE
[13.0][FIX] edi_account & edi_bank_statment_oca: unify menuitems

### DIFF
--- a/edi_account/views/edi_exchange_record.xml
+++ b/edi_account/views/edi_exchange_record.xml
@@ -17,7 +17,7 @@
     <menuitem
         id="menu_account_edi_root"
         name="Exchange records"
-        parent="account.menu_finance_entries"
+        parent="account.menu_finance"
         sequence="20"
     />
     <menuitem

--- a/edi_bank_statement_oca/__manifest__.py
+++ b/edi_bank_statement_oca/__manifest__.py
@@ -9,7 +9,7 @@
     "license": "LGPL-3",
     "author": "ForgeFlow, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/edi",
-    "depends": ["account", "edi", "component_event"],
+    "depends": ["edi_account", "component_event"],
     "data": [
         "views/account_bank_statement_views.xml",
         "views/edi_exchange_record_views.xml",

--- a/edi_bank_statement_oca/views/edi_exchange_record_views.xml
+++ b/edi_bank_statement_oca/views/edi_exchange_record_views.xml
@@ -15,16 +15,10 @@
         <field name="context">{}</field>
     </record>
     <menuitem
-        id="menu_bank_statement_edi_root"
-        name="Exchange records"
-        parent="account.menu_finance_configuration"
-        sequence="20"
-    />
-    <menuitem
         id="menu_bank_statement_edi_exchange_record"
         name="Bank Statements"
         action="act_open_edi_exchange_record_account_bank_statement_view"
-        parent="menu_bank_statement_edi_root"
+        parent="edi_account.menu_account_edi_root"
         sequence="20"
     />
 </odoo>


### PR DESCRIPTION
Both edi_account and edi_bank_statement_oca have an action to view related exchange records, which can be found in:
- Invoicing > Configuration > Exchange Records > Bank Statements (edi_bank_statement_oca)
- Invoicing > Accounting > Exchange Records > Moves (edi_account)

With this PR we will be able to find them both in Invoicing > Exchange Records as it is done in modules such as edi_puchase_oca and edi_stock_oca 