### PR TITLE
[FIX] edi_webservice_oca: add internal user webservice backend read a…

### DIFF
--- a/edi_webservice_oca/models/edi_backend.py
+++ b/edi_webservice_oca/models/edi_backend.py
@@ -5,7 +5,6 @@ from odoo import fields, models
 
 
 class EdiBackend(models.Model):
-
     _inherit = "edi.backend"
 
     webservice_backend_id = fields.Many2one("webservice.backend")
@@ -22,7 +21,7 @@ class EdiBackend(models.Model):
         res = super()._component_match_attrs(exchange_record, key)
         if not self.webservice_backend_id or key not in self._webservice_actions:
             return res
-        res["webservice_protocol"] = self.webservice_backend_id.protocol
+        res["webservice_protocol"] = self.webservice_backend_id.sudo().protocol
         return res
 
     def _component_sort_key(self, component_class):


### PR DESCRIPTION
…ccess

queue.job task are running in the context with the user that create the edi exchage record as those user are able to create exchange they should be able to read webservice backend in order to etablish the connexion to send payloads to the related webserivce