### PR TITLE
[16.0][FIX] base_ubl: taxes - declare given taxes

### DIFF
--- a/base_ubl/models/ubl.py
+++ b/base_ubl/models/ubl.py
@@ -373,7 +373,7 @@ class BaseUbl(models.AbstractModel):
         return ""
 
     @api.model
-    def _ubl_add_item(
+    def _ubl_add_item(  # noqa  C901
         self,
         name,
         product,
@@ -441,10 +441,12 @@ class BaseUbl(models.AbstractModel):
                     schemeID="0160",  # GTIN = 0160
                 )
                 std_identification_id.text = product.barcode
-            # I'm not 100% sure, but it seems that ClassifiedTaxCategory
-            # contains the taxes of the product without taking into
-            # account the fiscal position
-            if type_ == "sale":
+            if taxes is not None:
+                pass
+                # Provide the line taxes to this method otherwise it will
+                # fallback on the product taxes without taking into account the
+                # fiscal position
+            elif type_ == "sale":
                 taxes = product.taxes_id.filtered(
                     lambda t: t.unece_type_id.code == "VAT"
                 )
@@ -452,16 +454,17 @@ class BaseUbl(models.AbstractModel):
                 taxes = product.supplier_taxes_id.filtered(
                     lambda t: t.unece_type_id.code == "VAT"
                 )
-            skip_taxes = self.env.context.get("ubl_add_item__skip_taxes")
-            if taxes and not skip_taxes:
-                for tax in taxes:
-                    self._ubl_add_tax_category(
-                        tax,
-                        item,
-                        ns,
-                        node_name="ClassifiedTaxCategory",
-                        version=version,
-                    )
+        skip_taxes = self.env.context.get("ubl_add_item__skip_taxes")
+        if taxes and not skip_taxes:
+            for tax in taxes:
+                self._ubl_add_tax_category(
+                    tax,
+                    item,
+                    ns,
+                    node_name="ClassifiedTaxCategory",
+                    version=version,
+                )
+        if product:
             for attribute_value in product.attribute_line_ids.mapped("value_ids"):
                 item_property = etree.SubElement(
                     item, ns["cac"] + "AdditionalItemProperty"


### PR DESCRIPTION
Use given taxes if not None. Do not override with product taxes. For instance, in a UBL invoice, declare given invoice line tax instead of product tax.

Declare the line taxes even when no product is defined.

cc @sbejaoui 