### PR TITLE
[15.0][FIX] edi_oca: avoid pre-migrate error

### DIFF
--- a/edi_oca/migrations/15.0.1.6.0/pre-migrate.py
+++ b/edi_oca/migrations/15.0.1.6.0/pre-migrate.py
@@ -10,7 +10,9 @@ _logger = logging.getLogger(__name__)
 
 
 def migrate(cr, version):
-    if not version:
+    if not version or not tools.sql.column_exists(
+        cr, "edi_exchange_type", "model_manual_btn"
+    ):
         return
 
     # Backup old style rules to be used later on post migrate


### PR DESCRIPTION
Column _model_manual_btn_ for table _edi_exchange_type_ does not exist for versions 13 and lower. So if a migration is being performed from some of those versions to version 15, the pre-migrate script may give an error when executing the SQL query with that column. 