### PR TITLE
[13.0][FIX] purchase_order_ubl: render_qweb_pdf where res_ids is int

### DIFF
--- a/purchase_order_ubl/models/report.py
+++ b/purchase_order_ubl/models/report.py
@@ -29,6 +29,8 @@ class IrActionsReport(models.Model):
     def render_qweb_pdf(self, res_ids=None, data=None):
         """This is only necessary when tests are enabled.
         It forces the creation of pdf instead of html."""
+        if isinstance(res_ids, int):
+            res_ids = [res_ids]
         if len(res_ids or []) == 1 and not self.env.context.get("no_embedded_ubl_xml"):
             if len(self) == 1 and self.is_ubl_xml_to_embed_in_purchase_order():
                 self = self.with_context(force_report_rendering=True)


### PR DESCRIPTION
In some instances in Odoo's code, they call the render_qweb_pdf using a single id in the res_ids parameter. Ex:
`content, content_type = self.env.ref('account.action_report_account_statement').render_qweb_pdf(statement.id)`