### PR TITLE
[12.0][FIX] edi_oca: avoid read error in exchange record tree view

### DIFF
--- a/edi_oca/models/edi_exchange_record.py
+++ b/edi_oca/models/edi_exchange_record.py
@@ -125,7 +125,7 @@ class EDIExchangeRecord(models.Model):
     @api.depends("model", "res_id", "parent_id")
     def _compute_related_name(self):
         for rec in self:
-            related_record = rec.record
+            related_record = rec.sudo().record
             rec.related_name = related_record.display_name if related_record else ""
 
     @api.depends("model", "type_id", "res_id")
@@ -181,7 +181,7 @@ class EDIExchangeRecord(models.Model):
     @api.depends("res_id", "model", "parent_id")
     def _compute_related_record_exists(self):
         for rec in self:
-            rec.related_record_exists = bool(rec.record)
+            rec.related_record_exists = bool(rec.sudo().record)
 
     def needs_ack(self):
         return self.type_id.ack_type_id and not self.ack_exchange_id
@@ -242,8 +242,8 @@ class EDIExchangeRecord(models.Model):
         result = []
         for rec in self:
             rec_name = rec.identifier
-            if rec.res_id and rec.model and rec.record:
-                rec_name = rec.record.display_name
+            if rec.res_id and rec.model and rec.sudo().record:
+                rec_name = rec.sudo().record.display_name
             name = "[{}] {}".format(rec.type_id.name, rec_name)
             result.append((rec.id, name))
         return result


### PR DESCRIPTION
Let's not have errors when accessing tree view. If you later click in a non accessible record, then the error will show anyway. It's just avoid blocking accessing the EDI menu.

The good solution would be filtering the exchange records by related record, as said in https://github.com/OCA/edi/issues/933 discussion. But here we are speaking of v12, no need to be too picky in this version, right?