### PR TITLE
[13.0] Replace 'Camptocamp SA' with 'Camptocamp'

### DIFF
--- a/account_invoice_export/__manifest__.py
+++ b/account_invoice_export/__manifest__.py
@@ -7,7 +7,7 @@
     "category": "Invoicing Management",
     "license": "AGPL-3",
     "summary": "",
-    "author": "Camptocamp SA, Odoo Community Association (OCA)",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/edi",
     "depends": ["account_invoice_transmit_method", "queue_job"],
     "data": [

--- a/base_ebill_payment_contract/__manifest__.py
+++ b/base_ebill_payment_contract/__manifest__.py
@@ -7,7 +7,7 @@
         Base for managing e-billing contracts""",
     "version": "13.0.1.0.0",
     "license": "AGPL-3",
-    "author": "Camptocamp SA,Odoo Community Association (OCA)",
+    "author": "Camptocamp,Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/edi",
     "depends": ["account_invoice_transmit_method"],
     "data": ["security/ir.model.access.csv", "views/ebill_payment_contract.xml"],

--- a/sale_order_customer_free_ref/__manifest__.py
+++ b/sale_order_customer_free_ref/__manifest__.py
@@ -9,7 +9,7 @@
     "summary": "Splits the Customer Reference on sale orders into two fields. "
     "An Id and a Free reference. The existing field is transformed "
     "into a computed one.",
-    "author": "Camptocamp SA, Odoo Community Association (OCA)",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/edi",
     "depends": ["sale"],
     "data": ["views/sale_order.xml", "views/account_move.xml"],

--- a/sale_order_import_ubl_customer_free_ref/__manifest__.py
+++ b/sale_order_import_ubl_customer_free_ref/__manifest__.py
@@ -4,7 +4,7 @@
     "category": "Sales Management",
     "license": "AGPL-3",
     "summary": "Extract CustomerReference from sale UBL",
-    "author": "Camptocamp SA, Odoo Community Association (OCA)",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/edi",
     "depends": ["sale_order_import_ubl", "sale_order_customer_free_ref"],
     "installable": True,


### PR DESCRIPTION
This pull request contains changes to replace 'Camptocamp SA' with 'Camptocamp' in __manifest__.py files for branch 13.0.