### PR TITLE
[16.0][FIX] account_invoice_report: backport use of _is_invoice_report()

### DIFF
--- a/account_invoice_facturx/models/ir_actions_report.py
+++ b/account_invoice_facturx/models/ir_actions_report.py
@@ -18,12 +18,11 @@ class IrActionsReport(models.Model):
             report_ref, data, res_ids=res_ids
         )
         amo = self.env["account.move"]
-        invoice_reports = amo._get_invoice_report_names()
         if (
             collected_streams
             and res_ids
             and len(res_ids) == 1
-            and report_ref in invoice_reports
+            and self._is_invoice_report(report_ref)
             and not self.env.context.get("no_embedded_factur-x_xml")
         ):
             move = amo.browse(res_ids)


### PR DESCRIPTION
This PR fixes this warning:
```
2024-12-26 09:25:13,336 10016 WARNING o6_test1 py.warnings: /home/alexis/new_boite/dev/16/edi/account_invoice_facturx/models/ir_actions_report.py:26: UserWarning: unsupported operand type(s) for "==": 'ir.actions.report()' == ''account.report_invoice_with_payments''
```

This is caused by the fact that the report_ref arg for _render_qweb_pdf_prepare_streams() can be anything, not just a report_name.

This is a simple backport from v17.  _is_invoice_report was introduced in v16.