### PR TITLE
[14.0][IMP] product_import: support company-specific vendors

### DIFF
--- a/product_import/tests/common.py
+++ b/product_import/tests/common.py
@@ -12,7 +12,10 @@ class TestCommon(SavepointCase):
         super().setUpClass()
         cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
         cls.wiz_model = cls.env["product.import"]
-        cls.supplier = cls.env["res.partner"].create({"name": "Catalogue Vendor"})
+        cls.company = cls.env["res.company"].create({"name": "Customer ABC"})
+        cls.supplier = cls.env["res.partner"].create(
+            {"name": "Catalogue Vendor", "company_id": cls.company.id}
+        )
 
     def _mock(self, method_name):
         return mock.patch.object(type(self.wiz_model), method_name)

--- a/product_import/wizard/product_import.py
+++ b/product_import/wizard/product_import.py
@@ -236,8 +236,7 @@ class ProductImport(models.TransientModel):
         if not catalogue.get("products"):
             raise UserError(_("This catalogue doesn't have any product!"))
         company_id = self._get_company_id(catalogue)
-        seller = self._get_seller(catalogue)
-        self.with_context(product_company_id=company_id)._create_products(
-            catalogue, seller, filename=self.product_filename
-        )
+        wiz = self.with_company(company_id).with_context(product_company_id=company_id)
+        seller = wiz._get_seller(catalogue)
+        wiz._create_products(catalogue, seller, filename=self.product_filename)
         return {"type": "ir.actions.act_window_close"}


### PR DESCRIPTION
Allow to import product when the vendor is company-specific (`res.partner` with `company_id` set)