### PR TITLE
[16.0][FIX] base_ubl: street3 in UBL generation

### DIFF
--- a/base_ubl/models/ubl.py
+++ b/base_ubl/models/ubl.py
@@ -38,17 +38,31 @@ class BaseUbl(models.AbstractModel):
     @api.model
     def _ubl_add_address(self, partner, node_name, parent_node, ns, version="2.1"):
         address = etree.SubElement(parent_node, ns["cac"] + node_name)
-        if partner.street:
+        if partner.street or partner.street2:
             streetname = etree.SubElement(address, ns["cbc"] + "StreetName")
-            streetname.text = partner.street
-        if partner.street2:
+            streetname.text = partner.street or partner.street2
+        if partner.street and partner.street2:
             addstreetname = etree.SubElement(
                 address, ns["cbc"] + "AdditionalStreetName"
             )
             addstreetname.text = partner.street2
+        # if oca/partner-contact/partner_address_street3 is installed
         if hasattr(partner, "street3") and partner.street3:
-            blockname = etree.SubElement(address, ns["cbc"] + "BlockName")
-            blockname.text = partner.street3
+            # In an address, the real street is usually put in the last field
+            if partner.street and partner.street2:
+                # The first field is usually the Department
+                department = etree.SubElement(address, ns["cbc"] + "Department")
+                department.text = partner.street
+                streetname.text = partner.street2
+                addstreetname.text = partner.street3
+            elif partner.street or partner.street2:
+                addstreetname = etree.SubElement(
+                    address, ns["cbc"] + "AdditionalStreetName"
+                )
+                addstreetname.text = partner.street3
+            else:
+                streetname = etree.SubElement(address, ns["cbc"] + "StreetName")
+                streetname.text = partner.street3
         if partner.city:
             city = etree.SubElement(address, ns["cbc"] + "CityName")
             city.text = partner.city


### PR DESCRIPTION
In an address, the real street is usually put on the last "street" field. Ensure we get this in StreetName or AdditionalStreetName but not in another element.

Example from https://en.wikipedia.org/wiki/Address
 - name: Ms H Williams
 - street: Finance and Accounting
 - street2: Australia Post
 - street3: 219–241 Cleveland St

Also improve UBL generation in case one of the street field is empty

cc @simahawk @nilshamerlinck 