### PR TITLE
[14.0][FIX] edi_oca: avoid flooding error in the record chatter

### DIFF
--- a/edi_oca/models/edi_backend.py
+++ b/edi_oca/models/edi_backend.py
@@ -453,7 +453,7 @@ class EDIBackend(models.Model):
         check = self._exchange_process_check(exchange_record)
         if not check:
             return False
-        state = exchange_record.edi_exchange_state
+        old_state = state = exchange_record.edi_exchange_state
         error = False
         message = None
         try:
@@ -478,7 +478,10 @@ class EDIBackend(models.Model):
                     "exchanged_on": fields.Datetime.now(),
                 }
             )
-            if state == "input_processed_error":
+            if (
+                state == "input_processed_error"
+                and old_state != "input_processed_error"
+            ):
                 exchange_record._notify_error("process_ko")
             elif state == "input_processed":
                 exchange_record._notify_done()


### PR DESCRIPTION
If the exchange record is linked to a record, and the `process` fails, then it happens this, which is ugly:
![Selection_2088](https://github.com/OCA/edi/assets/25005517/2922e744-1465-43a0-9520-200f3fc3181b)
