### PR TITLE
[16.0][FIX] base_business_document_import tests

### DIFF
--- a/base_business_document_import/tests/test_business_document_import.py
+++ b/base_business_document_import/tests/test_business_document_import.py
@@ -96,7 +96,7 @@ class TestBaseBusinessDocumentImport(TransactionCase):
             "xmlid": "base.main_partner",
         }
         partner = bdio._direct_match(partner_dict, self.env["res.partner"], True)
-        self.assertEqual(partner.name, "YourCompany")
+        self.assertEqual(partner.id, self.env.ref("base.main_partner").id)
 
     def test_match_partner_ref(self):
         partner1 = self.env["res.partner"].create(


### PR DESCRIPTION
- default `base.main_partner`'s name is "YourCompany" but if stock module is installed, it is changed to "My Company (San Francisco)"
- so here's a fix for tests to pass with or without stock module installed