### PR TITLE
[15.0][FIX] edi_oca: fix search logic

### DIFF
--- a/edi_oca/models/edi_exchange_record.py
+++ b/edi_oca/models/edi_exchange_record.py
@@ -524,8 +524,6 @@ class EDIExchangeRecord(models.Model):
                     access_rights_uid=access_rights_uid,
                 )[: limit - len(result)]
             )
-        # Restore original ordering
-        result = [x for x in orig_ids if x in result]
         return len(result) if count else list(result)
 
     def read(self, fields=None, load="_classic_read"):


### PR DESCRIPTION
Maintaining this part of code can occur a visual issue. If the `result` variable has 80 records (default by Odoo) and the `orig_ids` is less than result, Odoo only shows the `orig_ids`, and we lost the previous work finding next records.


@ForgeFlow 