### PR TITLE
[18.0][IMP] account_invoice_import: Very simple fix of tests to be independent of demo data

### DIFF
--- a/account_invoice_import/tests/test_invoice_import.py
+++ b/account_invoice_import/tests/test_invoice_import.py
@@ -96,11 +96,7 @@ class TestInvoiceImport(TransactionCase):
             {"company": cls.company},
         ]
 
-        # Define partners as supplier and customer
-        # Wood Corner
-        cls.env.ref("base.res_partner_1").supplier_rank = 1
-        # Deco Addict
-        cls.env.ref("base.res_partner_2").customer_rank = 1
+        # Define journals & partners
         cls.pur_journal1 = cls.env["account.journal"].create(
             {
                 "type": "purchase",


### PR DESCRIPTION
Before : tests were failing because `demo` data are not loaded in tests anymore and of the reference to `base.res_partner_1` and `base.res_partner_2`
Now : removed update of `supplier_rank` or `customer_rank`, since tests are running OK without it