### PR TITLE
[16.0][FIX + IMP] pdf helper: Fix multi-attachments + Add pdf_embed_xml

### DIFF
--- a/base_ubl/models/ubl.py
+++ b/base_ubl/models/ubl.py
@@ -14,12 +14,6 @@ from odoo.tools import file_open, float_is_zero, float_round
 
 logger = logging.getLogger(__name__)
 
-try:
-    from PyPDF2 import PdfFileReader, PdfFileWriter
-    from PyPDF2.generic import NameObject
-except ImportError:
-    logger.debug("Cannot import PyPDF2")
-
 
 class BaseUbl(models.AbstractModel):
     _name = "base.ubl"
@@ -593,23 +587,18 @@ class BaseUbl(models.AbstractModel):
             ) from e
         return True
 
-    # TODO: move to pdf_helper
     @api.model
     def _ubl_add_xml_in_pdf_buffer(self, xml_string, xml_filename, buffer):
-        # Add attachment to PDF content.
-        reader = PdfFileReader(buffer)
-        writer = PdfFileWriter()
-        writer.appendPagesFromReader(reader)
-        writer.addAttachment(xml_filename, xml_string)
-        # show attachments when opening PDF
-        writer._root_object.update(
-            {NameObject("/PageMode"): NameObject("/UseAttachments")}
+        logger.warning(
+            "`_ubl_add_xml_in_pdf_buffer` deprecated: use `pdf.helper.pdf_embed_xml`"
         )
-        new_buffer = BytesIO()
-        writer.write(new_buffer)
+        pdf_content = buffer.getvalue()
+        new_content = self.env["pdf.helper"].pdf_embed_xml(
+            pdf_content, xml_filename, xml_string
+        )
+        new_buffer = BytesIO(new_content)
         return new_buffer
 
-    # TODO: move to pdf_helper
     @api.model
     def _embed_ubl_xml_in_pdf_content(self, xml_string, xml_filename, pdf_content):
         """Add the attachments to the PDF content.
@@ -617,16 +606,14 @@ class BaseUbl(models.AbstractModel):
         -> it will return the new PDF binary with the embedded XML
         (used for qweb-pdf reports)
         """
+        logger.warning(
+            "`_embed_ubl_xml_in_pdf_content` deprecated: use `pdf.helper.pdf_embed_xml`"
+        )
         self.ensure_one()
         logger.debug("Starting to embed %s in PDF", xml_filename)
-
-        with BytesIO(pdf_content) as reader_buffer:
-            buffer = self._ubl_add_xml_in_pdf_buffer(
-                xml_string, xml_filename, reader_buffer
-            )
-        pdf_content = buffer.getvalue()
-        buffer.close()
-
+        pdf_content = self.env["pdf.helper"].pdf_embed_xml(
+            pdf_content, xml_filename, xml_string
+        )
         logger.info("%s file added to PDF content", xml_filename)
         return pdf_content
 
@@ -649,8 +636,8 @@ class BaseUbl(models.AbstractModel):
         if pdf_file:
             with open(pdf_file, "rb") as f:
                 pdf_content = f.read()
-        updated_pdf_content = self._embed_ubl_xml_in_pdf_content(
-            xml_string, xml_filename, pdf_content
+        updated_pdf_content = self.env["pdf.helper"].pdf_embed_xml(
+            pdf_content, xml_filename, xml_string
         )
         if pdf_file:
             with open(pdf_file, "wb") as f:

--- a/pdf_helper/models/helper.py
+++ b/pdf_helper/models/helper.py
@@ -7,7 +7,7 @@ import io
 import logging
 
 from odoo import api, models
-from odoo.tools.pdf import OdooPdfFileReader, OdooPdfFileWriter
+from odoo.tools.pdf import NameObject, OdooPdfFileReader, OdooPdfFileWriter
 
 from ..utils import PDFParser
 
@@ -42,5 +42,9 @@ class PDFHelper(models.AbstractModel):
             writer = OdooPdfFileWriter()
             writer.cloneReaderDocumentRoot(reader)
             writer.addAttachment(xml_filename, xml_string, subtype="text/xml")
+            # show attachments when opening PDF
+            writer._root_object.update(
+                {NameObject("/PageMode"): NameObject("/UseAttachments")}
+            )
             writer.write(new_pdf_stream)
             return new_pdf_stream.getvalue()

--- a/pdf_helper/models/helper.py
+++ b/pdf_helper/models/helper.py
@@ -1,11 +1,11 @@
 # Copyright 2022 Camptocamp SA
 # @author: Simone Orsi <simahawk@gmail.com>
+# Copyright 2023 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
 import logging
 
-from PyPDF2.utils import PdfReadError
-
-from odoo import models
+from odoo import api, models
 
 from ..utils import PDFParser
 
@@ -18,16 +18,16 @@ class PDFHelper(models.AbstractModel):
 
     _PDF_PARSER_KLASS = PDFParser
 
+    @api.model
     def pdf_get_xml_files(self, pdf_file):
+        """Extract XML attachments from pdf
+
+        :param pdf_file: binary PDF file content
+        :returns: a dict like {$filename: $parsed_xml_file_obj}.
+        """
         parser = self._PDF_PARSER_KLASS(pdf_file)
         try:
             return parser.get_xml_files()
-        except self._pdf_get_xml_files_swallable_exceptions() as err:
-            # TODO: can't we catch specific exceptions?
-            # This try/except block was added to reflect what done
-            # in base_business_document_import till now.
+        except parser.get_xml_files_swallable_exceptions() as err:
             _logger.error("PDF file parsing failed: %s", str(err))
             return {}
-
-    def _pdf_get_xml_files_swallable_exceptions(self):
-        return (KeyError, PdfReadError)

--- a/pdf_helper/readme/CONTRIBUTORS.rst
+++ b/pdf_helper/readme/CONTRIBUTORS.rst
@@ -1,2 +1,3 @@
 * Simone Orsi <simone.orsi@camptocamp.com>
 * Alexis de Lattre <alexis.delattre@akretion.com>
+* Jacques-Etienne Baudoux (BCIM) <je@bcim.be>

--- a/pdf_helper/readme/USAGE.rst
+++ b/pdf_helper/readme/USAGE.rst
@@ -2,6 +2,8 @@ Inside Odoo env::
 
     res = env["pdf.helper"].pdf_get_xml_files(pdf_filecontent)
 
+    new_pdf_filecontent = env["pdf.helper"].pdf_embed_xml(pdf_filecontent, filename, xml)
+
 Outside Odoo env::
 
     from odoo.addons.pdf_helper.utils import PDFParser

--- a/pdf_helper/tests/test_helper.py
+++ b/pdf_helper/tests/test_helper.py
@@ -43,3 +43,15 @@ class TestPDFHelper(TransactionCase):
                 "PDF file parsing failed: Cannot read an empty file",
                 log_catcher.output[0],
             )
+
+    def test_embed_xml(self):
+        pdf_content = read_test_file("pdf_with_xml_test.pdf", mode="rb")
+        filename = "test"
+        xml = b"<root>test</root>"
+        newpdf_content = self.env["pdf.helper"].pdf_embed_xml(
+            pdf_content, filename, xml
+        )
+        attachments = self.env["pdf.helper"].pdf_get_xml_files(newpdf_content)
+        self.assertTrue(filename in attachments)
+        etree_content = attachments[filename]
+        self.assertEqual(xml, etree.tostring(etree_content))

--- a/pdf_helper/tests/test_helper.py
+++ b/pdf_helper/tests/test_helper.py
@@ -27,14 +27,14 @@ class TestPDFHelperUtils(TestCase):
 
 
 class TestPDFHelper(TransactionCase):
-    def test_parse_xml(self):
+    def test_get_xml(self):
         pdf_content = read_test_file("pdf_with_xml_test.pdf", mode="rb")
         res = self.env["pdf.helper"].pdf_get_xml_files(pdf_content)
         fname, xml_root = tuple(res.items())[0]
         self.assertEqual(fname, "factur-x.xml")
         self.assertTrue(isinstance(xml_root, etree._Element))
 
-    def test_parse_xml_fail(self):
+    def test_get_xml_fail(self):
         with self.assertLogs(
             "odoo.addons.pdf_helper.models.helper", level="ERROR"
         ) as log_catcher:


### PR DESCRIPTION
* Extraction of the xml file was failing when there are multi attachments in the PDF. Replaced parser code by odoo.tools.pdf and only return XML data
* Add a new helper to easily embed an attachment in a PDF.
* base_ubl: use new pdf.helper.pdf_embed_xml
  * Mark _ubl_add_xml_in_pdf_buffer as deprecated
  * Mark _embed_ubl_xml_in_pdf_content as deprecated
    
    