### PR TITLE
[FIX] pdf_helper: Error double requirement given

### DIFF
--- a/pdf_helper/__manifest__.py
+++ b/pdf_helper/__manifest__.py
@@ -15,5 +15,5 @@
     "depends": [
         "base",
     ],
-    "external_dependencies": {"python": ["pypdf"]},
+    "external_dependencies": {"python": ["pypdf>=3.1.0"]},
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@ factur-x
 invoice2data
 ovh
 phonenumbers
-pypdf
 pypdf>=3.1.0
 pyyaml
 regex


### PR DESCRIPTION
Fix error:

ERROR: Double requirement given: pypdf>=3.1.0 (from -r /oca/edi/requirements.txt (line 8)) (already in pypdf (from -r /oca/edi/requirements.txt (line 7)), name='pypdf')