### PR TITLE
[16.0][IMP] base_wamas_ubl: Support negative float and raise error when missing telegram

### DIFF
--- a/base_wamas_ubl/lib/wamas/tests/test_utils.py
+++ b/base_wamas_ubl/lib/wamas/tests/test_utils.py
@@ -66,11 +66,11 @@ class TestUtils(unittest.TestCase):
         self.assertEqual(_set_string_bool("J", 1, False), "J")
 
     def test_set_string_float(self):
-        # Input is the positive value
+        # Positive
         self.assertEqual(_set_string_float(3.6, 9, 3), "000003600")
         self.assertEqual(_set_string_float(3.0, 9, 3), "000003000")
 
-        # Input is the negative value
+        # Negative
         self.assertEqual(_set_string_float(-3.6, 9, 3), "-00003600")
         self.assertEqual(_set_string_float(-3.0, 9, 3), "-00003000")
 

--- a/base_wamas_ubl/lib/wamas/tests/test_utils.py
+++ b/base_wamas_ubl/lib/wamas/tests/test_utils.py
@@ -5,6 +5,7 @@ from dotty_dict import Dotty
 
 from ..utils import (
     _set_string_bool,
+    _set_string_float,
     file_open,
     file_path,
     get_address_elements,
@@ -63,6 +64,15 @@ class TestUtils(unittest.TestCase):
         # Input is string
         self.assertEqual(_set_string_bool("N", 1, False), "N")
         self.assertEqual(_set_string_bool("J", 1, False), "J")
+
+    def test_set_string_float(self):
+        # Input is the positive value
+        self.assertEqual(_set_string_float(3.6, 9, 3), "000003600")
+        self.assertEqual(_set_string_float(3.0, 9, 3), "000003000")
+
+        # Input is the negative value
+        self.assertEqual(_set_string_float(-3.6, 9, 3), "-00003600")
+        self.assertEqual(_set_string_float(-3.0, 9, 3), "-00003000")
 
 
 if __name__ == "__main__":

--- a/base_wamas_ubl/lib/wamas/utils.py
+++ b/base_wamas_ubl/lib/wamas/utils.py
@@ -91,17 +91,25 @@ def _set_string_int(val, length, dp, **kwargs):
 def _set_string_float(val, length, dp, **kwargs):
     res = str(float(val or 0))
 
-    # Check if it is int / float or not
-    if not res.replace(".", "", 1).isdigit():
+    try:
+        res = str(float(val or 0))
+    except ValueError as err:
         raise Exception(
             "The value '%s' is not the float type. Please check it again!" % res
-        )
+        ) from err
+
+    # Support for the negative float
+    signed = ""
+    if "-" in res:
+        signed = "-"
+        length = length - 1
+        res = res.lstrip("-")
 
     str_whole_number, str_decimal_portion = res.split(".")
     str_whole_number = str_whole_number.rjust(length - dp, "0")
     str_decimal_portion = str_decimal_portion.ljust(dp, "0")
 
-    return (str_whole_number + str_decimal_portion)[:length]
+    return signed + (str_whole_number + str_decimal_portion)[:length]
 
 
 def _set_string_date(val, length, dp, **kwargs):

--- a/base_wamas_ubl/lib/wamas/utils.py
+++ b/base_wamas_ubl/lib/wamas/utils.py
@@ -89,8 +89,6 @@ def _set_string_int(val, length, dp, **kwargs):
 
 
 def _set_string_float(val, length, dp, **kwargs):
-    res = str(float(val or 0))
-
     try:
         res = str(float(val or 0))
     except ValueError as err:
@@ -100,7 +98,7 @@ def _set_string_float(val, length, dp, **kwargs):
 
     # Support for the negative float
     signed = ""
-    if "-" in res:
+    if res.startswith("-"):
         signed = "-"
         length = length - 1
         res = res.lstrip("-")

--- a/base_wamas_ubl/lib/wamas/wamas2ubl.py
+++ b/base_wamas_ubl/lib/wamas/wamas2ubl.py
@@ -29,6 +29,9 @@ class Extractor:
             key_name: the key in the dict that serves as key in the new dict
             head: the result dict that is build
         """
+        if telegram_type not in self.data:
+            raise ValueError("Missing telegram: %s" % telegram_type)
+
         if head is None:
             head = self.transfers
         for item in self.data[telegram_type]:
@@ -52,6 +55,9 @@ class Extractor:
             package_key_name: the key in the dict that serves to identify the
                               related package
         """
+        if telegram_type not in self.data:
+            raise ValueError("Missing telegram: %s" % telegram_type)
+
         for line in self.data[telegram_type]:
             key = line[transfer_key_name]
             if key not in self.transfers:


### PR DESCRIPTION
The module has already supported to parse negative float in wamas to ubl [here](https://github.com/OCA/edi/blob/a61dbb6e951304538125ddabe3424766a187d692/base_wamas_ubl/lib/wamas/utils.py#L402)
```
>>> b = '-00000024000000000000000'
>>> dp =15
>>> c = float(b[:-dp] + "." + b[-dp:])
>>> c
-24.0
```