### PR TITLE
[14.0][IMP] edi_oca: add index on ack_exchange_id

### DIFF
--- a/edi_oca/models/edi_exchange_record.py
+++ b/edi_oca/models/edi_exchange_record.py
@@ -110,6 +110,7 @@ class EDIExchangeRecord(models.Model):
         help="ACK generated for current exchange.",
         compute="_compute_ack_exchange_id",
         store=True,
+        index=True,
     )
     ack_received_on = fields.Datetime(
         string="ACK received on", related="ack_exchange_id.exchanged_on"


### PR DESCRIPTION
Found while analyzing slow database queries.

Before:
```sql
# EXPLAIN ANALYZE
SELECT id FROM "edi_exchange_record" WHERE ("ack_exchange_id" in (2345679, 123341)) ORDER BY "id";
                                                             QUERY PLAN                                                              
-------------------------------------------------------------------------------------------------------------------------------------
 Sort  (cost=7438.46..7438.47 rows=1 width=4) (actual time=26.323..30.384 rows=0 loops=1)
   Sort Key: id
   Sort Method: quicksort  Memory: 25kB
   ->  Gather  (cost=1000.00..7438.45 rows=1 width=4) (actual time=26.317..30.377 rows=0 loops=1)
         Workers Planned: 2
         Workers Launched: 2
         ->  Parallel Seq Scan on edi_exchange_record  (cost=0.00..6438.35 rows=1 width=4) (actual time=9.030..9.030 rows=0 loops=3)
               Filter: (ack_exchange_id = ANY ('{2345679,123341}'::integer[]))
               Rows Removed by Filter: 51415
 Planning Time: 0.197 ms
 Execution Time: 30.413 ms
(11 rows)
```

After:
```sql
# EXPLAIN ANALYZE                                               
SELECT id FROM "edi_exchange_record" WHERE ("ack_exchange_id" in (2345679, 123341)) ORDER BY "id";
                                                                                  QUERY PLAN                                                                                  
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Sort  (cost=12.62..12.63 rows=1 width=4) (actual time=0.029..0.030 rows=0 loops=1)
   Sort Key: id
   Sort Method: quicksort  Memory: 25kB
   ->  Index Scan using edi_exchange_record_ack_exchange_id_index on edi_exchange_record  (cost=0.29..12.62 rows=1 width=4) (actual time=0.024..0.024 rows=0 loops=1)
         Index Cond: (ack_exchange_id = ANY ('{2345679,123341}'::integer[]))
 Planning Time: 0.348 ms
 Execution Time: 0.055 ms
(7 rows)
```