### PR TITLE
[18.0][IMP]account_invoice_export with report selection to export

### DIFF
--- a/account_invoice_export/models/account_move.py
+++ b/account_invoice_export/models/account_move.py
@@ -121,7 +121,11 @@ class AccountMove(models.Model):
         Use the format expected by the request library
         By default returns the PDF report.
         """
-        report = "account.report_invoice"
+        report = (
+            self.transmit_method_id.report_to_export.report_name
+            if self.transmit_method_id.report_to_export
+            else "account.report_invoice"
+        )
         pdf, _ = self.env["ir.actions.report"]._render(report, [self.id])
         filename = self._get_report_base_filename().replace("/", "_") + ".pdf"
         return {"file": (filename, pdf, "application/pdf")}

--- a/account_invoice_export/models/account_move.py
+++ b/account_invoice_export/models/account_move.py
@@ -109,8 +109,8 @@ class AccountMove(models.Model):
         res = requests.post(url, headers=headers, files=file_data, timeout=timeout)
         if res.status_code != 200:
             raise UserError(
-                self.env._("HTTP error %s sending invoice to %s")
-                % (res.status_code, self.transmit_method_id.name)
+                self.env._("HTTP error %s sending invoice to %s. %s")
+                % (res.status_code, self.transmit_method_id.name, res.text)
             )
         self.invoice_exported = self.invoice_export_confirmed = True
         return res.text

--- a/account_invoice_export/models/transmit_method.py
+++ b/account_invoice_export/models/transmit_method.py
@@ -20,6 +20,13 @@ class TransmitMethod(models.Model):
         default=10,
         help="Timeout in seconds, use 0 (zero) for no timeout.",
     )
+    report_to_export = fields.Many2one(
+        comodel_name="ir.actions.report",
+        default=lambda self: self.env.ref("account.account_invoices_without_payment"),
+        string="Report to send",
+        domain=[("report_type", "=", "qweb-pdf"), ("model", "=", "account.move")],
+        help="Report used to generate the document to send.",
+    )
 
     def get_transmission_http_header(self):
         """Generate the HTTP header needed by the transmission method.

--- a/account_invoice_export/views/transmit_method.xml
+++ b/account_invoice_export/views/transmit_method.xml
@@ -29,6 +29,7 @@
                         name="export_connection_timeout"
                         invisible="not send_through_http"
                     />
+                    <field name="report_to_export" invisible="not send_through_http" />
                 </group>
             </xpath>
         </field>


### PR DESCRIPTION
Add a configuration on the transmit method to select which report needs to be used to generate the payload.
The default stays the same.