### PR TITLE
[18.0][FIX] sale_order_import_ubl: Update super call with proper parameters

### DIFF
--- a/sale_order_import_ubl/wizard/sale_order_import.py
+++ b/sale_order_import_ubl/wizard/sale_order_import.py
@@ -36,7 +36,7 @@ class SaleOrderImport(models.TransientModel):
                 return "rfq"
             else:
                 return self.parse_ubl_sale_order(xml_root)
-        return super().parse_xml_order(xml_root)
+        return super().parse_xml_order(data, detect_doc_type=detect_doc_type)
 
     @api.model
     def parse_ubl_sale_order_line(self, line, ns):


### PR DESCRIPTION
Updated the super() parameters because the payload had already been parsed via _parse_xml() (See https://github.com/OCA/edi/blob/18.0/sale_order_import/wizard/sale_order_import.py#L150). 
Passing the parsed XML to super() caused unexpected behaviour and an error.