### PR TITLE
[17.0][IMP] base_import_pdf_by_template_account: Define a class for the import process

### DIFF
--- a/base_import_pdf_by_template_account/models/account_move.py
+++ b/base_import_pdf_by_template_account/models/account_move.py
@@ -6,22 +6,22 @@ from odoo import models
 class AccountMove(models.Model):
     _inherit = "account.move"
 
-    def _import_base_import_pdf_by_template(self, file_data, new=False):
+    def _import_base_import_pdf_by_template(self, invoice, file_data, new=False):
         """Method to process the PDF with base_import_pdf_by_template_account
         if any template is available (similar to account_edi_ubl_cii)."""
         template_model = self.env["base.import.pdf.template"].with_company(
-            self.company_id.id
+            invoice.company_id.id
         )
-        total_templates = template_model.search_count([("model", "=", self._name)])
+        total_templates = template_model.search_count([("model", "=", invoice._name)])
         if total_templates == 0:
             return False
-        self.move_type = (
-            "in_invoice" if self.journal_id.type == "purchase" else "out_invoice"
+        invoice.move_type = (
+            "in_invoice" if invoice.journal_id.type == "purchase" else "out_invoice"
         )
         wizard = self.env["wizard.base.import.pdf.upload"].create(
             {
-                "model": self._name,
-                "record_ref": f"{self._name},{self.id}",
+                "model": invoice._name,
+                "record_ref": f"{invoice._name},{invoice.id}",
                 "attachment_ids": [(6, 0, file_data["attachment"].ids)],
             }
         )
@@ -30,10 +30,5 @@ class AccountMove(models.Model):
 
     def _get_edi_decoder(self, file_data, new=False):
         if file_data["type"] == "pdf":
-            res = self._import_base_import_pdf_by_template(file_data, new)
-            if res:
-                # If everything worked correctly, we return False to avoid what
-                # is done in the _extend_with_attachments() method of account
-                # with the result of the _get_edi_decoder() method.
-                return False
+            return self._import_base_import_pdf_by_template
         return super()._get_edi_decoder(file_data, new=new)

--- a/base_import_pdf_by_template_account/tests/test_base_import_pdf_by_template_account.py
+++ b/base_import_pdf_by_template_account/tests/test_base_import_pdf_by_template_account.py
@@ -4,6 +4,8 @@
 from base64 import b64encode
 from os import path
 
+from odoo.tools import mute_logger
+
 from odoo.addons.base.tests.common import BaseCommon
 
 
@@ -66,7 +68,7 @@ class TestBaseImportPdfByTemplateAccount(BaseCommon):
             {"seller_ids": [(5, 0, 0)]}
         )
         # pylint: disable=W1401
-        cls.env["base.import.pdf.template"].create(
+        cls.template = cls.env["base.import.pdf.template"].create(
             {
                 "name": "Invoices Tecnativa",
                 "model_id": cls.env.ref("account.model_account_move").id,
@@ -232,3 +234,35 @@ class TestBaseImportPdfByTemplateAccount(BaseCommon):
         self.assertEqual(len(invoice.attachment_ids), 1)
         self.assertEqual(attachment, invoice.attachment_ids)
         self._test_account_invoice_tecnativa_data(invoice)
+
+    def test_account_move_from_alias_with_template(self):
+        invoice = (
+            self.env["account.move"]
+            .with_context(default_move_type="in_invoice")
+            .create({})
+        )
+        attachment = self._create_ir_attachment("account_invoice_tecnativa.pdf")
+        res = invoice.with_context(from_alias=True)._check_and_decode_attachment(
+            attachment
+        )
+        self.assertEqual(res, {attachment: invoice})
+        self.assertTrue(attachment.exists())
+        self.assertEqual(len(invoice.attachment_ids), 1)
+        self.assertEqual(attachment, invoice.attachment_ids)
+        self._test_account_invoice_tecnativa_data(invoice)
+
+    @mute_logger("odoo.models.unlink")
+    def test_account_move_from_alias_without_template(self):
+        invoice = (
+            self.env["account.move"]
+            .with_context(default_move_type="in_invoice")
+            .create({})
+        )
+        attachment = self._create_ir_attachment("account_invoice_tecnativa.pdf")
+        self.template.unlink()
+        res = invoice.with_context(from_alias=True)._check_and_decode_attachment(
+            attachment
+        )
+        self.assertEqual(res, {attachment: invoice})
+        self.assertTrue(attachment.exists())
+        self.assertEqual(len(invoice.invoice_line_ids), 0)


### PR DESCRIPTION
Define a class for the import process

Similar to what is done in other modules: `account_edi_ubl_cii`, `l10n_es_edi_facturae`, `l10n_it_edi`

Problems solved with this change:
- [x] When a pdf file is processed through the email alias and no template is applied, the attachment will not be deleted. (https://github.com/odoo/odoo/blob/b99f635935c3e29e4969fc7918f13a363f0583aa/addons/account/models/account_move.py#L4901)
- [x] When a pdf file is processed and if a template is applied and lines are defined in the invoice, the automatic garbled message will not be defined. (https://github.com/odoo/odoo/blob/b99f635935c3e29e4969fc7918f13a363f0583aa/addons/account/models/account_move.py#L4892)

Please @pedrobaeza and @pilarvargas-tecnativa can you review it?

@Tecnativa TT56089 TT55764