### PR TITLE
[14.0][FIX] account_invoice_download: don't set default_name in context

### DIFF
--- a/account_invoice_download/views/account_invoice_import_config.xml
+++ b/account_invoice_download/views/account_invoice_import_config.xml
@@ -20,7 +20,7 @@
                     class="oe_stat_button"
                     type="action"
                     name="%(account_invoice_download.account_invoice_download_config_action)d"
-                    context="{'search_default_import_config_id': active_id, 'default_import_config_id': active_id, 'default_name': name}"
+                    context="{'search_default_import_config_id': active_id, 'default_import_config_id': active_id}"
                     icon="fa-bars"
                 >
                     <field

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,3 +4,5 @@ responses
 # Python Dependencies
 PyYAML
 xmlunittest
+# tests use python 3.6 and pypdf dropped support for python 3.6-3.7 in 5.0
+pypdf==4.3.1


### PR DESCRIPTION
If default_name is set in context just to have a default label on the account.invoice.import.download, it will also be used if do a manual run right after, so you will get draft invoices with a 'name' already set !