### PR TITLE
[14.0] edi_exchange_template: declare tmpl to use explicitly 

### DIFF
--- a/edi_exchange_template_oca/__manifest__.py
+++ b/edi_exchange_template_oca/__manifest__.py
@@ -5,7 +5,7 @@
 {
     "name": "EDI Exchange Template",
     "summary": """Allows definition of exchanges via templates.""",
-    "version": "14.0.1.5.2",
+    "version": "14.0.1.6.0",
     "development_status": "Beta",
     "license": "LGPL-3",
     "author": "ACSONE,Camptocamp,Odoo Community Association (OCA)",
@@ -15,5 +15,6 @@
     "data": [
         "security/ir_model_access.xml",
         "views/edi_exchange_template_output_views.xml",
+        "views/edi_exchange_type_views.xml",
     ],
 }

--- a/edi_exchange_template_oca/migrations/14.0.1.6.0/post-migrate.py
+++ b/edi_exchange_template_oca/migrations/14.0.1.6.0/post-migrate.py
@@ -1,0 +1,60 @@
+# Copyright 2025 Camptocamp SA (http://www.camptocamp.com)
+# @author Simone Orsi <simahawk@gmail.com>
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+import logging
+
+from odoo import SUPERUSER_ID, api
+
+_logger = logging.getLogger(__name__)
+
+
+def migrate(cr, version):
+    if not version:
+        return
+
+    env = api.Environment(cr, SUPERUSER_ID, {})
+
+    # Look for templates w/ a type set and set them as allowed on the type
+    # plus link the type to the template
+    templates = env["edi.exchange.template.output"].search([("type_id", "!=", False)])
+    for tmpl in templates:
+        allowed_type = tmpl.type_id
+        tmpl.type_id.output_template_id = tmpl
+        tmpl.allowed_type_ids += allowed_type
+        tmpl.type_id = None
+        _logger.info(
+            "Set output template %s on exchange type %s",
+            tmpl.name,
+            allowed_type.name,
+        )
+
+    # Look for types w/o a template
+    # and find the template by code to set as output template
+    types = env["edi.exchange.type"].search([("output_template_id", "=", False)])
+    for t in types:
+        settings = t.get_settings()
+        generate_usage = settings.get("components", {}).get("generate", {}).get("usage")
+        if generate_usage:
+            templates = env["edi.exchange.template.output"].search(
+                [
+                    ("code", "=", generate_usage),
+                    ("backend_type_id", "=", t.backend_type_id.id),
+                ]
+            )
+            if len(templates) == 1:
+                tmpl = templates[0]
+                tmpl.allowed_type_ids += t
+                t.output_template_id = tmpl
+                _logger.info(
+                    "Set output template %s on exchange type %s",
+                    t.output_template_id.name,
+                    t.name,
+                )
+                continue
+
+        _logger.warning(
+            "Cannot set a template for exchange type %s. "
+            "Either no template found or multiple found.",
+            t.name,
+        )

--- a/edi_exchange_template_oca/models/__init__.py
+++ b/edi_exchange_template_oca/models/__init__.py
@@ -1,3 +1,4 @@
 from . import edi_backend
 from . import edi_exchange_template_mixin
 from . import edi_exchange_template_output
+from . import edi_exchange_type

--- a/edi_exchange_template_oca/models/edi_backend.py
+++ b/edi_exchange_template_oca/models/edi_backend.py
@@ -34,9 +34,12 @@ class EDIBackend(models.Model):
         # TODO: maybe we can add a m2o to output templates
         # but then we would need another for input templates if they are introduced.
         tmpl = None
+        code = code or exchange_record.type_id.code
         if code:
             domain = [("code", "=", code)]
-            return search(domain, limit=1)
+            tmpl = search(domain, limit=1)
+            if tmpl:
+                return tmpl
         for domain in self._get_output_template_domains(exchange_record):
             tmpl = search(domain, limit=1)
             if tmpl:

--- a/edi_exchange_template_oca/models/edi_backend.py
+++ b/edi_exchange_template_oca/models/edi_backend.py
@@ -1,8 +1,13 @@
 # Copyright 2020 ACSONE SA
