### PR TITLE
[16.0][FIX] base_ubl: contact - cannot be empty

### DIFF
--- a/base_ubl/models/ubl.py
+++ b/base_ubl/models/ubl.py
@@ -81,20 +81,24 @@ class BaseUbl(models.AbstractModel):
     def _ubl_add_contact(
         self, partner, parent_node, ns, node_name="Contact", version="2.1"
     ):
-        contact = etree.SubElement(parent_node, ns["cac"] + node_name)
+        contact = None  # Do not create an empty contact element
         contact_id_text = self._ubl_get_contact_id(partner)
         if contact_id_text:
+            contact = etree.SubElement(parent_node, ns["cac"] + node_name)
             contact_id = etree.SubElement(contact, ns["cbc"] + "ID")
             contact_id.text = contact_id_text
         if partner.parent_id:
+            contact = contact or etree.SubElement(parent_node, ns["cac"] + node_name)
             contact_name = etree.SubElement(contact, ns["cbc"] + "Name")
             contact_name.text = partner.name or partner.parent_id.name
         phone = partner.phone or partner.commercial_partner_id.phone
         if phone:
+            contact = contact or etree.SubElement(parent_node, ns["cac"] + node_name)
             telephone = etree.SubElement(contact, ns["cbc"] + "Telephone")
             telephone.text = phone
         email = partner.email or partner.commercial_partner_id.email
         if email:
+            contact = contact or etree.SubElement(parent_node, ns["cac"] + node_name)
             electronicmail = etree.SubElement(contact, ns["cbc"] + "ElectronicMail")
             electronicmail.text = email
 


### PR DESCRIPTION
Do not declare empty contact. Empty element is not permitted

cc @sbejaoui 