### PR TITLE
[15.0][FIX] edi_voxel_account_invoice_oca: Product total tag wrong computation

### DIFF
--- a/edi_voxel_account_invoice_oca/reports/report_voxel_invoice.py
+++ b/edi_voxel_account_invoice_oca/reports/report_voxel_invoice.py
@@ -140,13 +140,13 @@ class ReportVoxelInvoice(models.AbstractModel):
             "Qty": str(line.quantity),
             "MU": line.product_uom_id.voxel_code,
             "UP": str(line.price_unit),
-            "Total": str(round(line.price_subtotal, 2)),
+            "Total": str(round(line.quantity * line.price_unit, 2)),
         }
 
     def _get_product_discounts_data(self, line):
         taxes = []
         if line.discount:
-            amount = round(line.price_subtotal / line.quantity - line.price_unit, 2)
+            amount = round(line.quantity * line.price_unit - line.price_subtotal, 2)
             taxes.append(
                 {
                     "Qualifier": line.discount > 0.0 and "Descuento" or "Cargo",
@@ -162,8 +162,8 @@ class ReportVoxelInvoice(models.AbstractModel):
         for tax in line.tax_ids:
             rate = tax.amount_type != "group" and str(tax.amount) or False
             totals_dic = line._get_price_total_and_subtotal(taxes=tax)
-            tax_amount = line.currency_id.round(
-                totals_dic["price_total"] - totals_dic["price_subtotal"]
+            tax_amount = round(
+                totals_dic["price_total"] - totals_dic["price_subtotal"], 2
             )
             taxes.append(
                 {

--- a/edi_voxel_account_invoice_oca/tests/test_voxel_account_invoice.py
+++ b/edi_voxel_account_invoice_oca/tests/test_voxel_account_invoice.py
@@ -249,7 +249,7 @@ class TestVoxelAccountInvoice(TransactionCase):
                     "Qty": "3.0",
                     "MU": "Unidades",
                     "UP": "147.0",
-                    "Total": "352.8",
+                    "Total": "441.0",
                 },
                 "taxes": [
                     {"Rate": "15.0", "Type": False, "Amount": "52.92"},
@@ -257,7 +257,7 @@ class TestVoxelAccountInvoice(TransactionCase):
                 ],
                 "discounts": [
                     {
-                        "Amount": "-29.4",
+                        "Amount": "88.2",
                         "Qualifier": "Descuento",
                         "Rate": "20.0",
                         "Type": "Comercial",


### PR DESCRIPTION
cc @Tecnativa TT58025

ping @carlosdauden @victoralmau 

Following the Voxel documentation, I do the nex changes:
 * **Atributte "Total" = Qty * price unit**
<img width="748" height="391" alt="image" src="https://github.com/user-attachments/assets/c597f3d9-825f-4abd-bab4-279e4adf97fc" />

 * **Discount by line: Get total discount by line instead of unit discount and positive.**

<img width="757" height="309" alt="image" src="https://github.com/user-attachments/assets/2613474d-f35c-4986-ab34-5a95f2a3ae1a" />

**Fix test**
