### PR TITLE
[14.0][FIX] pdf_helper: fix crash in PDF parsing and PyPDF2 -> pypdf

### DIFF
--- a/pdf_helper/__manifest__.py
+++ b/pdf_helper/__manifest__.py
@@ -15,4 +15,5 @@
     "depends": [
         "base",
     ],
+    "external_dependencies": {"python": ["pypdf"]},
 }

--- a/pdf_helper/models/helper.py
+++ b/pdf_helper/models/helper.py
@@ -3,7 +3,7 @@
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 import logging
 
-from PyPDF2.utils import PdfReadError
+from pypdf.errors import PdfReadError
 
 from odoo import models
 

--- a/pdf_helper/static/description/index.html
+++ b/pdf_helper/static/description/index.html
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ factur-x
 invoice2data
 ovh
 phonenumbers
+pypdf
 pypdf>=3.1.0
 pyyaml
 regex


### PR DESCRIPTION
Switch from PyPDF2 (deprecated) to pypdf (actively maintained)

Fix crash when importing a factur-x file:

```2024-05-13 14:01:42,422 41565 ERROR o4_test1 odoo.http: Exception during JSON request handling. 
Traceback (most recent call last):
  File "/home/alexis/new_boite/dev/14/odoo/odoo/addons/base/models/ir_http.py", line 237, in _dispatch
    result = request.dispatch()
  File "/home/alexis/new_boite/dev/14/odoo/odoo/http.py", line 696, in dispatch
    result = self._call_function(**self.params)
  File "/home/alexis/new_boite/dev/14/odoo/odoo/http.py", line 370, in _call_function
    return checked_call(self.db, *args, **kwargs)
  File "/home/alexis/new_boite/dev/14/odoo/odoo/service/model.py", line 94, in wrapper
    return f(dbname, *args, **kwargs)
  File "/home/alexis/new_boite/dev/14/odoo/odoo/http.py", line 358, in checked_call
    result = self.endpoint(*a, **kw)
  File "/home/alexis/new_boite/dev/14/odoo/odoo/http.py", line 919, in __call__
    return self.method(*args, **kw)
  File "/home/alexis/new_boite/dev/14/odoo/odoo/http.py", line 544, in response_wrap
    response = f(*args, **kw)
  File "/home/alexis/new_boite/dev/14/odoo/addons/web/controllers/main.py", line 1374, in call_button
    action = self._call_kw(model, method, args, kwargs)
  File "/home/alexis/new_boite/dev/14/odoo/addons/web/controllers/main.py", line 1362, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "/home/alexis/new_boite/dev/14/odoo/odoo/api.py", line 406, in call_kw
    result = _call_kw_multi(method, model, args, kwargs)
  File "/home/alexis/new_boite/dev/14/odoo/odoo/api.py", line 391, in _call_kw_multi
    result = method(recs, *args, **kwargs)
  File "/home/alexis/new_boite/dev/14/edi/account_invoice_import/wizard/account_invoice_import.py", line 802, in import_invoice
    parsed_inv = self.get_parsed_invoice()
  File "/home/alexis/new_boite/dev/14/edi/account_invoice_import/wizard/account_invoice_import.py", line 651, in get_parsed_invoice
    return self.parse_invoice(self.invoice_file, self.invoice_filename)
  File "/home/alexis/new_boite/dev/14/edi/account_invoice_import/wizard/account_invoice_import.py", line 514, in parse_invoice
    parsed_inv = self.parse_pdf_invoice(file_data)
  File "/home/alexis/new_boite/dev/14/edi/account_invoice_import/wizard/account_invoice_import.py", line 91, in parse_pdf_invoice
    xml_files_dict = self.get_xml_files_from_pdf(file_data)
  File "/home/alexis/new_boite/dev/14/symlink/base_business_document_import/models/business_document_import.py", line 1287, in get_xml_files_from_pdf
    return self.env["pdf.helper"].pdf_get_xml_files(pdf_file)
  File "/home/alexis/new_boite/dev/14/edi/pdf_helper/models/helper.py", line 24, in pdf_get_xml_files
    return parser.get_xml_files()
  File "/home/alexis/new_boite/dev/14/edi/pdf_helper/utils.py", line 33, in get_xml_files
    xmlfiles = self._extract_xml_files(fd)
  File "/home/alexis/new_boite/dev/14/edi/pdf_helper/utils.py", line 53, in _extract_xml_files
    mime_res = mimetypes.guess_type(embeddedfile)
  File "/usr/lib/python3.10/mimetypes.py", line 307, in guess_type
    return _db.guess_type(url, strict)
  File "/usr/lib/python3.10/mimetypes.py", line 122, in guess_type
    url = os.fspath(url)
Exception

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/alexis/new_boite/dev/14/odoo/odoo/http.py", line 652, in _handle_exception
    return super(JsonRequest, self)._handle_exception(exception)
  File "/home/alexis/new_boite/dev/14/odoo/odoo/http.py", line 317, in _handle_exception
    raise exception.with_traceback(None) from new_cause
TypeError: expected str, bytes or os.PathLike object, not IndirectObject
``