### PR TITLE
[12.0][IMP] edi_oca: don't consider exchange records if jobs have been created

### DIFF
--- a/edi_oca/models/__init__.py
+++ b/edi_oca/models/__init__.py
@@ -5,3 +5,4 @@ from . import edi_exchange_consumer_mixin
 from . import edi_exchange_type
 from . import edi_exchange_type_rule
 from . import edi_id_mixin
+from . import queue_job

--- a/edi_oca/models/edi_backend.py
+++ b/edi_oca/models/edi_backend.py
@@ -414,6 +414,7 @@ class EDIBackend(models.Model):
             len(new_records),
         )
         for rec in new_records:
+            rec.is_queued = True
             job1 = rec.delayable().action_exchange_generate()
             if not skip_send:
                 # Chain send job.
@@ -447,6 +448,7 @@ class EDIBackend(models.Model):
             ("type_id.direction", "=", "output"),
             ("edi_exchange_state", "=", "new"),
             ("exchange_file", "=", False),
+            ("is_queued", "=", False),
         ]
         if record_ids:
             domain.append(("id", "in", record_ids))
@@ -627,6 +629,7 @@ class EDIBackend(models.Model):
             len(pending_records),
         )
         for rec in pending_records:
+            rec.is_queued = True
             rec.with_delay().action_exchange_receive()
 
         pending_process_records = self.exchange_record_model.search(
@@ -645,6 +648,7 @@ class EDIBackend(models.Model):
             ("type_id.direction", "=", "input"),
             ("edi_exchange_state", "=", "input_pending"),
             ("exchange_file", "=", False),
+            ("is_queued", "=", False),
         ]
         if record_ids:
             domain.append(("id", "in", record_ids))

--- a/edi_oca/models/edi_exchange_record.py
+++ b/edi_oca/models/edi_exchange_record.py
@@ -112,6 +112,8 @@ class EDIExchangeRecord(models.Model):
         compute="_compute_retryable",
         help="The record state can be rolled back manually in case of failure.",
     )
+    is_queued = fields.Boolean(
+        help="Technical field to know if a related job has been created already.")
 
     _sql_constraints = [
         ("identifier_uniq", "unique(identifier)", "The identifier must be unique."),

--- a/edi_oca/models/queue_job.py
+++ b/edi_oca/models/queue_job.py
@@ -1,0 +1,22 @@
+# Copyright 2024 ForgeFlow S.L.
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html)
+
+import logging
+
+from odoo import models
+
+_logger = logging.getLogger(__name__)
+
+
+class QueueJob(models.Model):
+    _inherit = 'queue.job'
+
+    def write(self, vals):
+        for job in self:
+            records = job.records.exists()
+            if len(records) != 1 or records._name != "edi.exchange.record":
+                continue
+            if (vals.get("state", "") == "failed" and records.is_queued
+                    and job.state != "failed"):
+                records.is_queued = False
+        return super().write(vals)


### PR DESCRIPTION
If two `_check_output_exchange_sync` are called consecutively, one after the other, maybe due to `_execute_next_action` method, the following error happens:
![Selection_3459](https://github.com/OCA/edi/assets/25005517/acc117ef-b344-44eb-bae3-f85e33d67e11)
Both `_check_output_exchange_sync` calls detect the same exchange records, and both create same jobs. The first batch of jobs will be processed but the second ones will fail due to check of state = "new".
