### PR TITLE
[17.0][IMP] base_import_pdf_by_template: Add json_value mapped compatibility

### DIFF
--- a/base_import_pdf_by_template/models/base_import_pdf_template.py
+++ b/base_import_pdf_by_template/models/base_import_pdf_template.py
@@ -421,7 +421,8 @@ class BaseImportPdfTemplateLine(models.Model):
         # Apply mapping (if any is found, we return that)
         mapped_items = self.mapped_ids.filtered(lambda x: x.origin == value)
         if mapped_items:
-            return fields.first(mapped_items).value
+            mapped_item = fields.first(mapped_items)
+            return mapped_item.value or json.loads(mapped_item.json_value)
         # Search and return the record only if found
         if self.search_field_id:
             record = self._get_record_search_from_value(value)
@@ -452,6 +453,7 @@ class BaseImportPdfTemplateLineMapped(models.Model):
     value = fields.Reference(
         selection="_selection_reference_value",
     )
+    json_value = fields.Text()
 
     @api.model
     def _selection_reference_value(self):

--- a/base_import_pdf_by_template/views/base_import_pdf_template_line_views.xml
+++ b/base_import_pdf_by_template/views/base_import_pdf_template_line_views.xml
@@ -130,12 +130,20 @@
                         <page
                             string="Mapped"
                             name="page_mapped_ids"
-                            invisible="value_type == 'fixed' or not field_relation"
+                            invisible="value_type == 'fixed' or (not field_relation and field_ttype != 'json')"
                         >
                             <field name="mapped_ids" nolabel="1">
                                 <tree editable="bottom">
                                     <field name="origin" />
-                                    <field name="value" />
+                                    <field
+                                        name="value"
+                                        column_invisible="parent.field_ttype == 'json'"
+                                    />
+                                    <field
+                                        name="json_value"
+                                        string="Value"
+                                        column_invisible="parent.field_ttype != 'json'"
+                                    />
                                 </tree>
                             </field>
                         </page>


### PR DESCRIPTION
Add `json_value` mapped compatibility

Use case example:
- Create a template linked to `accont.move`
- Create a template line linked to the `analytic_distribution` field (json)
- Define Mapped values in which we will indicate the json we want to be set (`{"20": 100.0}` for example)
- The invoice that is created will have the appropriate analytical distribution defined

Please @pedrobaeza and @eduezerouali-tecnativa can you review it?

@Tecnativa TT59782