### PR TITLE
[17.0][IMP] base_import_pdf_by_template: Add fixed value compatibility to different types of fields

### DIFF
--- a/base_import_pdf_by_template/README.rst
+++ b/base_import_pdf_by_template/README.rst
@@ -122,7 +122,6 @@ Known issues / Roadmap
 ======================
 
 -  Add operator in template lines (= or ilike)
--  Add support for selection fields as default value.
 -  Simplify auto-detection (defining a text only to search the system
    should search the corresponding regular expression).
 -  Allow compatibility with registration process created from email

--- a/base_import_pdf_by_template/demo/base_import_pdf_template.xml
+++ b/base_import_pdf_by_template/demo/base_import_pdf_template.xml
@@ -50,6 +50,16 @@
         <field name="fixed_value" ref="base.user_admin" />
     </record>
     <record
+        id="demo_base_import_pdf_template_res_partner_header_05"
+        model="base.import.pdf.template.line"
+    >
+        <field name="template_id" ref="demo_base_import_pdf_template_res_partner" />
+        <field name="related_model">header</field>
+        <field name="field_id" ref="base.field_res_partner__ref" />
+        <field name="value_type">fixed</field>
+        <field name="fixed_value_char">fixed-ref</field>
+    </record>
+    <record
         id="demo_base_import_pdf_template_res_partner_line_01"
         model="base.import.pdf.template.line"
     >

--- a/base_import_pdf_by_template/readme/ROADMAP.md
+++ b/base_import_pdf_by_template/readme/ROADMAP.md
@@ -1,5 +1,4 @@
 - Add operator in template lines (= or ilike)
-- Add support for selection fields as default value.
 - Simplify auto-detection (defining a text only to search the system
   should search the corresponding regular expression).
 - Allow compatibility with registration process created from email alias

--- a/base_import_pdf_by_template/static/description/index.html
+++ b/base_import_pdf_by_template/static/description/index.html
@@ -471,7 +471,6 @@ document structure.</p>
 <h1><a class="toc-backref" href="#toc-entry-3">Known issues / Roadmap</a></h1>
 <ul class="simple">
 <li>Add operator in template lines (= or ilike)</li>
-<li>Add support for selection fields as default value.</li>
 <li>Simplify auto-detection (defining a text only to search the system
 should search the corresponding regular expression).</li>
 <li>Allow compatibility with registration process created from email

--- a/base_import_pdf_by_template/tests/test_base_import_pdf_by_template.py
+++ b/base_import_pdf_by_template/tests/test_base_import_pdf_by_template.py
@@ -82,6 +82,7 @@ class TestBaseImportPdfByTemplate(BaseCommon):
         self.assertEqual(record.country_id.code, "ES")
         self.assertEqual(record.industry_id.name, "Food")
         self.assertEqual(record.user_id, self.user)
+        self.assertEqual(record.ref, "fixed-ref")
         self.assertEqual(len(record.child_ids), 3)
         child_1 = record.child_ids.filtered(lambda x: x.name == "Child 1")
         self.assertEqual(child_1.street, "Address 1")
@@ -118,6 +119,7 @@ class TestBaseImportPdfByTemplate(BaseCommon):
         self.assertEqual(record.country_id.code, "ES")
         self.assertEqual(record.industry_id.name, "Food")
         self.assertEqual(record.user_id, self.user)
+        self.assertEqual(record.ref, "fixed-ref")
         self.assertEqual(len(record.child_ids), 3)
         child_1 = record.child_ids.filtered(lambda x: x.name == "Child 1")
         self.assertEqual(child_1.street, "Address 1")
@@ -128,6 +130,7 @@ class TestBaseImportPdfByTemplate(BaseCommon):
         child_3 = record.child_ids.filtered(lambda x: x.name == "Child 3")
         self.assertEqual(child_3.street, "Address 3")
         self.assertEqual(child_3.country_id.code, "ES")
