### PR TITLE
[16.0][BP] sale_order_import: fix price source by pricelist

### DIFF
--- a/sale_order_import/wizard/sale_order_import.py
+++ b/sale_order_import/wizard/sale_order_import.py
@@ -502,6 +502,7 @@ class SaleOrderImport(models.TransientModel):
             # but it is not enough: we also need to play _onchange_discount()
             # to have the right discount for pricelist
             vals["order_id"] = order
+            vals = solo.play_onchanges(vals, ["product_id"])
             vals.pop("order_id")
 
         # Handle additional fields dynamically if available.

--- a/sale_order_import/wizard/sale_order_import.py
+++ b/sale_order_import/wizard/sale_order_import.py
@@ -45,7 +45,8 @@ class SaleOrderImport(models.TransientModel):
         readonly=True,
     )
     price_source = fields.Selection(
-        [("pricelist", "Pricelist"), ("order", "Customer Order")],
+        selection=[("pricelist", "Pricelist"), ("order", "Customer Order")],
+        default="pricelist",
         string="Apply Prices From",
     )
     # for state = update
@@ -486,7 +487,7 @@ class SaleOrderImport(models.TransientModel):
                 "company_id": company_id,
             }
         )
-
+        assert price_source, "price_source must be defined"
         if price_source == "order":
             if "price_unit" not in import_line:
                 raise UserError(


### PR DESCRIPTION
This line was removed in the migration to v16

in 2757735 .

I guess it was done by error and I guess there was no test...


Backport of https://github.com/OCA/edi/pull/1178