### PR TITLE
[14.0] sale_order_import: add confirm_order flag

### DIFF
--- a/sale_order_import/tests/test_order_import.py
+++ b/sale_order_import/tests/test_order_import.py
@@ -59,6 +59,18 @@ class TestOrderImport(TestCommon):
         self.assertEqual(len(order.order_line), 2)
         self.assertEqual(int(order.order_line[0].product_uom_qty), 3)
 
+    def test_order_import_action(self):
+        wiz = self.wiz_model.create({})
+        action = wiz.create_order_return_action(self.parsed_order, "order.ref")
+        order = self.env["sale.order"].browse(action["res_id"])
+        self.assertEqual(order.state, "draft")
+
+    def test_order_import_confirm(self):
+        wiz = self.wiz_model.create({"confirm_order": True})
+        action = wiz.create_order_return_action(self.parsed_order, "order.ref")
+        order = self.env["sale.order"].browse(action["res_id"])
+        self.assertEqual(order.state, "sale")
+
     def test_order_import_default_so_vals(self):
         default = {"client_order_ref": "OVERRIDE"}
         order = self.wiz_model.with_context(

--- a/sale_order_import/wizard/sale_order_import.py
+++ b/sale_order_import/wizard/sale_order_import.py
@@ -53,6 +53,7 @@ class SaleOrderImport(models.TransientModel):
         "res.partner", string="Shipping Address", readonly=True
     )
     sale_id = fields.Many2one("sale.order", string="Quotation to Update")
+    confirm_order = fields.Boolean(default=False)
 
     @api.onchange("order_file")
     def order_file_change(self):
@@ -312,23 +313,33 @@ class SaleOrderImport(models.TransientModel):
                 )
             )
 
+    # TODO: I wonder why these methods are model methods
     @api.model
-    def create_order(self, parsed_order, price_source, order_filename=None):
+    def create_order(
+        self, parsed_order, price_source, order_filename=None, confirm_order=False
+    ):
         soo = self.env["sale.order"].with_context(mail_create_nosubscribe=True)
         bdio = self.env["business.document.import"]
         so_vals = self._prepare_order(parsed_order, price_source)
         order = soo.create(so_vals)
+        if confirm_order:
+            order.action_confirm()
         bdio.post_create_or_update(parsed_order, order, doc_filename=order_filename)
         logger.info("Sale Order ID %d created", order.id)
         return order
 
     @api.model
-    def create_order_ws(self, parsed_order, price_source, order_filename=None):
+    def create_order_ws(
+        self, parsed_order, price_source, order_filename=None, confirm_order=False
+    ):
         """Same method as create_order() but callable via JSON-RPC
         webservice. Returns an ID to avoid this error:
         TypeError: sale.order(15,) is not JSON serializable"""
         order = self.create_order(
-            parsed_order, price_source, order_filename=order_filename
+            parsed_order,
+            price_source,
+            order_filename=order_filename,
+            confirm_order=confirm_order,
         )
         return order.id
 
@@ -409,7 +420,12 @@ class SaleOrderImport(models.TransientModel):
     # TODO: add tests
     def create_order_return_action(self, parsed_order, order_filename):
         self.ensure_one()
-        order = self.create_order(parsed_order, self.price_source, order_filename)
+        order = self.create_order(
+            parsed_order,
+            self.price_source,
+            order_filename,
+            confirm_order=self._order_should_be_confirmed(),
+        )
         order.message_post(
             body=_("Created automatically via file import (%s).") % self.order_filename
         )
@@ -423,6 +439,10 @@ class SaleOrderImport(models.TransientModel):
             }
         )
         return action
+
+    def _order_should_be_confirmed(self):
+        # Hook to override behavior
+        return self.confirm_order
 
     # TODO: add tests
     @api.model

--- a/sale_order_import/wizard/sale_order_import_view.xml
+++ b/sale_order_import/wizard/sale_order_import_view.xml
@@ -63,6 +63,7 @@
                         name="price_source"
                         attrs="{'invisible': [('doc_type', '!=', 'order')], 'required': [('doc_type', '=', 'order')]}"
                     />
+                    <field name="confirm_order" />
                 </group>
                 <footer>
                     <button


### PR DESCRIPTION
Allows to confirm order immediately.


Extracted from https://github.com/OCA/edi/pull/1090

Used in prod since ages.