### PR TITLE
[18.0][FIX] account_invoice_facturx: add missing migration script

### DIFF
--- a/account_invoice_facturx/migrations/18.0.2.0.0/pre-migrate.py
+++ b/account_invoice_facturx/migrations/18.0.2.0.0/pre-migrate.py
@@ -1,0 +1,17 @@
+# Copyright 2026 Akretion
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    # this inherited view has been removed with 2.0.0
+    # without this script other unrelated modules may
+    # break when updating the settings view
+    openupgrade.delete_records_safely_by_xml_id(
+        env,
+        ["account_invoice_facturx.view_account_config_settings"],
+        delete_childs=True,
+    )


### PR DESCRIPTION
A view has been removed with #1253

Without this script other unrelated modules may break when updating the settings view

To be merged with `/ocabot merge nobump`

@alexis-via 