### PR TITLE
account_invoice_facturx: Report: Get report name

### DIFF
--- a/account_invoice_facturx/models/ir_actions_report.py
+++ b/account_invoice_facturx/models/ir_actions_report.py
@@ -23,7 +23,7 @@ class IrActionsReport(models.Model):
             collected_streams
             and res_ids
             and len(res_ids) == 1
-            and report_ref in invoice_reports
+            and self._get_report(report_ref).report_name in invoice_reports
             and not self.env.context.get("no_embedded_factur-x_xml")
         ):
             move = amo.browse(res_ids)


### PR DESCRIPTION
Obtain the report first before obtaining the report name from a reference. This is because,
        report_ref: can be one of the following
            - ir.actions.report id
            - report record ir.actions.ir
            - ir.model.data reference to ir.actions.report
            - ir.actions.report report_name

This allows us to avoid this kind of error: "_UserWarning: unsupported operand type(s) for "==": 'ir.actions.report()' == ''account.report_invoice''_ "