### PR TITLE
[14.0][FIX] edi_oca: Don't run quick_exec if backend is not active

### DIFF
--- a/edi_oca/models/edi_exchange_record.py
+++ b/edi_oca/models/edi_exchange_record.py
@@ -257,7 +257,7 @@ class EDIExchangeRecord(models.Model):
     def _quick_exec_enabled(self):
         if self.env.context.get("edi__skip_quick_exec"):
             return False
-        return self.type_id.quick_exec
+        return self.type_id.quick_exec and self.backend_id.active
 
     def _execute_next_action(self):
         # The backend already knows how to handle records


### PR DESCRIPTION
Backport of https://github.com/OCA/edi-framework/pull/90.