### PR TITLE
[12.0] account_invoice_*facturx: fix factur-x lib version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # generated from manifests external_dependencies
-factur-x
+factur-x<=3.1
 invoice2data==0.3.5
 ovh
 phonenumbers

--- a/setup/account_invoice_facturx/setup.py
+++ b/setup/account_invoice_facturx/setup.py
@@ -5,7 +5,7 @@ setuptools.setup(
     odoo_addon={
         "external_dependencies_override": {
             "python": {
-                "facturx": "factur-x"
+                "facturx": "factur-x<=3.1"
             }
         }
     },

--- a/setup/account_invoice_facturx_py3o/setup.py
+++ b/setup/account_invoice_facturx_py3o/setup.py
@@ -5,7 +5,7 @@ setuptools.setup(
     odoo_addon={
         "external_dependencies_override": {
             "python": {
-                "facturx": "factur-x"
+                "facturx": "factur-x<=3.1"
             }
         }
     },

--- a/setup/account_invoice_import_facturx/setup.py
+++ b/setup/account_invoice_import_facturx/setup.py
@@ -5,7 +5,7 @@ setuptools.setup(
     odoo_addon={
         "external_dependencies_override": {
             "python": {
-                "facturx": "factur-x"
+                "facturx": "factur-x<=3.1"
             }
         }
     },


### PR DESCRIPTION
Pin 3.1 to fix `https://github.com/OCA/edi/issues/1084`

Port from: https://github.com/OCA/edi/pull/1085

### Note:
- Since `external_dependencies_override` has renamed the library, adding version directly to `external_dependencies` in the manifest cannot be executed.