### PR TITLE
[FIX] account_invoice_import: avoid crash when XML date field has spaces or line returns

### DIFF
--- a/account_invoice_import/wizard/account_invoice_import.py
+++ b/account_invoice_import/wizard/account_invoice_import.py
@@ -1471,7 +1471,7 @@ class AccountInvoiceImport(models.TransientModel):
                         and xpath_res[0].attrib.get("format") != "102"
                     ):
                         raise UserError(_("Only the date format 102 is supported "))
-                    date_dt = datetime.strptime(xpath_res[0].text, "%Y%m%d")
+                    date_dt = datetime.strptime(xpath_res[0].text.strip(), "%Y%m%d")
                     date_str = fields.Date.to_string(date_dt)
                     return date_str
                 elif isfloat:


### PR DESCRIPTION
Avoid a crash when importing Factur-X invoices generates by Pennylane that has the following XML:

```
<ram:IssueDateTime>
    <udt:DateTimeString format="102">
      20250515
    </udt:DateTimeString>
  </ram:IssueDateTime>
```

Avoid this crash:

```
2025-06-24 09:37:51,221 292387 INFO test1 odoo.addons.account_invoice_import.wizard.account_invoice_import: Trying to parse XML file factur-x.xml
2025-06-24 09:37:51,221 292387 INFO test1 factur-x: Flavor is factur-x (autodetected)
2025-06-24 09:37:51,221 292387 INFO test1 factur-x: Level is en16931 (autodetected)
2025-06-24 09:37:51,223 292387 INFO test1 factur-x: factur-x XML file successfully validated against XSD
2025-06-24 09:37:51,224 292387 ERROR test1 odoo.http: Exception during JSON request handling.
Traceback (most recent call last):
  File "/home/odoo/erp/odoo/odoo/addons/base/models/ir_http.py", line 237, in _dispatch
    result = request.dispatch()
  File "/home/odoo/erp/odoo/odoo/http.py", line 696, in dispatch
    result = self._call_function(**self.params)
  File "/home/odoo/erp/odoo/odoo/http.py", line 370, in _call_function
    return checked_call(self.db, *args, **kwargs)
  File "/home/odoo/erp/odoo/odoo/service/model.py", line 94, in wrapper
    return f(dbname, *args, **kwargs)
  File "/home/odoo/erp/odoo/odoo/http.py", line 358, in checked_call
    result = self.endpoint(*a, **kw)
  File "/home/odoo/erp/odoo/odoo/http.py", line 919, in __call__
    return self.method(*args, **kw)
  File "/home/odoo/erp/odoo/odoo/http.py", line 544, in response_wrap
    response = f(*args, **kw)
  File "/home/odoo/erp/odoo/addons/web/controllers/main.py", line 1374, in call_button
    action = self._call_kw(model, method, args, kwargs)
  File "/home/odoo/erp/odoo/addons/web/controllers/main.py", line 1362, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "/home/odoo/erp/odoo/odoo/api.py", line 406, in call_kw
    result = _call_kw_multi(method, model, args, kwargs)
  File "/home/odoo/erp/odoo/odoo/api.py", line 391, in _call_kw_multi
    result = method(recs, *args, **kwargs)
  File "/home/odoo/erp/edi/account_invoice_import/wizard/account_invoice_import.py", line 808, in import_invoice
    parsed_inv = self.get_parsed_invoice()
  File "/home/odoo/erp/edi/account_invoice_import/wizard/account_invoice_import.py", line 657, in get_parsed_invoice   
    return self.parse_invoice(self.invoice_file, self.invoice_filename)
  File "/home/odoo/erp/edi/account_invoice_import/wizard/account_invoice_import.py", line 516, in parse_invoice
    parsed_inv = self.parse_pdf_invoice(file_data)
  File "/home/odoo/erp/edi/account_invoice_import/wizard/account_invoice_import.py", line 94, in parse_pdf_invoice
    parsed_inv = self.parse_xml_invoice(xml_root)
  File "/home/odoo/erp/edi/account_invoice_import_facturx/wizard/account_invoice_import.py", line 30, in parse_xml_invoice
    return self.parse_facturx_invoice(xml_root)
  File "/home/odoo/erp/edi/account_invoice_import_facturx/wizard/account_invoice_import.py", line 394, in parse_facturx_invoice
    res = self.xpath_to_dict_helper(xml_root, xpath_dict, namespaces)
  File "/home/odoo/erp/edi/account_invoice_import/wizard/account_invoice_import.py", line 1451, in xpath_to_dict_helper
    xpath_dict[key] = self.multi_xpath_helper(
  File "/home/odoo/erp/edi/account_invoice_import/wizard/account_invoice_import.py", line 1474, in multi_xpath_helper  
    date_dt = datetime.strptime(xpath_res[0].text, "%Y%m%d")
  File "/usr/lib/python3.10/_strptime.py", line 568, in _strptime_datetime
    tt, fraction, gmtoff_fraction = _strptime(data_string, format)
  File "/usr/lib/python3.10/_strptime.py", line 349, in _strptime
    raise ValueError("time data %r does not match format %r" %
Exception

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/odoo/erp/odoo/odoo/http.py", line 652, in _handle_exception
    return super(JsonRequest, self)._handle_exception(exception)
  File "/home/odoo/erp/odoo/odoo/http.py", line 317, in _handle_exception
    raise exception.with_traceback(None) from new_cause
ValueError: time data '\n      20250515\n    ' does not match format '%Y%m%d'
```