### PR TITLE
[IMP] account_invoice_import: restore narration field removed during migration

### DIFF
--- a/account_invoice_import/wizard/account_invoice_import.py
+++ b/account_invoice_import/wizard/account_invoice_import.py
@@ -283,6 +283,7 @@ class AccountInvoiceImport(models.TransientModel):
             "company_id": company.id,
             "invoice_origin": parsed_inv.get("origin"),
             "ref": parsed_inv.get("invoice_number"),
+            "narration": parsed_inv.get("narration", ""),
             "invoice_date": parsed_inv.get("date"),
             "invoice_line_ids": [],
         }


### PR DESCRIPTION
This PR restores the `narration`  field in the account invoice import module that was removed during the 14 to 16 migration.

