### PR TITLE
[16.0][FIX] base_ubl: schemeID for GTIN is 0160

### DIFF
--- a/base_ubl/models/ubl.py
+++ b/base_ubl/models/ubl.py
@@ -421,7 +421,7 @@ class BaseUbl(models.AbstractModel):
                     std_identification,
                     ns["cbc"] + "ID",
                     schemeAgencyID="6",
-                    schemeID="GTIN",
+                    schemeID="0160",  # GTIN = 0160
                 )
                 std_identification_id.text = product.barcode
             # I'm not 100% sure, but it seems that ClassifiedTaxCategory
@@ -784,8 +784,9 @@ class BaseUbl(models.AbstractModel):
         return {}
 
     def ubl_parse_product(self, line_node, ns):
+        # GTIN schemeID is 0160 in peppol
         barcode_xpath = line_node.xpath(
-            "cac:Item/cac:StandardItemIdentification/cbc:ID[@schemeID='GTIN']",
+            "cac:Item/cac:StandardItemIdentification/cbc:ID[@schemeID=('0160' or 'GTIN')]",
             namespaces=ns,
         )
         code_xpath = line_node.xpath(

--- a/base_ubl/tests/__init__.py
+++ b/base_ubl/tests/__init__.py
@@ -1,3 +1,4 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from . import test_ubl_generate
+from . import test_ubl_parse

--- a/base_ubl/tests/test_ubl_parse.py
+++ b/base_ubl/tests/test_ubl_parse.py
@@ -1,0 +1,56 @@
+# Copyright 2024 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from lxml import etree
+
+from odoo.tests.common import TransactionCase
+
+
+class TestBaseUblParse(TransactionCase):
+    def test_parse_product_schemeid_gtin(self):
+        xml_string = b"""<?xml version="1.0" encoding="UTF-8" ?>
+        <Root
+            xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2"
+            xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+        >
+            <cac:Item>
+                <cbc:Description>Acme beeswax</cbc:Description>
+                <cbc:Name>beeswax</cbc:Name>
+                <cac:StandardItemIdentification>
+                    <cbc:ID schemeID="GTIN">6578489</cbc:ID>
+                </cac:StandardItemIdentification>
+                <cac:SellersItemIdentification>
+                    <cbc:ID>17589683</cbc:ID>
+                </cac:SellersItemIdentification>
+            </cac:Item>
+        </Root>
+        """
+        xml_root = etree.fromstring(xml_string)
+        ns = xml_root.nsmap
+        product = self.env["base.ubl"].ubl_parse_product(xml_root, ns)
+        self.assertEqual(product.get("barcode"), "6578489")
+        self.assertEqual(product.get("code"), "17589683")
+
+    def test_parse_product_schemeid_0160(self):
+        xml_string = b"""<?xml version="1.0" encoding="UTF-8" ?>
+        <Root
+            xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2"
+            xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+        >
+            <cac:Item>
+                <cbc:Description>Acme beeswax</cbc:Description>
+                <cbc:Name>beeswax</cbc:Name>
+                <cac:StandardItemIdentification>
+                    <cbc:ID schemeID="0160">6578489</cbc:ID>
+                </cac:StandardItemIdentification>
+                <cac:SellersItemIdentification>
+                    <cbc:ID>17589683</cbc:ID>
+                </cac:SellersItemIdentification>
+            </cac:Item>
+        </Root>
+        """
+        xml_root = etree.fromstring(xml_string)
+        ns = xml_root.nsmap
+        product = self.env["base.ubl"].ubl_parse_product(xml_root, ns)
+        self.assertEqual(product.get("barcode"), "6578489")
+        self.assertEqual(product.get("code"), "17589683")


### PR DESCRIPTION
Added support for 0160 schemeID on top of GTIN