### PR TITLE
[14.0] edi: edi.conf add btn to view partners

### DIFF
--- a/edi_oca/models/edi_configuration.py
+++ b/edi_oca/models/edi_configuration.py
@@ -5,6 +5,7 @@
 import datetime
 
 import pytz
+from psycopg2.extensions import AsIs
 
 from odoo import _, api, exceptions, fields, models
 from odoo.tools import DotDict, safe_eval
@@ -198,3 +199,23 @@ class EdiConfiguration(models.Model):
             backend_ids.append(False)
             domain.append(("backend_id", "in", backend_ids))
         return self.filtered_domain(domain)
+
+    def action_view_partners(self):
+        # TODO: add tests
+        partner_model = self.env["res.partner"]
+        partner_ids = set()
+        # Find partners linked to this conf no matter which field
+        for field in partner_model._fields.values():
+            if field.type == "many2many" and field.comodel_name == self._name:
+                query = "SELECT DISTINCT(partner_id) FROM %(table)s WHERE conf_id=%(conf_id)s"
+                self.env.cr.execute(
+                    query, {"table": AsIs(field.relation), "conf_id": self.id}
+                )
+                partner_ids.update([r[0] for r in self.env.cr.fetchall()])
+        return {
+            "type": "ir.actions.act_window",
+            "name": _("Partners"),
+            "res_model": "res.partner",
+            "view_mode": "tree,form",
+            "domain": [("id", "in", list(partner_ids))],
+        }

--- a/edi_oca/views/edi_configuration_views.xml
+++ b/edi_oca/views/edi_configuration_views.xml
@@ -42,6 +42,15 @@
         <field name="arch" type="xml">
             <form string="EDI Configuration">
                 <sheet>
+                    <div class="oe_button_box" name="button_box">
+                      <button
+                            type="object"
+                            name="action_view_partners"
+                            class="oe_stat_button"
+                            string="Partners"
+                            icon="fa-eye"
+                        />
+                    </div>
                     <field name="active" invisible="1" />
                     <widget
                         name="web_ribbon"

--- a/edi_sale_oca/views/res_partner.xml
+++ b/edi_sale_oca/views/res_partner.xml
@@ -5,7 +5,7 @@
     <record id="view_partner_form" model="ir.ui.view">
         <field name="name">res.partner.view.form</field>
         <field name="model">res.partner</field>
-        <field name="inherit_id" ref="base.view_partner_form" />
+        <field name="inherit_id" ref="edi_oca.view_partner_form" />
         <field name="arch" type="xml">
             <group name="edi_main" position="after">
                <group name="sale" string="Sale">


### PR DESCRIPTION
It's very handy to be able to see all partners using a specific configuration at once.

Collateral fix: edi_sale partner view was extending the wrong base class.