### PR TITLE
[14.0] edi_endpoint: extend mixin views

### DIFF
--- a/edi_endpoint_oca/views/edi_endpoint_views.xml
+++ b/edi_endpoint_oca/views/edi_endpoint_views.xml
@@ -42,7 +42,7 @@
 
     <record model="ir.ui.view" id="edi_endpoint_search_view">
         <field name="model">edi.endpoint</field>
-        <field name="inherit_id" ref="endpoint.endpoint_endpoint_search_view" />
+        <field name="inherit_id" ref="endpoint.endpoint_mixin_search_view" />
         <field name="mode">primary</field>
         <field name="arch" type="xml">
             <field name="exec_mode" position="after">
@@ -72,7 +72,7 @@
 
     <record model="ir.ui.view" id="edi_endpoint_tree_view">
         <field name="model">edi.endpoint</field>
-        <field name="inherit_id" ref="endpoint.endpoint_endpoint_tree_view" />
+        <field name="inherit_id" ref="endpoint.endpoint_mixin_list_view" />
         <field name="mode">primary</field>
         <field name="arch" type="xml">
             <field name="exec_mode" position="after">


### PR DESCRIPTION
edi.endpoint views must be independent
that's why primary mode is used.
endpoint.endpoint views might be polluted
by other modules: this change ensures they are isolated.

Depends on  https://github.com/OCA/web-api/pull/87