### PR TITLE
[16.0][FIX] account_invoice_facturx: crash when name is empty on invoice line

### DIFF
--- a/account_invoice_facturx/__manifest__.py
+++ b/account_invoice_facturx/__manifest__.py
@@ -20,6 +20,7 @@
     "external_dependencies": {"python": ["factur-x"]},
     "data": [
         "views/res_partner.xml",
+        "views/account_move.xml",
         "views/res_config_settings.xml",
     ],
     "post_init_hook": "set_xml_format_in_pdf_invoice_to_facturx",

--- a/account_invoice_facturx/models/account_move.py
+++ b/account_invoice_facturx/models/account_move.py
@@ -614,7 +614,7 @@ class AccountMove(models.Model):
                 )
                 product_code.text = iline.product_id.default_code
         product_name = etree.SubElement(trade_product, ns["ram"] + "Name")
-        product_name.text = iline.name
+        product_name.text = iline.name or _("No invoice line label")
         if (
             ns["level"] in PROFILES_EN_UP
             and iline.product_id

--- a/account_invoice_facturx/static/description/index.html
+++ b/account_invoice_facturx/static/description/index.html
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>

--- a/account_invoice_facturx/views/account_move.xml
+++ b/account_invoice_facturx/views/account_move.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+  Copyright 2024 Akretion France (http://www.akretion.com/)
+  @author: Alexis de Lattre <alexis.delattre@akretion.com>
+  License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+-->
+<odoo>
+
+
+<record id="view_move_form" model="ir.ui.view">
+    <field name="model">account.move</field>
+    <field name="inherit_id" ref="account.view_move_form" />
+    <field name="arch" type="xml">
+        <xpath
+                expr="//page[@id='invoice_tab']/field[@name='invoice_line_ids']/tree/field[@name='name']"
+                position="attributes"
+            >
+            <attribute name="required">1</attribute>
+        </xpath>
+    </field>
+</record>
+
+
+</odoo>


### PR DESCRIPTION
Make name of invoice line required in the view (only on invoice line, not on regular move line)