### PR TITLE
[12.0][BACKPORT][IMP] edi_oca: Split exchange error and traceback

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -4,7 +4,7 @@
 # F601 pylint support this case with expected tests
 # W503 changed by W504 and OCA prefers allow both
 # E203: whitespace before ':' (black behaviour and not pep8 compliant)
-ignore = E123,E133,E226,E241,E242,F811,F601,W503,W504,E203
+ignore = E123,E133,E226,E241,E242,F811,F601,W503,W504,E203,F841,E722
 max-line-length = 88
 per-file-ignores=
     __init__.py:F401

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -11,12 +11,12 @@ on:
 
 jobs:
   pre-commit:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.6"
+          python-version: "3.8"
       - name: Get python version
         run: echo "PY=$(python -VV | sha256sum | cut -d' ' -f1)" >> $GITHUB_ENV
       - uses: actions/cache@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
               fi
           done
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     container: ${{ matrix.container }}
     name: ${{ matrix.name }}
     strategy:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,10 +12,12 @@ exclude: |
   /static/(src/)?lib/|
   # Repos using Sphinx to generate docs don't need prettying
   ^docs/_templates/.*\.html$|
+  # Ignore build and dist directories in addons
+  /build/|/dist/|
   # You don't usually want a bot to modify your legal texts
   (LICENSE.*|COPYING.*)
 default_language_version:
-  python: python3.6
+  python: python3.8
 repos:
   - repo: https://github.com/oca/maintainer-tools
     rev: ab1d7f6
@@ -28,8 +30,8 @@ repos:
     rev: 3.1.8
     hooks:
       - id: setuptools-odoo-make-default
-  - repo: https://github.com/OCA/mirrors-flake8
-    rev: v3.4.1
+  - repo: https://github.com/PyCQA/flake8
+    rev: 3.7.9
     hooks:
       - id: flake8
         name: flake8 excluding __init__.py

--- a/edi_oca/models/edi_backend.py
+++ b/edi_oca/models/edi_backend.py
@@ -20,7 +20,13 @@ from ..exceptions import EDIValidationError
 _logger = logging.getLogger(__name__)
 
 
-def _get_exception_msg():
+def _get_exception_msg(exc):
+    if hasattr(exc, "args") and isinstance(exc.args[0], str):
+        return exc.args[0]
+    return repr(exc)
+
+
+def _get_exception_traceback():
     buff = StringIO()
     traceback.print_exc(file=buff)
     traceback_txt = buff.getvalue()
@@ -242,12 +248,17 @@ class EDIBackend(models.Model):
             message = exchange_record._exchange_status_message("generate_ok")
             try:
                 self._validate_data(exchange_record, output)
-            except EDIValidationError:
-                error = _get_exception_msg()
+            except EDIValidationError as err:
+                traceback = _get_exception_traceback()
+                error = _get_exception_msg(err)
                 state = "validate_error"
                 message = exchange_record._exchange_status_message("validate_ko")
                 exchange_record.update(
-                    {"edi_exchange_state": state, "exchange_error": error}
+                    {
+                        "edi_exchange_state": state,
+                        "exchange_error": error,
+                        "exchange_error_traceback": traceback,
+                    }
                 )
                 exchange_record._onchange_edi_exchange_state()
         exchange_record.notify_action_complete("generate", message=message)
@@ -310,22 +321,24 @@ class EDIBackend(models.Model):
         if not check:
             return "Nothing to do. Likely already sent."
         state = exchange_record.edi_exchange_state
-        error = False
+        error = traceback = False
         message = None
         res = ""
         try:
             self._exchange_send(exchange_record)
             _logger.debug("%s sent", exchange_record.identifier)
         except self._send_retryable_exceptions() as err:
-            error = _get_exception_msg()
+            traceback = _get_exception_traceback()
+            error = _get_exception_msg(err)
             _logger.debug("%s send failed. To be retried.", exchange_record.identifier)
             raise RetryableJobError(
                 error, **exchange_record._job_retry_params()
             ) from err
-        except self._swallable_exceptions():
+        except self._swallable_exceptions() as err:
             if self.env.context.get("_edi_send_break_on_error"):
                 raise
-            error = _get_exception_msg()
+            traceback = _get_exception_traceback()
+            error = _get_exception_msg(err)
             state = "output_error_on_send"
             message = exchange_record._exchange_status_message("send_ko")
             res = "Error: {}".format(error)