+# Copyright 2025 Camptocamp SA
 # @author Simone Orsi <simahawk@gmail.com>
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 
-from odoo import models
+import logging
+
+from odoo import fields, models
+
+_logger = logging.getLogger(__name__)
 
 
 class EDIBackend(models.Model):
@@ -26,30 +31,48 @@ class EDIBackend(models.Model):
         return self.env["edi.exchange.template.output"]
 
     def _get_output_template(self, exchange_record, code=None):
-        """Retrieve output templates by convention.
+        """Retrieve output template.
 
-        Template's code must match the same component usage as per normal components.
+        :param exchange_record: record to generate.
+        :param code: explicit template code to lookup.
         """
+        tmpl = exchange_record.type_id.output_template_id
+        if tmpl:
+            return tmpl
+        _logger.warning(
+            "DEPRECATED: please set the template to use explicitly on the type %s.",
+            exchange_record.type_id.code,
+        )
+        # Deprecated behavior: emplate's code must match
+        # the same component usage as per normal components.t
+        # Wherever possible old types relying on code
+        # have been migrated to use the explicit template.
         search = self.output_template_model.search
-        # TODO: maybe we can add a m2o to output templates
-        # but then we would need another for input templates if they are introduced.
         tmpl = None
+        # NOTE: this is kind of broken because
+        # it should use the usage of the generate component one.
+        # As this is depraecated we can leave it as is.
         code = code or exchange_record.type_id.code
         if code:
             domain = [("code", "=", code)]
             tmpl = search(domain, limit=1)
             if tmpl:
                 return tmpl
-        for domain in self._get_output_template_domains(exchange_record):
-            tmpl = search(domain, limit=1)
-            if tmpl:
-                break
+        tmpl = self._get_output_template_fallback(exchange_record)
         return tmpl
 
-    def _get_output_template_domains(self, exchange_record):
+    def _get_output_template_fallback(self, exchange_record):
         """Retrieve domains to lookup for templates by priority."""
-        backend_type_leaf = [("backend_type_id", "=", self.backend_type_id.id)]
-        exchange_type_leaf = [("type_id", "=", exchange_record.type_id.id)]
-        full_match_domain = backend_type_leaf + exchange_type_leaf
-        partial_match_domain = backend_type_leaf
-        return full_match_domain, partial_match_domain
+        # Match by backend and allowed types
+        base_domain = [
+            ("backend_type_id", "=", self.backend_type_id.id),
+            "|",
+            ("allowed_type_ids", "in", exchange_record.type_id.ids),
+            ("allowed_type_ids", "=", False),
+        ]
+        candidates = self.output_template_model.search(base_domain)
+        for rec in candidates:
+            if rec.type_id == exchange_record.type_id:
+                return rec
+        # Take the 1st one having allowed_type_ids set
+        return fields.first(candidates.sorted(lambda x: 0 if x.allowed_type_ids else 1))

--- a/edi_exchange_template_oca/models/edi_exchange_template_mixin.py
+++ b/edi_exchange_template_oca/models/edi_exchange_template_mixin.py
@@ -1,4 +1,5 @@
 # Copyright 2020 ACSONE SA
+# Copyright 2025 Camptocamp SA
 # @author Simone Orsi <simahawk@gmail.com>
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 import datetime
@@ -7,7 +8,7 @@ import textwrap
 
 import pytz
 
-from odoo import fields, models
+from odoo import _, api, exceptions, fields, models
 from odoo.tools import DotDict, safe_eval
 
 _logger = logging.getLogger(__name__)
@@ -41,11 +42,22 @@ class EDIExchangeTemplateMixin(models.AbstractModel):
         ondelete="restrict",
         required=True,
     )
+    # TODO: deprecate this field.
+    # Templates should be explicitly linked by a type
+    # and use `allowed_type_ids` to define allowed types.
     type_id = fields.Many2one(
         string="EDI Exchange type",
         comodel_name="edi.exchange.type",
         ondelete="cascade",
         auto_join=True,
+    )
+    allowed_type_ids = fields.Many2many(
+        comodel_name="edi.exchange.type",
+        relation="edi_exchange_template_type_rel",
+        column1="template_id",
+        column2="type_id",
+        string="Allowed Exchange Types",
+        help="Types allowed to use this template.",
     )
     backend_id = fields.Many2one(
         comodel_name="edi.backend",
@@ -147,3 +159,20 @@ class EDIExchangeTemplateMixin(models.AbstractModel):
 
     def validate(self, exchange_record):
         pass
+
+    @api.constrains("type_id", "allowed_type_ids")
+    def _check_type_id(self):
+        for rec in self:
+            if (
+                rec.type_id
+                and rec.allowed_type_ids
+                and rec.type_id not in rec.allowed_type_ids
+            ):
+                raise exceptions.ValidationError(
+                    _(
+                        "The selected type must appear among the allowed types. "
+                        "NOTE: the type field is deprecated and will be removed soon. "
+                        "Use 'Allowed types' instead and set the template to use "
+                        "explicitly on the type that will use this template."
+                    )
+                )

--- a/edi_exchange_template_oca/models/edi_exchange_type.py
+++ b/edi_exchange_template_oca/models/edi_exchange_type.py
@@ -1,0 +1,45 @@
+# Copyright 2025 Camptocamp SA
+# @author: Simone Orsi <simone.orsi@camptocamp.com>
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+
+from odoo import _, api, exceptions, fields, models
+
+
+class EDIExchangeType(models.Model):
+    _inherit = "edi.exchange.type"
+
+    output_template_id = fields.Many2one(
+        comodel_name="edi.exchange.template.output",
+        string="Exchange Template",
+        ondelete="restrict",
+        required=False,
+        help="Template used to generate or process this type.",
+    )
+    output_template_allowed_ids = fields.Many2many(
+        comodel_name="edi.exchange.template.output",
+        # Inverse relation is defined in `edi.exchange.template.mixin`
+        relation="edi_exchange_template_type_rel",
+        column1="type_id",
+        column2="template_id",
+        string="Allowed Templates",
+        help="Templates allowed to be used with this type.",
+    )
+
+    @api.constrains("output_template_id")
+    def _check_output_template_id(self):
+        for rec in self:
+            tmpl = rec.output_template_id
+            if tmpl.type_id:
+                if tmpl.type_id != rec:
+                    raise exceptions.ValidationError(
+                        _("Template type must match exchange type.")
+                    )
+            if (
+                tmpl
+                and tmpl.allowed_type_ids
+                and tmpl not in rec.output_template_allowed_ids
+            ):
+                raise exceptions.ValidationError(
+                    _("Template not allowed for this type.")
+                )

--- a/edi_exchange_template_oca/tests/__init__.py
+++ b/edi_exchange_template_oca/tests/__init__.py
@@ -1,2 +1,3 @@
 from . import test_edi_backend_output
 from . import test_nswrapper
+from . import test_backend_and_type

--- a/edi_exchange_template_oca/tests/test_backend_and_type.py
+++ b/edi_exchange_template_oca/tests/test_backend_and_type.py
@@ -2,8 +2,9 @@
 # @author: Simone Orsi <simone.orsi@camptocamp.com>
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 
-
+from odoo.exceptions import ValidationError
 from odoo.tests.common import SavepointCase
+from odoo.tools import mute_logger
 
 
 class TestExchangeType(SavepointCase):
@@ -47,10 +48,8 @@ class TestExchangeType(SavepointCase):
                 "code": "tmpl_test_type_out1",
                 "name": "Out 1",
                 "backend_type_id": cls.backend_type.id,
-                "type_id": cls.type_out1.id,
                 "template_id": qweb_tmpl.id,
                 "output_type": "txt",
-                "allowed_type_ids": [(6, 0, [cls.type_out1.id, cls.type_out2.id])],
             }
         )
         cls.tmpl_out2 = model.create(
@@ -58,10 +57,8 @@ class TestExchangeType(SavepointCase):
                 "code": "tmpl_test_type_out2",
                 "name": "Out 2",
                 "backend_type_id": cls.env.ref("edi_oca.demo_edi_backend_type").id,
-                "type_id": cls.type_out1.id,
                 "template_id": qweb_tmpl.id,
                 "output_type": "txt",
-                "allowed_type_ids": [(6, 0, [cls.type_out2.id])],
             }
         )
         vals = {
@@ -79,7 +76,8 @@ class TestExchangeType(SavepointCase):
         }
         cls.record2 = cls.backend.create_record("test_type_out2", vals)
 
-    # TODO: getting a template via code is deprecated
+    # TODO: getting a template via code or relying on a fallback is deprecated
+    @mute_logger("odoo.addons.edi_exchange_template_oca.models.edi_backend")
     def test_get_template_by_code(self):
         self.assertEqual(
             self.backend._get_output_template(self.record2, code=self.tmpl_out1.code),
@@ -94,6 +92,7 @@ class TestExchangeType(SavepointCase):
             self.backend._get_output_template(self.record2), self.tmpl_out2
         )
 
+    @mute_logger("odoo.addons.edi_exchange_template_oca.models.edi_backend")
     def test_get_template_by_fallback(self):
         self.assertEqual(
             self.backend._get_output_template(self.record2, code=self.tmpl_out1.code),
@@ -105,6 +104,54 @@ class TestExchangeType(SavepointCase):
         # Here's is shown the limitation of the fallback lookup by backend type:
         # if you have more than one template allowed for the same type,
         # the first one is returned.
+        self.assertEqual(
+            self.backend._get_output_template(self.record2), self.tmpl_out1
+        )
+
+    @mute_logger("odoo.addons.edi_exchange_template_oca.models.edi_backend")
+    def test_get_template_allowed(self):
+        # No match by code on both templates
+        self.assertNotEqual(self.type_out1.code, self.tmpl_out1.code)
+        self.assertNotEqual(self.type_out1.code, self.tmpl_out2.code)
+        # Tmpl 2 is available for all types
+        self.assertFalse(self.tmpl_out2.allowed_type_ids)
+        # Tmpl 1 is explicitly set as allowed for type 1 -> we should get it 1st
+        self.tmpl_out1.allowed_type_ids = self.type_out1
+        self.assertEqual(
+            self.backend._get_output_template(self.record1),
+            self.tmpl_out1,
+        )
+        # Add a template, but still the 1st one is returned
+        self.tmpl_out1.allowed_type_ids += self.type_out2
+        self.assertEqual(
+            self.backend._get_output_template(self.record1), self.tmpl_out1
+        )
+
+    def test_template_validation(self):
+        self.tmpl_out1.allowed_type_ids = self.type_out1
+        self.assertIn(self.tmpl_out1, self.type_out1.output_template_allowed_ids)
+        with self.assertRaisesRegex(ValidationError, "Template not allowed"):
+            self.type_out2.output_template_id = self.tmpl_out1
+        with self.assertRaisesRegex(
+            ValidationError, "The selected type must appear among the allowed types"
+        ):
+            self.tmpl_out1.type_id = self.type_out2
+
+    def test_get_template_selected(self):
+        self.type_out1.output_template_id = self.tmpl_out1
+        self.type_out2.output_template_id = self.tmpl_out2
+        self.assertEqual(
+            self.backend._get_output_template(self.record1), self.tmpl_out1
+        )
+        self.assertEqual(
+            self.backend._get_output_template(self.record2), self.tmpl_out2
+        )
+        # inverse
+        self.type_out1.output_template_id = self.tmpl_out2
+        self.type_out2.output_template_id = self.tmpl_out1
+        self.assertEqual(
+            self.backend._get_output_template(self.record1), self.tmpl_out2
+        )
         self.assertEqual(
             self.backend._get_output_template(self.record2), self.tmpl_out1
         )

--- a/edi_exchange_template_oca/tests/test_backend_and_type.py
+++ b/edi_exchange_template_oca/tests/test_backend_and_type.py
@@ -1,0 +1,110 @@
+# Copyright 2025 Camptocamp SA
+# @author: Simone Orsi <simone.orsi@camptocamp.com>
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+
+from odoo.tests.common import SavepointCase
+
+
+class TestExchangeType(SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.backend_type = cls.env.ref("edi_oca.demo_edi_backend_type")
+        cls.backend = cls.env.ref("edi_oca.demo_edi_backend")
+        cls.type_out1 = cls.env["edi.exchange.type"].create(
+            {
+                "name": "Type output 1",
+                "direction": "output",
+                "code": "test_type_out1",
+                "exchange_file_ext": "txt",
+                "backend_type_id": cls.backend_type.id,
+            }
+        )
+        cls.type_out2 = cls.env["edi.exchange.type"].create(
+            {
+                "name": "Type output 2",
+                "direction": "output",
+                "code": "test_type_out2",
+                "exchange_file_ext": "txt",
+                "backend_type_id": cls.backend_type.id,
+            }
+        )
+        model = cls.env["edi.exchange.template.output"]
+        qweb_tmpl = cls.env["ir.ui.view"].create(
+            {
+                "type": "qweb",
+                "key": "edi_exchange.test_output1",
+                "arch": """
+            <t t-name="edi_exchange.test_output1">
+                TEST
+            </t>
+            """,
+            }
+        )
+        cls.tmpl_out1 = model.create(
+            {
+                "code": "tmpl_test_type_out1",
+                "name": "Out 1",
+                "backend_type_id": cls.backend_type.id,
+                "type_id": cls.type_out1.id,
+                "template_id": qweb_tmpl.id,
+                "output_type": "txt",
+                "allowed_type_ids": [(6, 0, [cls.type_out1.id, cls.type_out2.id])],
+            }
+        )
+        cls.tmpl_out2 = model.create(
+            {
+                "code": "tmpl_test_type_out2",
+                "name": "Out 2",
+                "backend_type_id": cls.env.ref("edi_oca.demo_edi_backend_type").id,
+                "type_id": cls.type_out1.id,
+                "template_id": qweb_tmpl.id,
+                "output_type": "txt",
+                "allowed_type_ids": [(6, 0, [cls.type_out2.id])],
+            }
+        )
+        vals = {
+            # doesn't matter what model we use
+            "model": cls.env.user._name,
+            "res_id": cls.env.user.id,
+            "type_id": cls.type_out2.id,
+        }
+        cls.record1 = cls.backend.create_record("test_type_out1", vals)
+        vals = {
+            # doesn't matter what model we use
+            "model": cls.env.user._name,
+            "res_id": cls.env.user.id,
+            "type_id": cls.type_out2.id,
+        }
+        cls.record2 = cls.backend.create_record("test_type_out2", vals)
+
+    # TODO: getting a template via code is deprecated
+    def test_get_template_by_code(self):
+        self.assertEqual(
+            self.backend._get_output_template(self.record2, code=self.tmpl_out1.code),
+            self.tmpl_out1,
+        )
+        self.record1.type_id.code = self.tmpl_out1.code
+        self.assertEqual(
+            self.backend._get_output_template(self.record1), self.tmpl_out1
+        )
+        self.record2.type_id.code = self.tmpl_out2.code
+        self.assertEqual(
+            self.backend._get_output_template(self.record2), self.tmpl_out2
+        )
+
+    def test_get_template_by_fallback(self):
+        self.assertEqual(
+            self.backend._get_output_template(self.record2, code=self.tmpl_out1.code),
+            self.tmpl_out1,
+        )
+        self.assertEqual(
+            self.backend._get_output_template(self.record1), self.tmpl_out1
+        )
+        # Here's is shown the limitation of the fallback lookup by backend type:
+        # if you have more than one template allowed for the same type,
+        # the first one is returned.
+        self.assertEqual(
+            self.backend._get_output_template(self.record2), self.tmpl_out1
+        )

--- a/edi_exchange_template_oca/tests/test_edi_backend_output.py
+++ b/edi_exchange_template_oca/tests/test_edi_backend_output.py
@@ -123,18 +123,6 @@ result = {"res_ids": record.ids}
 
 # TODO: add more unit tests
 class TestEDIBackendOutput(TestEDIBackendOutputBase):
-    def test_get_template(self):
-        self.assertEqual(
-            self.backend._get_output_template(self.record1), self.tmpl_out1
-        )
-        self.assertEqual(
-            self.backend._get_output_template(self.record2), self.tmpl_out2
-        )
-        self.assertEqual(
-            self.backend._get_output_template(self.record2, code=self.tmpl_out1.code),
-            self.tmpl_out1,
-        )
-
     def test_generate_file(self):
         output = self.backend.exchange_generate(self.record1)
         expected = "{0.ref} - {0.name}".format(self.partner)

--- a/edi_exchange_template_oca/tests/test_edi_backend_output.py
+++ b/edi_exchange_template_oca/tests/test_edi_backend_output.py
@@ -34,11 +34,11 @@ class TestEDIBackendOutputBase(EDIBackendCommonComponentTestCase):
                 "code": "edi.output.generate.demo_backend.test_type_out1",
                 "name": "Out 1",
                 "backend_type_id": cls.backend.backend_type_id.id,
-                "type_id": cls.type_out1.id,
                 "template_id": qweb_tmpl.id,
                 "output_type": "txt",
             }
         )
+        cls.type_out1.output_template_id = cls.tmpl_out1
         vals = {
             "model": cls.partner._name,
             "res_id": cls.partner.id,
@@ -74,7 +74,6 @@ class TestEDIBackendOutputBase(EDIBackendCommonComponentTestCase):
                 "code": "edi.output.generate.demo_backend.test_type_out2",
                 "name": "Out 2",
                 "backend_type_id": cls.backend.backend_type_id.id,
-                "type_id": cls.type_out2.id,
                 "template_id": qweb_tmpl.id,
                 "output_type": "xml",
                 "code_snippet": """
