### PR TITLE
[15.0][FIX] edi_voxel_stock_picking_oca: Proper action_done method

### DIFF
--- a/edi_voxel_stock_picking_oca/models/stock_picking.py
+++ b/edi_voxel_stock_picking_oca/models/stock_picking.py
@@ -52,8 +52,8 @@ class Picking(models.Model):
             ]
         return [("id", "in", self.search(domain).ids)]
 
-    def action_done(self):
-        res = super(Picking, self).action_done()
+    def _action_done(self):
+        res = super()._action_done()
         for picking in self.filtered(lambda p: p.picking_type_code == "outgoing"):
             picking.action_send_to_voxel()
         return res


### PR DESCRIPTION
`action_done` no longer exists. It's `_action_done`.

@Tecnativa TT46226