### PR TITLE
[14.0][FIX] edi_oca: do not try to automatically re-process input_processed_error records

### DIFF
--- a/edi_oca/models/edi_backend.py
+++ b/edi_oca/models/edi_backend.py
@@ -631,7 +631,7 @@ class EDIBackend(models.Model):
         return domain
 
     def _input_pending_process_records_domain(self, record_ids=None):
-        states = ("input_received", "input_processed_error")
+        states = ("input_received",)
         domain = [
             ("backend_id", "=", self.id),
             ("type_id.direction", "=", "input"),


### PR DESCRIPTION
Backport from:
- https://github.com/OCA/edi-framework/pull/89