### PR TITLE
[15.0][IMP] edi_voxel_stock_picking_oca: Remove HTML tags from picking note for Voxel compatibility

### DIFF
--- a/edi_voxel_stock_picking_oca/reports/report_voxel_picking.py
+++ b/edi_voxel_stock_picking_oca/reports/report_voxel_picking.py
@@ -2,6 +2,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo import api, models
+from odoo.tools import html2plaintext
 
 
 class ReportVoxelPicking(models.AbstractModel):
@@ -77,7 +78,9 @@ class ReportVoxelPicking(models.AbstractModel):
         ]
 
     def _get_comments_data(self, picking):
-        return picking.note and [{"Msg": picking.note}] or []
+        """Ensure the note is in str and strips HTML tags"""
+        note = picking.note and html2plaintext(picking.note)
+        return [{"Msg": note}] if note else []
 
     def _get_references_data(self, picking):
         so = picking.sale_id

--- a/edi_voxel_stock_picking_oca/tests/test_voxel_stock_picking.py
+++ b/edi_voxel_stock_picking_oca/tests/test_voxel_stock_picking.py
@@ -239,7 +239,7 @@ class TestVoxelStockPicking(TestVoxelStockPickingCommon):
         ]
 
     def _get_comments_data(self):
-        return [{"Msg": "<p>Picking note (test)</p>"}]
+        return [{"Msg": "Picking note (test)"}]
 
     def _get_references_data(self):
         return [{"PORef": "Sale order name (test)"}]


### PR DESCRIPTION
The change is made because the picking.note field is now of type HTML, and even if the HTML is empty, `"Markup('<p><br></p>')"` is added. Voxel requires the note to be in str, and previously, if the field was empty, HTML tags were being sent. Now, the tags are stripped to ensure compatibility.

@Tecnativa TT55445
@sergio-teruel @pedrobaeza