### PR TITLE
[14.0] edi_oca: revert fix on tests for access error

### DIFF
--- a/edi_oca/models/edi_backend.py
+++ b/edi_oca/models/edi_backend.py
@@ -127,7 +127,7 @@ class EDIBackend(models.Model):
                     components, key=lambda x: self._component_sort_key(x), reverse=True
                 )
                 component = components[0](c_work_ctx)
-                _logger.debug("using component", component._name)
+                _logger.debug("using component %s", component._name)
                 break
         if not component and not safe:
             raise NoComponentError(

--- a/edi_oca/models/edi_exchange_record.py
+++ b/edi_oca/models/edi_exchange_record.py
@@ -237,6 +237,7 @@ class EDIExchangeRecord(models.Model):
             rec._execute_next_action()
         return rec
 
+    @api.model
     def _get_identifier(self):
         return self.env["ir.sequence"].next_by_code("edi.exchange")
 

--- a/edi_oca/tests/test_backend_base.py
+++ b/edi_oca/tests/test_backend_base.py
@@ -7,7 +7,7 @@ from freezegun import freeze_time
 from .common import EDIBackendCommonTestCase
 
 
-class EDIBackendTestCase(EDIBackendCommonTestCase):
+class EDIBackendTestCaseBase(EDIBackendCommonTestCase):
     @freeze_time("2020-10-21 10:00:00")
     def test_create_record(self):
         self.env.user.tz = None  # Have no timezone used in generated filename

--- a/edi_oca/tests/test_backend_input.py
+++ b/edi_oca/tests/test_backend_input.py
@@ -2,17 +2,11 @@
 # @author: Simone Orsi <simahawk@gmail.com>
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 
-# import mock
-# from freezegun import freeze_time
-
-# from odoo import fields
-# from odoo.exceptions import UserError
-
 from .common import EDIBackendCommonComponentRegistryTestCase
 from .fake_components import FakeInputReceive
 
 
-class EDIBackendTestCase(EDIBackendCommonComponentRegistryTestCase):
+class EDIBackendTestInputCase(EDIBackendCommonComponentRegistryTestCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()

--- a/edi_oca/tests/test_backend_jobs.py
+++ b/edi_oca/tests/test_backend_jobs.py
@@ -7,7 +7,7 @@ from odoo.addons.queue_job.tests.common import JobMixin
 from .common import EDIBackendCommonTestCase
 
 
-class EDIBackendTestCase(EDIBackendCommonTestCase, JobMixin):
+class EDIBackendTestJobsCase(EDIBackendCommonTestCase, JobMixin):
     @classmethod
     def _setup_context(cls):
         return dict(super()._setup_context(), test_queue_job_no_delay=None)

--- a/edi_oca/tests/test_backend_output.py
+++ b/edi_oca/tests/test_backend_output.py
@@ -12,7 +12,7 @@ from .common import EDIBackendCommonComponentRegistryTestCase
 from .fake_components import FakeOutputChecker, FakeOutputGenerator, FakeOutputSender
 
 
-class EDIBackendTestCase(EDIBackendCommonComponentRegistryTestCase):
+class EDIBackendTestOutputCase(EDIBackendCommonComponentRegistryTestCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()

--- a/edi_oca/tests/test_backend_process.py
+++ b/edi_oca/tests/test_backend_process.py
@@ -14,7 +14,7 @@ from .common import EDIBackendCommonComponentRegistryTestCase
 from .fake_components import FakeInputProcess
 
 
-class EDIBackendTestCase(EDIBackendCommonComponentRegistryTestCase):
+class EDIBackendTestProcessCase(EDIBackendCommonComponentRegistryTestCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()

--- a/edi_oca/tests/test_backend_validate.py
+++ b/edi_oca/tests/test_backend_validate.py
@@ -14,7 +14,7 @@ from .fake_components import (
 )
 
 
-class EDIBackendTestCase(EDIBackendCommonComponentRegistryTestCase):
+class EDIBackendTestValidateCase(EDIBackendCommonComponentRegistryTestCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()

--- a/edi_oca/tests/test_component_match.py
+++ b/edi_oca/tests/test_component_match.py
@@ -7,7 +7,7 @@ from odoo.addons.component.core import Component
 from .common import EDIBackendCommonComponentRegistryTestCase
 
 
-class EDIBackendTestCase(EDIBackendCommonComponentRegistryTestCase):
+class EDIBackendTestMatchCase(EDIBackendCommonComponentRegistryTestCase):
     def test_component_match(self):
         """Lookup with special match method."""
 

--- a/edi_oca/tests/test_edi_backend_cron.py
+++ b/edi_oca/tests/test_edi_backend_cron.py
@@ -10,7 +10,7 @@ from .fake_components import FakeOutputChecker, FakeOutputGenerator, FakeOutputS
 LOGGERS = ("odoo.addons.edi_oca.models.edi_backend", "odoo.addons.queue_job.delay")
 
 
-class EDIBackendTestCase(EDIBackendCommonComponentRegistryTestCase):
+class EDIBackendTestCronCase(EDIBackendCommonComponentRegistryTestCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()

--- a/edi_oca/tests/test_security.py
+++ b/edi_oca/tests/test_security.py
@@ -86,7 +86,9 @@ class TestEDIExchangeRecordSecurity(EDIBackendCommonTestCase):
     def test_rule_no_create(self):
         self.user.write({"groups_id": [(4, self.group.id)]})
         self.consumer_record.name = "no_rule"
-        with self.assertRaisesRegex(AccessError, "Exchange Record rule demo"):
+        model = self.consumer_record
+        msg = rf"not allowed to modify '{model._description}' \({model._name}\)"
+        with self.assertRaisesRegex(AccessError, msg):
             self.create_record(self.user)
 
     @mute_logger("odoo.addons.base.models.ir_model")
@@ -97,7 +99,9 @@ class TestEDIExchangeRecordSecurity(EDIBackendCommonTestCase):
     @mute_logger("odoo.addons.base.models.ir_model")
     def test_no_group_no_read(self):
         exchange_record = self.create_record()
-        with self.assertRaisesRegex(AccessError, "You are not allowed to access"):
+        model = self.consumer_record
+        msg = rf"not allowed to access '{model._description}' \({model._name}\)"
+        with self.assertRaisesRegex(AccessError, msg):
             exchange_record.with_user(self.user).read()
 
     @mute_logger("odoo.addons.base.models.ir_rule")
@@ -106,7 +110,9 @@ class TestEDIExchangeRecordSecurity(EDIBackendCommonTestCase):
         self.user.write({"groups_id": [(4, self.group.id)]})
         self.assertTrue(exchange_record.with_user(self.user).read())
         self.consumer_record.name = "no_rule"
-        with self.assertRaisesRegex(AccessError, "Exchange Record rule demo"):
+        model = self.consumer_record
+        msg = rf"not allowed to access '{model._description}' \({model._name}\)"
+        with self.assertRaisesRegex(AccessError, msg):
             exchange_record.with_user(self.user).read()
 
     @mute_logger("odoo.addons.base.models.ir_model")
@@ -126,7 +132,9 @@ class TestEDIExchangeRecordSecurity(EDIBackendCommonTestCase):
         exchange_record = self.create_record()
         self.user.write({"groups_id": [(4, self.group.id)]})
         self.consumer_record.name = "no_rule"
-        with self.assertRaisesRegex(AccessError, "Exchange Record rule demo"):
+        model = self.consumer_record
+        msg = rf"not allowed to modify '{model._description}' \({model._name}\)"
+        with self.assertRaisesRegex(AccessError, msg):
             exchange_record.with_user(self.user).unlink()
 
     def test_no_group_no_search(self):
@@ -211,5 +219,7 @@ class TestEDIExchangeRecordSecurity(EDIBackendCommonTestCase):
         exchange_record = self.create_record()
         self.user.write({"groups_id": [(4, self.group.id)]})
         self.consumer_record.name = "no_rule"
-        with self.assertRaisesRegex(AccessError, "Exchange Record rule demo"):
+        model = self.consumer_record
+        msg = rf"not allowed to modify '{model._description}' \({model._name}\)"
+        with self.assertRaisesRegex(AccessError, msg):
             exchange_record.with_user(self.user).write({"external_identifier": "1234"})

--- a/edi_oca/tests/test_security.py
+++ b/edi_oca/tests/test_security.py
@@ -86,18 +86,18 @@ class TestEDIExchangeRecordSecurity(EDIBackendCommonTestCase):
     def test_rule_no_create(self):
         self.user.write({"groups_id": [(4, self.group.id)]})
         self.consumer_record.name = "no_rule"
-        with self.assertRaises(AccessError):
+        with self.assertRaisesRegex(AccessError, "Exchange Record rule demo"):
             self.create_record(self.user)
 
     @mute_logger("odoo.addons.base.models.ir_model")
     def test_no_group_no_create(self):
-        with self.assertRaises(AccessError):
+        with self.assertRaisesRegex(AccessError, "You are not allowed to modify"):
             self.create_record(self.user)
 
     @mute_logger("odoo.addons.base.models.ir_model")
     def test_no_group_no_read(self):
         exchange_record = self.create_record()
-        with self.assertRaises(AccessError):
+        with self.assertRaisesRegex(AccessError, "You are not allowed to access"):
             exchange_record.with_user(self.user).read()
 
     @mute_logger("odoo.addons.base.models.ir_rule")
@@ -106,13 +106,13 @@ class TestEDIExchangeRecordSecurity(EDIBackendCommonTestCase):
         self.user.write({"groups_id": [(4, self.group.id)]})
         self.assertTrue(exchange_record.with_user(self.user).read())
         self.consumer_record.name = "no_rule"
-        with self.assertRaises(AccessError):
+        with self.assertRaisesRegex(AccessError, "Exchange Record rule demo"):
             exchange_record.with_user(self.user).read()
 
     @mute_logger("odoo.addons.base.models.ir_model")
     def test_no_group_no_unlink(self):
         exchange_record = self.create_record()
-        with self.assertRaises(AccessError):
+        with self.assertRaisesRegex(AccessError, "You are not allowed to modify"):
             exchange_record.with_user(self.user).unlink()
 
     @mute_logger("odoo.models.unlink")
@@ -126,7 +126,7 @@ class TestEDIExchangeRecordSecurity(EDIBackendCommonTestCase):
         exchange_record = self.create_record()
         self.user.write({"groups_id": [(4, self.group.id)]})
         self.consumer_record.name = "no_rule"
-        with self.assertRaises(AccessError):
+        with self.assertRaisesRegex(AccessError, "Exchange Record rule demo"):
             exchange_record.with_user(self.user).unlink()
 
     def test_no_group_no_search(self):
@@ -197,7 +197,7 @@ class TestEDIExchangeRecordSecurity(EDIBackendCommonTestCase):
     @mute_logger("odoo.addons.base.models.ir_model")
     def test_no_group_no_write(self):
         exchange_record = self.create_record()
-        with self.assertRaises(AccessError):
+        with self.assertRaisesRegex(AccessError, "You are not allowed to modify"):
             exchange_record.with_user(self.user).write({"external_identifier": "1234"})
 
     def test_group_write(self):
@@ -211,5 +211,5 @@ class TestEDIExchangeRecordSecurity(EDIBackendCommonTestCase):
         exchange_record = self.create_record()
         self.user.write({"groups_id": [(4, self.group.id)]})
         self.consumer_record.name = "no_rule"
-        with self.assertRaises(AccessError):
+        with self.assertRaisesRegex(AccessError, "Exchange Record rule demo"):
             exchange_record.with_user(self.user).write({"external_identifier": "1234"})

--- a/edi_oca/views/edi_backend_views.xml
+++ b/edi_oca/views/edi_backend_views.xml
@@ -3,7 +3,7 @@
     <record id="edi_backend_view_tree" model="ir.ui.view">
         <field name="model">edi.backend</field>
         <field name="arch" type="xml">
-            <tree string="EDI Backend" decoration-muted="(not active)">
+            <tree decoration-muted="(not active)">
                 <field name="name" />
                 <field name="active" />
             </tree>
@@ -12,7 +12,7 @@
     <record id="edi_backend_view_form" model="ir.ui.view">
         <field name="model">edi.backend</field>
         <field name="arch" type="xml">
-            <form string="EDI Backend">
+            <form>
                 <sheet>
                     <widget
                         name="web_ribbon"

--- a/edi_oca/views/edi_backend_views.xml
+++ b/edi_oca/views/edi_backend_views.xml
@@ -3,7 +3,7 @@
     <record id="edi_backend_view_tree" model="ir.ui.view">
         <field name="model">edi.backend</field>
         <field name="arch" type="xml">
-            <tree decoration-muted="(not active)">
+            <tree string="EDI Backend" decoration-muted="(not active)">
                 <field name="name" />
                 <field name="active" />
             </tree>
@@ -12,7 +12,7 @@
     <record id="edi_backend_view_form" model="ir.ui.view">
         <field name="model">edi.backend</field>
         <field name="arch" type="xml">
-            <form>
+            <form string="EDI Backend">
                 <sheet>
                     <widget
                         name="web_ribbon"


### PR DESCRIPTION
Fixes https://github.com/OCA/edi/issues/818
Revert https://github.com/OCA/edi/pull/819 with https://github.com/OCA/edi/pull/822/commits/7612ed31adddbaedee4e742ad3690bd255b0247d
Plus... backport fixes from https://github.com/OCA/edi-framework/pull/5