### PR TITLE
[17.0][FIX] base_import_pdf_by_template_account: Preventing 2 attachments linked to the same invoice

### DIFF
--- a/base_import_pdf_by_template_account/models/account_move.py
+++ b/base_import_pdf_by_template_account/models/account_move.py
@@ -1,7 +1,5 @@
 # Copyright 2024-2025 Tecnativa - Víctor Martínez
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
-from base64 import b64encode
-
 from odoo import models
 
 
@@ -17,11 +15,6 @@ class AccountMove(models.Model):
         total_templates = template_model.search_count([("model", "=", self._name)])
         if total_templates == 0:
             return False
-        # We need to create the attachment that we will use in the wizard because it
-        # has not been created yet.
-        attachment = self.env["ir.attachment"].create(
-            {"name": file_data["filename"], "datas": b64encode(file_data["content"])}
-        )
         self.move_type = (
             "in_invoice" if self.journal_id.type == "purchase" else "out_invoice"
         )
@@ -29,7 +22,7 @@ class AccountMove(models.Model):
             {
                 "model": self._name,
                 "record_ref": f"{self._name},{self.id}",
-                "attachment_ids": [(6, 0, attachment.ids)],
+                "attachment_ids": [(6, 0, file_data["attachment"].ids)],
             }
         )
         wizard.with_context(skip_template_not_found_error=True).action_process()

--- a/base_import_pdf_by_template_account/tests/test_base_import_pdf_by_template_account.py
+++ b/base_import_pdf_by_template_account/tests/test_base_import_pdf_by_template_account.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Tecnativa - Víctor Martínez
+# Copyright 2024-2025 Tecnativa - Víctor Martínez
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from base64 import b64encode
@@ -220,7 +220,8 @@ class TestBaseImportPdfByTemplateAccount(BaseCommon):
         res = wizard.action_process()
         self.assertEqual(res["res_model"], "account.move")
         record = self.env[res["res_model"]].browse(res["res_id"])
-        self.assertIn(attachment, record.attachment_ids)
+        self.assertEqual(len(record.attachment_ids), 1)
+        self.assertEqual(attachment, record.attachment_ids)
         self._test_account_invoice_tecnativa_data(record)
 
     def test_account_move_edi_decoder(self):
@@ -228,5 +229,6 @@ class TestBaseImportPdfByTemplateAccount(BaseCommon):
         invoice = self.journal.with_context(
             default_journal_id=self.journal.id
         )._create_document_from_attachment(attachment.id)
-        self.assertIn(attachment, invoice.attachment_ids)
+        self.assertEqual(len(invoice.attachment_ids), 1)
+        self.assertEqual(attachment, invoice.attachment_ids)
         self._test_account_invoice_tecnativa_data(invoice)


### PR DESCRIPTION
Preventing 2 attachments linked to the same invoice

Required since https://github.com/odoo/odoo/commit/51d327b7390a68c568e5456d7302c336461a27b4

Please @pedrobaeza can you review it?

@Tecnativa TT54750