### PR TITLE
[18.0] base_business_document_import: fix supplier product match

### DIFF
--- a/base_business_document_import/models/business_document_import.py
+++ b/base_business_document_import/models/business_document_import.py
@@ -670,6 +670,7 @@ class BusinessDocumentImport(models.AbstractModel):
             )
             if sinfo and len(sinfo.product_tmpl_id.product_variant_ids) == 1:
                 return sinfo.product_tmpl_id.product_variant_id
+        # TODO: add test
         raise self.user_error_wrap(
             "_match_product",
             product_dict,
@@ -681,7 +682,7 @@ class BusinessDocumentImport(models.AbstractModel):
                 "Supplier: %(supplier)s\n",
                 barcode=product_dict.get("barcode") or "",
                 product_code=product_dict.get("code") or "",
-                supplier=seller and seller.name or "",
+                supplier=seller and seller.display_name or "",
             ),
         )
 


### PR DESCRIPTION
When wrapping the error was still using the seller.name relation which does not exists anymore.

Left over from v18 migration.