### PR TITLE
[15.0][IMP] edi_oca: Add mute_logger to test to prevent confusion in logs

### DIFF
--- a/edi_oca/tests/test_exchange_type.py
+++ b/edi_oca/tests/test_exchange_type.py
@@ -2,8 +2,9 @@
 # Copyright 2022 Camptocamp SA (https://www.camptocamp.com).
 # @author: Simone Orsi <simahawk@gmail.com>
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
-
 from freezegun import freeze_time
+
+from odoo.tools import mute_logger
 
 from .common import EDIBackendCommonTestCase
 
@@ -23,6 +24,7 @@ class EDIExchangeTypeTestCase(EDIBackendCommonTestCase):
             self.exchange_type_out_ack.ack_for_type_ids.ids,
         )
 
+    @mute_logger("odoo.sql_db")
     def test_same_code_same_backend(self):
         with self.assertRaises(Exception) as err:
             self.exchange_type_in.copy({"code": "test_csv_input"})


### PR DESCRIPTION
Add mute_logger to test to prevent confusion in logs

Previous log:

```
ERROR devel odoo.sql_db: bad query: INSERT INTO "edi_exchange_type" ("id", "ack_type_id", "active", "advanced_settings_edit", "backend_id", "backend_type_id", "code", "create_date", "create_uid", "direction", "enable_domain", "enable_snippet", "exchange_file_auto_generate", "exchange_file_ext", "exchange_filename_pattern", "job_channel_id", "model_manual_btn", "name", "quick_exec", "write_date", "write_uid") VALUES (nextval('edi_exchange_type_id_seq'), NULL, true, NULL, 1, 1, 'test_csv_input', '2025-05-21 12:24:02.582474', 1, 'input', NULL, NULL, false, 'csv', '{record.ref}-{type.code}-{dt}', NULL, false, 'Test CSV input', false, '2025-05-21 12:24:02.582474', 1) RETURNING id
ERROR: duplicate key value violates unique constraint "edi_exchange_type_code_uniq"
DETAIL:  Key (code, backend_id)=(test_csv_input, 1) already exists.
```

Please @CarlosRoca13 can you review it?

@Tecnativa