### PR TITLE
[17.0][IMP+FIX] base_import_pdf_by_template_account: Suitable value of sort_weight in _unwrap_edi_attachments() method if applicable

### DIFF
--- a/base_import_pdf_by_template/wizards/wizard_base_import_pdf_upload.py
+++ b/base_import_pdf_by_template/wizards/wizard_base_import_pdf_upload.py
@@ -75,7 +75,8 @@ class WizardBaseImportPdfUpload(models.TransientModel):
         for line in self.line_ids.filtered("template_id"):
             try:
                 records += line.action_process()
-            except Exception:
+            except Exception as e:
+                logger.info(e)
                 if not self.env.context.get("skip_template_not_found_error"):
                     raise
         action = {
@@ -190,7 +191,8 @@ class WizardBaseImportPdfUploadLine(models.TransientModel):
         else:
             try:
                 setattr(_form, field_name, value)
-            except Exception:
+            except Exception as e:
+                logger.info(e)
                 self._add_log_error_text(field_name, value)
 
     def _process_form(self):
@@ -217,7 +219,8 @@ class WizardBaseImportPdfUploadLine(models.TransientModel):
                     field_value = model[field_name].browse(field_value)
                 try:
                     setattr(model_form, field_name, field_value)
-                except Exception:
+                except Exception as e:
+                    logger.info(e)
                     extra_vals[field_name] = ctx[key]
         # Set the values of the header in Form
         header_values = template._get_field_header_values(text)
@@ -240,7 +243,8 @@ class WizardBaseImportPdfUploadLine(models.TransientModel):
                     child_field_value = child_fixed_values[field_name]
                     try:
                         setattr(line_form, field_name, child_field_value)
-                    except Exception:
+                    except Exception as e:
+                        logger.info(e)
                         self._add_log_error_text(field_name, child_field_value)
                 # set the values of any line
                 for field_name in list(line.keys()):

--- a/base_import_pdf_by_template/wizards/wizard_base_import_pdf_upload.py
+++ b/base_import_pdf_by_template/wizards/wizard_base_import_pdf_upload.py
@@ -207,7 +207,10 @@ class WizardBaseImportPdfUploadLine(models.TransientModel):
         # appropriate (fiscal position).
         extra_vals = {}
         for key in list(ctx.keys()):
-            if key.startswith("default_"):
+            # It is important to skip this field, when using fetchmail it
+            # is defined as default_ but it does not exist and there
+            # would be an error preventing the record from being created.
+            if key.startswith("default_") and key != "default_fetchmail_server_id":
                 field_name = key.replace("default_", "")
                 field_value = ctx[key]
                 if model._fields[field_name].type == "many2one":

--- a/base_import_pdf_by_template_account/models/__init__.py
+++ b/base_import_pdf_by_template_account/models/__init__.py
@@ -1,1 +1,2 @@
 from . import account_move
+from . import ir_attachment

--- a/base_import_pdf_by_template_account/models/ir_attachment.py
+++ b/base_import_pdf_by_template_account/models/ir_attachment.py
@@ -1,0 +1,30 @@
+# Copyright 2025 Tecnativa - Víctor Martínez
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from odoo import models
+
+
+class IrAttachment(models.Model):
+    _inherit = "ir.attachment"
+
+    # TODO: Remove in v19 because _extend_with_attachments() method is properly done
+    # in account.document.import.mixin
+    def _unwrap_edi_attachments(self):
+        to_process = super()._unwrap_edi_attachments()
+        if len(to_process) > 1 and any(a["type"] == "pdf" for a in to_process):
+            attachment = to_process[0]["attachment"]
+            if attachment.res_model and attachment.res_id:
+                record = self.env[attachment.res_model].browse(attachment.res_id)
+                template_model = self.env["base.import.pdf.template"]
+                if "company_id" in record._fields:
+                    template_model = template_model.with_company(record.company_id.id)
+                total_templates = template_model.search_count(
+                    [("model", "=", record._name)]
+                )
+                if total_templates > 0:
+                    # Define a sort_weight=1 to have a higher priority in the
+                    # _extend_with_attachments() method when doing the decoder
+                    for to_process_item in to_process:
+                        if to_process_item["type"] == "pdf":
+                            to_process_item["sort_weight"] = 1
+                    to_process.sort(key=lambda x: x["sort_weight"])
+        return to_process


### PR DESCRIPTION
Suitable value of `sort_weight` in `_unwrap_edi_attachments()` method if applicable

**Example of use case**:
- Create a pdf template linked to invoices.
- Define an email alias to automatically create the invoices and process the attachments
- Send an email to the alias with 2 attachments: example.xml and example.pdf

**Before**:
The `_unwrap_edi_attachments()` method indirectly applied a lower sort_weight value (10) to the example.xml file than to the example.pdf file (20), which meant that the https://github.com/odoo/odoo/blob/399da69818d22860a808f5416829863f002ad38a/addons/account/models/account_move.py#L3202 condition was met for the example.pdf file and the pdf was not processed correctly (https://github.com/odoo/odoo/blob/399da69818d22860a808f5416829863f002ad38a/addons/account/models/account_move.py#L3215).

**After**:
The `_unwrap_edi_attachments()` method modifies the value of sort_weight in .pdf files if there is +1 file and if there is any pdf import template that applies to the corresponding record.

**Future**:
In v19 (master for now) the process has been improved using the `account.document.import.mixin` and https://github.com/odoo/odoo/blob/cf4e5b95c34357e5129adf9c78429f7c1a4ea33e/addons/account/models/account_document_import_mixin.py#L318 template.

@Tecnativa TT56274