### PR TITLE
[15.0][BKP][IMP] edi_oca: add button to regenerate file after error on validation

### DIFF
--- a/edi_oca/models/edi_backend.py
+++ b/edi_oca/models/edi_backend.py
@@ -206,10 +206,13 @@ class EDIBackend(models.Model):
 
         :param exchange_record: edi.exchange.record recordset
         :param store: store output on the record itself
-        :param force: allow to re-genetate the content
+        :param force: allow to re-generate the content
         :param kw: keyword args to be propagated to output generate handler
         """
         self.ensure_one()
+        if force and exchange_record.exchange_file:
+            # Remove file to regenerate
+            exchange_record.exchange_file = False
         self._check_exchange_generate(exchange_record, force=force)
         output = self._exchange_generate(exchange_record, **kw)
         message = None

--- a/edi_oca/models/edi_exchange_record.py
+++ b/edi_oca/models/edi_exchange_record.py
@@ -341,6 +341,10 @@ class EDIExchangeRecord(models.Model):
             self._execute_next_action()
         return True
 
+    def action_regenerate(self):
+        for rec in self:
+            rec.action_exchange_generate(force=True)
+
     def action_open_related_record(self):
         self.ensure_one()
         if not self.related_record_exists:

--- a/edi_oca/tests/test_backend_validate.py
+++ b/edi_oca/tests/test_backend_validate.py
@@ -91,3 +91,28 @@ class EDIBackendTestCase(EDIBackendCommonComponentRegistryTestCase):
             ],
         )
         self.assertIn("Data seems wrong!", self.record_out.exchange_error)
+
+    def test_validate_record_error_regenerate(self):
+        self.record_out.write({"edi_exchange_state": "new"})
+        exc = EDIValidationError("Data seems wrong!")
+        self.backend.with_context(test_break_validate=exc).exchange_generate(
+            self.record_out
+        )
+        self.assertRecordValues(
+            self.record_out,
+            [
+                {
+                    "edi_exchange_state": "validate_error",
+                }
+            ],
+        )
+        self.record_out.with_context(fake_output="yeah!").action_regenerate()
+        self.assertEqual(self.record_out._get_file_content(), "yeah!")
+        self.assertRecordValues(
+            self.record_out,
+            [
+                {
+                    "edi_exchange_state": "output_pending",
+                }
+            ],
+        )

--- a/edi_oca/views/edi_exchange_record_views.xml
+++ b/edi_oca/views/edi_exchange_record_views.xml
@@ -49,6 +49,12 @@
                         string="Retry"
                         attrs="{'invisible': [('retryable', '=', False)]}"
                     />
+                    <button
+                        name="action_regenerate"
+                        type="object"
+                        string="Regenerate"
+                        attrs="{'invisible': ['|', ('direction', 'in', ('input', False)), ('edi_exchange_state', '!=', 'validate_error')]}"
+                    />
                     <!-- FIXME: colors are ignored...
                     and can't find how they are supposed to work.
                     Probably not supported at all. -->


### PR DESCRIPTION
Backport of https://github.com/OCA/edi-framework/pull/86