### PR TITLE
[15.0][IMP] edi_voxel_stock_picking_oca: Select the desired XML template in the partner company.

### DIFF
--- a/edi_voxel_stock_picking_oca/README.rst
+++ b/edi_voxel_stock_picking_oca/README.rst
@@ -114,6 +114,7 @@ Contributors
   * Ernesto Tejeda
   * Pedro M. Baeza
   * Sergio Teruel
+  * Juan Carlos Oñate
 
 Maintainers
 ~~~~~~~~~~~

--- a/edi_voxel_stock_picking_oca/__manifest__.py
+++ b/edi_voxel_stock_picking_oca/__manifest__.py
@@ -15,6 +15,7 @@
         "views/stock_picking_views.xml",
         "views/res_company_view.xml",
         "views/res_config_settings_views.xml",
+        "views/res_partner_view.xml",
     ],
     "installable": True,
 }

--- a/edi_voxel_stock_picking_oca/models/__init__.py
+++ b/edi_voxel_stock_picking_oca/models/__init__.py
@@ -3,3 +3,4 @@
 from . import stock_picking
 from . import res_company
 from . import res_config_settings
+from . import res_partner

--- a/edi_voxel_stock_picking_oca/models/res_partner.py
+++ b/edi_voxel_stock_picking_oca/models/res_partner.py
@@ -1,0 +1,14 @@
+from odoo import api, fields, models
+
+
+class ResPartner(models.Model):
+    _inherit = "res.partner"
+
+    voxel_picking_report_id = fields.Many2one(
+        comodel_name="ir.actions.report",
+        domain=[("report_type", "=", "qweb-xml"), ("model", "=", "stock.picking")],
+    )
+
+    @api.model
+    def _commercial_fields(self):
+        return super()._commercial_fields() + ["voxel_picking_report_id"]

--- a/edi_voxel_stock_picking_oca/models/stock_picking.py
+++ b/edi_voxel_stock_picking_oca/models/stock_picking.py
@@ -75,9 +75,12 @@ class Picking(models.Model):
 
         pickings = self.filtered(able_to_voxel)
         if pickings:
-            pickings.enqueue_voxel_report(
-                "edi_voxel_stock_picking_oca.report_voxel_picking"
-            )
+            for picking in pickings:
+                report = picking.partner_id.voxel_picking_report_id or self.env.ref(
+                    "edi_voxel_stock_picking_oca.report_voxel_picking"
+                )
+                if report:
+                    picking.enqueue_voxel_report(report)
 
     def get_document_type(self):
         """Document type name to be used in the name of the Voxel report"""

--- a/edi_voxel_stock_picking_oca/readme/CONTRIBUTORS.rst
+++ b/edi_voxel_stock_picking_oca/readme/CONTRIBUTORS.rst
@@ -3,3 +3,4 @@
   * Ernesto Tejeda
   * Pedro M. Baeza
   * Sergio Teruel
+  * Juan Carlos Oñate

--- a/edi_voxel_stock_picking_oca/static/description/index.html
+++ b/edi_voxel_stock_picking_oca/static/description/index.html
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
@@ -9,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -275,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -301,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -462,6 +462,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>Ernesto Tejeda</li>
 <li>Pedro M. Baeza</li>
 <li>Sergio Teruel</li>
+<li>Juan Carlos Oñate</li>
 </ul>
 </li>
 </ul>
@@ -469,7 +470,9 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-7">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>

--- a/edi_voxel_stock_picking_oca/views/res_partner_view.xml
+++ b/edi_voxel_stock_picking_oca/views/res_partner_view.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+    <record id="view_partner_form_voxel" model="ir.ui.view">
+        <field name="name">res.partner.form.voxel</field>
+        <field name="model">res.partner</field>
+        <field name="inherit_id" ref="base.view_partner_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='voxel_enabled']" position="after">
+                <field
+                    name="voxel_picking_report_id"
+                    attrs="{'invisible': ['|', ('is_company', '=', False), ('voxel_enabled', '=', False)]}"
+                    options="{'no_create': True, 'no_open': True}"
+                />
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
We added the voxel_report_id field in res.partner to allow companies to select an XML report template. Additionally, we set its visibility to be restricted to companies only, ensuring it remains hidden for individual contacts.

@Tecnativa TT55445
@sergio-teruel @pedrobaeza