@@ -335,7 +348,7 @@ class EDIBackend(models.Model):
         else:
             # TODO: maybe the send handler should return desired message and state
             message = exchange_record._exchange_status_message("send_ok")
-            error = None
+            error = traceback = None
             state = (
                 "output_sent_and_processed"
                 if self.output_sent_processed_auto
@@ -347,6 +360,7 @@ class EDIBackend(models.Model):
                 {
                     "edi_exchange_state": state,
                     "exchange_error": error,
+                    "exchange_error_traceback": traceback,
                     # FIXME: this should come from _compute_exchanged_on
                     # but somehow it's failing in send tests (in record tests it works).
                     "exchanged_on": fields.Datetime.now(),
@@ -506,24 +520,29 @@ class EDIBackend(models.Model):
         if not check:
             return "Nothing to do. Likely already processed."
         old_state = state = exchange_record.edi_exchange_state
-        error = False
+        error = traceback = False
         message = None
         try:
             res = self._exchange_process(exchange_record)
-        except self._swallable_exceptions():
+        except self._swallable_exceptions() as err:
             if self.env.context.get("_edi_process_break_on_error"):
                 raise
-            error = _get_exception_msg()
+            traceback = _get_exception_traceback()
+            error = _get_exception_msg(err)
             state = "input_processed_error"
             res = "Error: {}".format(error)
         else:
-            error = None
+            error = traceback = None
             state = "input_processed"
         finally:
             exchange_record.write(
                 {
                     "edi_exchange_state": state,
                     "exchange_error": error,
+                    "exchange_error_traceback": traceback,
+                    # FIXME: this should come from _compute_exchanged_on
+                    # but somehow it's failing in send tests (in record tests it works).
+                    "exchanged_on": fields.Datetime.now(),
                 }
             )
             exchange_record._onchange_edi_exchange_state()
@@ -552,7 +571,7 @@ class EDIBackend(models.Model):
         if not check:
             return "Nothing to do. Likely already received."
         state = exchange_record.edi_exchange_state
-        error = False
+        error = traceback = False
         message = None
         content = None
         try:
@@ -561,21 +580,23 @@ class EDIBackend(models.Model):
             if content is not None:
                 exchange_record._set_file_content(content)
                 self._validate_data(exchange_record)
-        except EDIValidationError:
-            error = _get_exception_msg()
+        except EDIValidationError as err:
+            traceback = _get_exception_traceback()
+            error = _get_exception_msg(err)
             state = "validate_error"
             message = exchange_record._exchange_status_message("validate_ko")
             res = "Validation error: {}".format(error)
-        except self._swallable_exceptions():
+        except self._swallable_exceptions() as err:
             if self.env.context.get("_edi_receive_break_on_error"):
                 raise
-            error = _get_exception_msg()
+            traceback = _get_exception_traceback()
+            error = _get_exception_msg(err)
             state = "input_receive_error"
             message = exchange_record._exchange_status_message("receive_ko")
             res = "Input error: {}".format(error)
         else:
             message = exchange_record._exchange_status_message("receive_ok")
-            error = None
+            error = traceback = None
             state = "input_received"
             res = message
         finally:
@@ -583,6 +604,7 @@ class EDIBackend(models.Model):
                 {
                     "edi_exchange_state": state,
                     "exchange_error": error,
+                    "exchange_error_traceback": traceback,
                     # FIXME: this should come from _compute_exchanged_on
                     # but somehow it's failing in send tests (in record tests it works).
                     "exchanged_on": fields.Datetime.now(),

--- a/edi_oca/models/edi_exchange_record.py
+++ b/edi_oca/models/edi_exchange_record.py
@@ -85,6 +85,9 @@ class EDIExchangeRecord(models.Model):
         ],
     )
     exchange_error = fields.Text(string="Exchange error", readonly=True, copy=False)
+    exchange_error_traceback = fields.Text(
+        string="Exchange error traceback", readonly=True, copy=False
+    )
     # Relations w/ other records
     parent_id = fields.Many2one(
         comodel_name="edi.exchange.record",

--- a/edi_oca/tests/test_backend_input.py
+++ b/edi_oca/tests/test_backend_input.py
@@ -51,8 +51,12 @@ class EDIBackendTestInputCase(EDIBackendCommonComponentRegistryTestCase):
             fake_output="", _edi_receive_break_on_error=False
         ).exchange_receive(self.record)
         # Check the record
-        msg = "Empty files are not allowed for exchange type"
-        self.assertIn(msg, self.record.exchange_error)
+        msg = "Empty files are not allowed for exchange type %(name)s (%(code)s)" % {
+            "name": self.exchange_type_in.name,
+            "code": self.exchange_type_in.code,
+        }
+        self.assertEqual(msg, self.record.exchange_error)
+        self.assertIn(msg, self.record.exchange_error_traceback)
         self.assertEqual(self.record._get_file_content(), "")
         self.assertRecordValues(
             self.record, [{"edi_exchange_state": "input_receive_error"}]

--- a/edi_oca/tests/test_backend_output.py
+++ b/edi_oca/tests/test_backend_output.py
@@ -73,10 +73,13 @@ class EDIBackendTestOutputCase(EDIBackendCommonComponentRegistryTestCase):
             [
                 {
                     "edi_exchange_state": "output_error_on_send",
+                    "exchange_error": "OOPS! Something went wrong :(",
                 }
             ],
         )
-        self.assertIn("OOPS! Something went wrong :(", self.record.exchange_error)
+        self.assertIn(
+            "OOPS! Something went wrong :(", self.record.exchange_error_traceback
+        )
 
     def test_send_invalid_direction(self):
         vals = {

--- a/edi_oca/tests/test_backend_process.py
+++ b/edi_oca/tests/test_backend_process.py
@@ -59,10 +59,13 @@ class EDIBackendTestProcessCase(EDIBackendCommonComponentRegistryTestCase):
             [
                 {
                     "edi_exchange_state": "input_processed_error",
+                    "exchange_error": "OOPS! Something went wrong :(",
                 }
             ],
         )
-        self.assertIn("OOPS! Something went wrong :(", self.record.exchange_error)
+        self.assertIn(
+            "OOPS! Something went wrong :(", self.record.exchange_error_traceback
+        )
 
     @mute_logger("odoo.models.unlink")
     def test_process_no_file_record(self):

--- a/edi_oca/tests/test_backend_validate.py
+++ b/edi_oca/tests/test_backend_validate.py
@@ -64,10 +64,11 @@ class EDIBackendTestValidateCase(EDIBackendCommonComponentRegistryTestCase):
             [
                 {
                     "edi_exchange_state": "validate_error",
+                    "exchange_error": "Data seems wrong!",
                 }
             ],
         )
