### PR TITLE
[14.0] edi_oca: avoid duplicate `Model` field name

### DIFF
--- a/edi_oca/models/edi_exchange_type_rule.py
+++ b/edi_oca/models/edi_exchange_type_rule.py
@@ -32,7 +32,7 @@ class EDIExchangeTypeRule(models.Model):
         help="Apply to this model",
         ondelete="cascade",
     )
-    model = fields.Char(related="model_id.model")  # Tech field
+    model = fields.Char("Model code", related="model_id.model")  # Tech field
     enable_domain = fields.Char(
         string="Enable on domain", help="Filter domain to be checked on Models"
     )


### PR DESCRIPTION
Avoid warning because of duplicated Model field name while installing this module

```
WARNING odoo odoo.addons.base.models.ir_model: Two fields (model, model_id) of edi.exchange.type.rule() have the same label: Model. 
```