### PR TITLE
[15.0][FIX] base_import_pdf_by_template: Proper argument name

### DIFF
--- a/base_import_pdf_by_template/models/mail_thread.py
+++ b/base_import_pdf_by_template/models/mail_thread.py
@@ -16,15 +16,15 @@ class MailThread(models.AbstractModel):
             self = self.with_context(process_pdf_template=process_pdf_template)
         return super().message_new(msg_dict, custom_values)
 
-    def _message_post_after_hook(self, new_message, message_values):
-        res = super()._message_post_after_hook(new_message, message_values)
+    def _message_post_after_hook(self, message, msg_vals):
+        res = super()._message_post_after_hook(message, msg_vals)
         if self.env.context.get("process_pdf_template", False):
             # Process PDF attachments only if they come from an alias with
             # ‘process_pdf_template’ in default values.
             # One record is already created automatically from the mail alias, all
             # other attachments are processed without the ‘record_ref’ key so that a
             # new record is created for each attachment.
-            attachments = new_message.attachment_ids.filtered(
+            attachments = message.attachment_ids.filtered(
                 lambda x: x.mimetype == "application/pdf"
             )
             ctx = self.env.context.copy()
@@ -36,7 +36,7 @@ class MailThread(models.AbstractModel):
                     "attachment_ids": [(6, 0, attachment.ids)],
                 }
                 if index == 0:
-                    wiz_vals["record_ref"] = f"{self._name},{self.id}"
+                    wiz_vals["record_ref"] = f"{self._name},{self.id}"  # noqa
                 # pylint: disable=W8121
                 pdf_upload_wiz = (
                     self.env["wizard.base.import.pdf.upload"]


### PR DESCRIPTION
The signature of the method `_message_post_after_hook` is `self, message, msg_vals`. Using other variable names has the risk of other overrides calling `super` using keyword arguments to fail, as it happens with a combination of installed modules:

```
    self._message_post_after_hook(new_message, values)
  File "/opt/odoo/auto/addons/mail/models/mail_channel.py", line 617, in _message_post_after_hook
    return super()._message_post_after_hook(message=message, msg_vals=msg_vals)
Exception

The above exception was the direct cause of the following exception:

Traceback (most recent call last):

  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 658, in _handle_exception
    return super(JsonRequest, self)._handle_exception(exception)
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 301, in _handle_exception
    raise exception.with_traceback(None) from new_cause

TypeError: _message_post_after_hook() got an unexpected keyword argument 'message'
```

TT58526