@@ -84,6 +83,7 @@ result = {"custom_bit": foo, "baz": baz}
                 """,
             }
         )
+        cls.type_out2.output_template_id = cls.tmpl_out2
         vals = {
             "model": cls.partner._name,
             "res_id": cls.partner.id,
@@ -103,7 +103,6 @@ result = {"custom_bit": foo, "baz": baz}
                 "code": "edi.output.generate.demo_backend.test_type_out3",
                 "name": "Out 3",
                 "backend_type_id": cls.backend.backend_type_id.id,
-                "type_id": cls.type_out3.id,
                 "generator": "report",
                 "report_id": cls.report.id,
                 "output_type": "pdf",
@@ -112,6 +111,7 @@ result = {"res_ids": record.ids}
                         """,
             }
         )
+        cls.type_out3.output_template_id = cls.tmpl_out3
         company = cls.env.ref("base.main_company")
         vals = {
             "model": company._name,

--- a/edi_exchange_template_oca/views/edi_exchange_template_output_views.xml
+++ b/edi_exchange_template_oca/views/edi_exchange_template_output_views.xml
@@ -27,7 +27,12 @@
                         <group name="main">
                             <field name="backend_type_id" />
                             <field name="backend_id" />
-                            <field name="type_id" />
+                            <field
+                                name="type_id"
+                                string="Type (deprecated)"
+                                help="Use allowed types and set the template explicitly on the type"
+                            />
+                            <field name="allowed_type_ids" widget="many2many_tags" />
                             <field name="code" />
                             <field name="output_type" />
                             <field name="generator" />

--- a/edi_exchange_template_oca/views/edi_exchange_type_views.xml
+++ b/edi_exchange_template_oca/views/edi_exchange_type_views.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+    <record id="edi_exchange_type_view_form" model="ir.ui.view">
+        <field name="model">edi.exchange.type</field>
+        <field name="inherit_id" ref="edi_oca.edi_exchange_type_view_form" />
+        <field name="arch" type="xml">
+            <group name="config" position="after">
+                <group
+                    name="template"
+                    attrs="{'invisible': [('direction', '!=', 'output')]}"
+                >
+                    <field name="output_template_allowed_ids" invisible="1" />
+                    <field
+                        name="output_template_id"
+                        domain="[('id', 'in', output_template_allowed_ids)]"
+                    />
+                </group>
+            </group>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Relying on the code by convention was fragile for many reasons.
Most important:

1. users have to remember about this convention
2. is not clear which template is going to be used by a specific type

With this change we make it more clear and deprecate the old behavior.

A long awaited improvement....