### PR TITLE
[13.0][FIX] edi_voxel_sale_order_import: Propagate onchange updates

### DIFF
--- a/edi_voxel_sale_order_import/models/sale_order.py
+++ b/edi_voxel_sale_order_import/models/sale_order.py
@@ -173,7 +173,7 @@ class SaleOrder(models.Model):
             partner = self._parse_partner_data_voxel(partner_data)
             if partner:
                 vals.update(partner_id=partner.id)
-                vals = self.play_onchanges(vals, ["partner_id"])
+                vals.update(self.play_onchanges(vals, ["partner_id"]))
 
     def _parse_customers_data_voxel(self, vals, xml_root, error_msgs):
         customer_elements = xml_root.xpath("//Customers/Customer")


### PR DESCRIPTION
Assigning the result of the `play_onchanges call` to the variable `vals` instantiates a new local variable instead of overwriting the one passed by argument, resulting in losing such updates.

We call `update` instead for dumping the result into the same variable.

TT44738