### PR TITLE
account_invoice_facturx: Test: Reset payment method

### DIFF
--- a/account_invoice_facturx/tests/test_facturx_invoice.py
+++ b/account_invoice_facturx/tests/test_facturx_invoice.py
@@ -33,11 +33,16 @@ class TestFacturXInvoice(TransactionCase):
                 "unece_categ_id": self.env.ref("account_tax_unece.tax_categ_s").id,
             }
         )
+        partner = self.env.ref("base.res_partner_2")
+        # Reset payment method to avoid conflict with account_banking_sepa_direct_debit
+        partner.customer_payment_mode_id = self.env.ref(
+            "account_payment_mode.payment_mode_inbound_ct1"
+        )
         self.invoice = self.env["account.move"].create(
             {
                 "company_id": self.company.id,
                 "move_type": "out_invoice",
-                "partner_id": self.env.ref("base.res_partner_2").id,
+                "partner_id": partner.id,
                 "currency_id": self.company.currency_id.id,
                 "invoice_line_ids": [
                     (


### PR DESCRIPTION
This avoids conflicts when tests of the `account_invoice_facturx` module run on a DB where `account_banking_sepa_direct_debit` (OCA/bank-payment) is also installed.

In its demo data, `account_banking_sepa_direct_debit` changes the payment method of the partner used in this test to a SEPA one which has no UNECE code by default (guess it should have one, but that's another issue).

The same partner is used in this test; leads to error:
```
ERROR: TestFacturXInvoice.test_deep_customer_invoice
Traceback (most recent call last):
  File "/opt/odoo/lib/python3.10/site-packages/odoo/addons/account_invoice_facturx/tests/test_facturx_invoice.py", line 93, in test_deep_customer_invoice
    xml_bytes, fx_level = self.invoice.generate_facturx_xml()
  File "/opt/odoo/lib/python3.10/site-packages/odoo/addons/account_invoice_facturx/models/account_move.py", line 871, in generate_facturx_xml
    self._cii_add_trade_settlement_block(trade_transaction, ns)
  File "/opt/odoo/lib/python3.10/site-packages/odoo/addons/account_invoice_facturx/models/account_move.py", line 498, in _cii_add_trade_settlement_block
    raise UserError(
odoo.exceptions.UserError: Missing UNECE code on payment method '[sepa_direct_debit] SEPA Direct Debit for customers (inbound)'
```