### PR TITLE
[ADD] EDIWebserviceSendHTTPException to catch http error form edi_web…

### DIFF
--- a/edi_webservice_oca/components/send.py
+++ b/edi_webservice_oca/components/send.py
@@ -2,9 +2,14 @@
 # @author: Simone Orsi <simahawk@gmail.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
+
+from requests.exceptions import HTTPError
+
 from odoo import _, exceptions
 
 from odoo.addons.component.core import Component
+
+from ..exceptions import EDIWebserviceSendHTTPException
 
 
 class EDIWebserviceSend(Component):
@@ -27,7 +32,10 @@ class EDIWebserviceSend(Component):
 
     def send(self):
         method, pargs, kwargs = self._get_call_params()
-        return self.webservice_backend.call(method, *pargs, **kwargs)
+        try:
+            return self.webservice_backend.call(method, *pargs, **kwargs)
+        except HTTPError as err:
+            raise EDIWebserviceSendHTTPException("EDI HTTP Error: %s" % err) from err
 
     def _get_call_params(self):
         try:

--- a/edi_webservice_oca/exceptions.py
+++ b/edi_webservice_oca/exceptions.py
@@ -1,0 +1,5 @@
+from requests.exceptions import HTTPError
+
+
+class EDIWebserviceSendHTTPException(HTTPError):
+    """Exception raised when an HTTP error occurs during a webservice call."""

--- a/edi_webservice_oca/tests/test_send.py
+++ b/edi_webservice_oca/tests/test_send.py
@@ -5,6 +5,7 @@ import responses
 
 from odoo import exceptions
 
+from ..exceptions import EDIWebserviceSendHTTPException
 from .common import TestEDIWebserviceBase
 
 
@@ -112,3 +113,15 @@ class TestSend(TestEDIWebserviceBase):
             responses.calls[0].request.headers["Content-Type"], "application/xml"
         )
         self.assertEqual(responses.calls[0].request.body, "This is a simple file")
+
+    @responses.activate
+    def test_component_send_raise_http_error(self):
+        self.record.type_id.set_settings(self.settings2)
+        record = self.record.with_user(self.a_user)
+        backend = self.backend.with_user(self.a_user)
+
+        url = "https://foo.test/push/here"
+        responses.add(responses.POST, url, status=404)
+        component = backend._get_component(record, "send")
+        with self.assertRaises(EDIWebserviceSendHTTPException):
+            component.send()


### PR DESCRIPTION
Add a new Exeception EDIWebserviceSendHTTPException inheriting from requests.error.HTTPError.

Catching request.error.HTTPError in EDIWebserviceSend.send to raise EDIWebserviceSendHTTPException instead