### PR TITLE
Add many2many type when using a fixed value

### DIFF
--- a/base_import_pdf_by_template/models/base_import_pdf_template.py
+++ b/base_import_pdf_by_template/models/base_import_pdf_template.py
@@ -348,6 +348,7 @@ class BaseImportPdfTemplateLine(models.Model):
             "text": "fixed_value_text",
             "json": "fixed_value_text",
             "many2one": "fixed_value",
+            "many2many": "fixed_value",
         }
 
     def _get_fixed_value(self):

--- a/base_import_pdf_by_template/models/base_import_pdf_template.py
+++ b/base_import_pdf_by_template/models/base_import_pdf_template.py
@@ -238,6 +238,7 @@ class BaseImportPdfTemplateLine(models.Model):
     date_format = fields.Selection(
         selection=[
             ("*Y-*d-*m", _("YY-dd-MM")),
+            ("*Y-*m-*d", _("YY-MM-dd")),
             ("*m-*d-*Y", _("MM-dd-YY")),
             ("*d-*m-*Y", _("dd-MM-YY")),
             ("*Y/*d/*m", _("YY/dd/MM")),


### PR DESCRIPTION
### Error description
When a line field is defined as "many2many" (for example tax_ids from invoice line) and has a fixed value, the following error is triggered during template use (doesn't happen during preview):
 `line 354, in _get_fixed_value
    f_name = self._get_fixed_field_name_ttype_mapped()[self.field_ttype]
             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^
KeyError: 'many2many'`

### Patch
Adding the `"many2many" : "fixed_value"` line avoids the error and writes the selected fixed value.

### Drawback
Only one value can be selected. For example, I haven't been able to select multiple tax ids in my case.