### PR TITLE
[14.0] edi: fix handling of archived types and rules

### DIFF
--- a/edi_oca/models/edi_exchange_type.py
+++ b/edi_oca/models/edi_exchange_type.py
@@ -30,7 +30,7 @@ class EDIExchangeType(models.Model):
     _name = "edi.exchange.type"
     _description = "EDI Exchange Type"
 
-    active = fields.Boolean(default=True)
+    active = fields.Boolean(default=True, inverse="_inverse_active")
     backend_id = fields.Many2one(
         string="Backend",
         comodel_name="edi.backend",
@@ -160,6 +160,12 @@ class EDIExchangeType(models.Model):
             "The code must be unique per backend",
         )
     ]
+
+    def _inverse_active(self):
+        for rec in self:
+            # Disable rules if type gets disabled
+            if not rec.active:
+                rec.rule_ids.active = False
 
     @api.depends("advanced_settings_edit")
     def _compute_advanced_settings(self):

--- a/edi_oca/tests/test_exchange_type.py
+++ b/edi_oca/tests/test_exchange_type.py
@@ -123,3 +123,25 @@ class EDIExchangeTypeTestCase(EDIBackendCommonTestCase):
             date_pattern: '%Y-%m-%d-%H-%M'
         """
         self._test_exchange_filename("Test-File-2022-04-28-10-37.csv")
+
+    def test_archive_rules(self):
+        exc_type = self.exchange_type_out
+        rule1 = exc_type.rule_ids.create(
+            {
+                "type_id": exc_type.id,
+                "name": "Fake partner rule",
+                "model_id": self.env["ir.model"]._get("res.partner").id,
+            }
+        )
+        rule2 = exc_type.rule_ids.create(
+            {
+                "type_id": exc_type.id,
+                "name": "Fake user rule",
+                "model_id": self.env["ir.model"]._get("res.users").id,
+            }
+        )
+        exc_type.active = False
+        rule1.invalidate_cache()
+        rule2.invalidate_cache()
+        self.assertFalse(rule1.active)
+        self.assertFalse(rule2.active)

--- a/edi_oca/views/edi_exchange_type_views.xml
+++ b/edi_oca/views/edi_exchange_type_views.xml
@@ -73,7 +73,7 @@
                                 context="{'default_type_id': active_id}"
                             >
                                 <tree decoration-muted="(not active)">
-                                    <field name="active" invisible="1" />
+                                    <field name="active" widget="boolean_toggle" />
                                     <field name="name" />
                                     <field name="model_id" />
                                     <field name="kind" />

--- a/edi_oca/views/edi_exchange_type_views.xml
+++ b/edi_oca/views/edi_exchange_type_views.xml
@@ -168,7 +168,14 @@
         <field name="view_mode">tree,form</field>
         <field name="search_view_id" ref="edi_exchange_type_view_search" />
         <field name="domain">[]</field>
-        <field name="context">{'search_default_filter_all': 1}</field>
+        <!--
+          `active_test` here is fundamental to see archived `rule_ids`.
+          Reason: when related fields are loaded with a `read`
+          the ctx that you could set at field level on the view is lost.
+        -->
+        <field
+            name="context"
+        >{'search_default_filter_all': 1, 'active_test': False}</field>
     </record>
     <record
         model="ir.actions.act_window.view"


### PR DESCRIPTION
* archived rules must be visible on their type form
* when a type is archived, rules must be archived too
* ease archive/unarchive from type form