-        self.assertIn("Data seems wrong!", self.record_in.exchange_error)
+        self.assertIn("Data seems wrong!", self.record_in.exchange_error_traceback)
 
     def test_generate_validate_record(self):
         self.record_out.write({"edi_exchange_state": "new"})
@@ -91,10 +92,11 @@ class EDIBackendTestValidateCase(EDIBackendCommonComponentRegistryTestCase):
             [
                 {
                     "edi_exchange_state": "validate_error",
+                    "exchange_error": "Data seems wrong!",
                 }
             ],
         )
-        self.assertIn("Data seems wrong!", self.record_out.exchange_error)
+        self.assertIn("Data seems wrong!", self.record_out.exchange_error_traceback)
 
     def test_validate_record_error_regenerate(self):
         self.record_out.write({"edi_exchange_state": "new"})

--- a/edi_oca/views/edi_exchange_record_views.xml
+++ b/edi_oca/views/edi_exchange_record_views.xml
@@ -17,6 +17,7 @@
                 <field name="exchanged_on" />
                 <field name="ack_received_on" />
                 <field name="edi_exchange_state" />
+                <field name="exchange_error" />
             </tree>
         </field>
     </record>
@@ -144,9 +145,10 @@
                         <page
                             name="error"
                             string="Error"
-                            attrs="{'invisible': [('exchange_error', '=', False)]}"
+                            attrs="{'invisible': [('exchange_error_traceback', '=', False)]}"
                         >
                             <field name="exchange_error" />
+                            <field name="exchange_error_traceback" />
                         </page>
                         <!-- FIXME: this `invisible` domain does not work -->
                         <page


### PR DESCRIPTION
Backport from https://github.com/OCA/edi/pull/1173