+        self.assertTrue(record.message_ids)  # Error message to set ref to childs
 
     def test_wizard_base_import_pdf_by_template_error(self):
         self.env.ref(

--- a/base_import_pdf_by_template/views/base_import_pdf_template_line_views.xml
+++ b/base_import_pdf_by_template/views/base_import_pdf_template_line_views.xml
@@ -55,16 +55,59 @@
                         />
                         <field
                             name="default_value"
+                            string="Fixed value"
                             invisible="value_type == 'fixed' or not field_relation"
                         />
                         <field
                             name="log_distinct_value"
                             invisible="not field_id or value_type == 'fixed'"
                         />
+                        <!-- Fixed value !-->
+                        <field
+                            name="fixed_value_char"
+                            string="Fixed value"
+                            invisible="value_type != 'fixed' or field_ttype != 'char'"
+                        />
+                        <field
+                            name="fixed_value_date"
+                            string="Fixed value"
+                            invisible="value_type != 'fixed' or field_ttype != 'date'"
+                        />
+                        <field
+                            name="fixed_value_datetime"
+                            string="Fixed value"
+                            invisible="value_type != 'fixed' or field_ttype != 'datetime'"
+                        />
+                        <field
+                            name="fixed_value_float"
+                            string="Fixed value"
+                            invisible="value_type != 'fixed' or field_ttype != 'float'"
+                        />
+                        <field
+                            name="fixed_value_html"
+                            string="Fixed value"
+                            invisible="value_type != 'fixed' or field_ttype != 'html'"
+                        />
+                        <field
+                            name="fixed_value_integer"
+                            string="Fixed value"
+                            invisible="value_type != 'fixed' or field_ttype != 'integer'"
+                        />
+                        <field
+                            name="fixed_value_selection"
+                            string="Fixed value"
+                            invisible="value_type != 'fixed' or field_ttype != 'selection'"
+                        />
+                        <field
+                            name="fixed_value_text"
+                            string="Fixed value"
+                            invisible="value_type != 'fixed' or field_ttype != 'text'"
+                        />
                         <field
                             name="fixed_value"
                             invisible="value_type != 'fixed' or not field_relation"
                         />
+                        <!-- Fixed value !-->
                         <field name="field_ttype" invisible="1" />
                         <field
                             name="date_format"

--- a/test_base_import_pdf_by_template/demo/base_import_pdf_template.xml
+++ b/test_base_import_pdf_by_template/demo/base_import_pdf_template.xml
@@ -82,6 +82,13 @@
         <field name="pattern">ES[0-9]{10}</field>
         <field name="value_type">variable</field>
     </record>
+    <record id="po_decathlon_line_origin" model="base.import.pdf.template.line">
+        <field name="template_id" ref="po_decathlon" />
+        <field name="related_model">header</field>
+        <field name="field_id" ref="purchase.field_purchase_order__origin" />
+        <field name="value_type">fixed</field>
+        <field name="fixed_value_char">fixed-origin</field>
+    </record>
     <record id="po_decathlon_line_product_id" model="base.import.pdf.template.line">
         <field name="template_id" ref="po_decathlon" />
         <field name="related_model">lines</field>
@@ -214,6 +221,16 @@
         <field name="field_id" ref="account.field_account_move__partner_id" />
         <field name="value_type">fixed</field>
         <field name="fixed_value" ref="partner_tecnativa" />
+    </record>
+    <record id="invoice_tecnativa_line_move_type" model="base.import.pdf.template.line">
+        <field name="template_id" ref="invoice_tecnativa" />
+        <field name="related_model">header</field>
+        <field name="field_id" ref="account.field_account_move__move_type" />
+        <field name="value_type">fixed</field>
+        <field
+            name="fixed_value_selection"
+            ref="account.selection__account_invoice_report__move_type__in_invoice"
+        />
     </record>
     <record
         id="invoice_tecnativa_line_product_id"

--- a/test_base_import_pdf_by_template/tests/test_base_import_pdf_by_template.py
+++ b/test_base_import_pdf_by_template/tests/test_base_import_pdf_by_template.py
@@ -64,6 +64,7 @@ class TestBaseImportPdfByTemplate(BaseCommon):
         attachments = self._get_attachments(record)
         self.assertEqual(record.partner_id, self.partner_decathlon)
         self.assertEqual(record.partner_ref, "ES9812110233")
+        self.assertEqual(record.origin, "fixed-origin")
         self.assertIn(attachment, attachments)
         self.assertEqual(len(record.order_line), 5)
         self.assertEqual(sum(record.order_line.mapped("product_uom_qty")), 5)
@@ -78,12 +79,13 @@ class TestBaseImportPdfByTemplate(BaseCommon):
     def test_account_invoice_tecnativa(self):
         attachment = self._create_ir_attachment("account_invoice_tecnativa.pdf")
         wizard = self._create_wizard_base_import_pdf_upload("account.move", attachment)
-        # Similar context from Vendor invoices menu
-        wizard = wizard.with_context(**{"default_move_type": "in_invoice"})
+        # Similar context from Customer invoices menu
+        wizard = wizard.with_context(**{"default_move_type": "out_invoice"})
         res = wizard.action_process()
         self.assertEqual(res["res_model"], "account.move")
         record = self.env[res["res_model"]].browse(res["res_id"])
         attachments = self._get_attachments(record)
+        self.assertEqual(record.move_type, "in_invoice")
         self.assertEqual(record.partner_id, self.partner_tecnativa)
         self.assertIn(attachment, attachments)
         self.assertEqual(len(record.invoice_line_ids), 6)


### PR DESCRIPTION
FWP from 15.0: https://github.com/OCA/edi/pull/1053

Add fixed value compatibility to different types of fields

Locked by:
- [x] `pdf_helper`: https://github.com/OCA/edi/pull/1057

Please @pedrobaeza and @pilarvargas-tecnativa can you review it?

@Tecnativa TT51379