### PR TITLE
[15.0][FIX] test_base_import_pdf_by_template: Improve pattern

### DIFF
--- a/account_invoice_facturx/__manifest__.py
+++ b/account_invoice_facturx/__manifest__.py
@@ -17,7 +17,7 @@
         "base_facturx",
         "base_vat",
     ],
-    "external_dependencies": {"python": ["factur-x"]},
+    "external_dependencies": {"python": ["factur-x<=3.1"]},
     "data": [
         "views/res_partner.xml",
         "views/res_config_settings.xml",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # generated from manifests external_dependencies
-factur-x
+factur-x<=3.1
 pypdf
 PyPDF2
 PyYAML

--- a/test_base_import_pdf_by_template/demo/base_import_pdf_template.xml
+++ b/test_base_import_pdf_by_template/demo/base_import_pdf_template.xml
@@ -254,7 +254,7 @@
         <field name="related_model">lines</field>
         <field name="field_id" ref="account.field_account_move_line__quantity" />
         <field name="column">1</field>
-        <field name="pattern">(^\d{1,3}\n)[0-9]{1,2}</field>
+        <field name="pattern">\[[A-Z\d]+[_|-][A-Z\d]+\] [a-zA-Záí]* ([0-9]{1,3})</field>
         <field name="value_type">variable</field>
     </record>
     <record id="invoice_tecnativa_price_unit" model="base.import.pdf.template.line">
@@ -262,7 +262,9 @@
         <field name="related_model">lines</field>
         <field name="field_id" ref="account.field_account_move_line__price_unit" />
         <field name="column">2</field>
-        <field name="pattern">(^\d{1,3}\.(?!00)\d{2}\n)</field>
+        <field
+            name="pattern"
+        >\[[A-Z\d]+[_|-][A-Z\d]+\] [a-zA-Záí]* [0-9]{1,3} ([0-9]{1,3}.[0-9]{2})</field>
         <field name="value_type">variable</field>
         <field name="log_distinct_value" eval="True" />
     </record>


### PR DESCRIPTION
Backport from 17.0: https://github.com/OCA/edi/pull/1081

Improve pattern

Related to https://github.com/OCA/edi/pull/1071#issuecomment-2511881677

Related to pypdf 5.1.0 and line breaks

https://pypdf.readthedocs.io/en/latest/meta/CHANGELOG.html

@Tecnativa