### PR TITLE
[IMP] edi_oca: Add company field

### DIFF
--- a/edi_oca/models/edi_backend.py
+++ b/edi_oca/models/edi_backend.py
@@ -56,6 +56,7 @@ class EDIBackend(models.Model):
     """
     )
     active = fields.Boolean(default=True)
+    company_id = fields.Many2one("res.company", string="Company")
 
     def _get_component(self, exchange_record, key):
         record_conf = self._get_component_conf_for_record(exchange_record, key)


### PR DESCRIPTION
The `edi.backend` model in edi_oca was missing a `company_id` Many2one field, which caused the contact form to crash in multi‑company environments.