### PR TITLE
[16.0][FIX] base_ubl: TaxExemptionReason - use odoo VATEX selection

### DIFF
--- a/account_invoice_ubl/models/account_move.py
+++ b/account_invoice_ubl/models/account_move.py
@@ -307,6 +307,9 @@ class AccountMove(models.Model):
             line_root,
             ns,
             type_="sale",
+            seller=None,
+            customer=self.partner_id,
+            taxes=iline.tax_ids.filtered(lambda t: t.unece_type_id.code == "VAT"),
             version=version,
         )
         price_node = etree.SubElement(line_root, ns["cac"] + "Price")
@@ -340,10 +343,19 @@ class AccountMove(models.Model):
                 tax_lines[tline.tax_line_id]["amount"] += sign * tline.balance
             elif tline.tax_ids:
                 # In case there are no declared (tag) repartition lines
+                # or the subtotal is 0
                 for tax in tline.tax_ids:
-                    if not tline.is_refund and tax.invoice_repartition_line_ids.tag_ids:
+                    if (
+                        not tline.is_refund
+                        and (tax.invoice_repartition_line_ids.tag_ids or tax.amount)
+                        and tline.price_subtotal
+                    ):
                         continue
-                    if tline.is_refund and tax.refund_repartition_line_ids.tag_ids:
+                    if (
+                        tline.is_refund
+                        and (tax.refund_repartition_line_ids.tag_ids or tax.amount)
+                        and tline.price_subtotal
+                    ):
                         continue
                     tax_lines.setdefault(
                         tax,
@@ -372,7 +384,7 @@ class AccountMove(models.Model):
                 charge_reason_node = etree.SubElement(
                     charge_node, ns["cbc"] + "AllowanceChargeReason"
                 )
-                charge_reason_node.text = "Miscellaneous"
+                charge_reason_node.text = tax.description
                 charge_amount_node = etree.SubElement(
                     charge_node, ns["cbc"] + "Amount", currencyID=cur_name
                 )
@@ -406,16 +418,6 @@ class AccountMove(models.Model):
                 ns,
                 version=version,
             )
-            if len(exempt_taxes) > 1:
-                # xpath cac:TaxCategory/cbc:Name
-                exempt_node = tax_total_node[-1]
-                exempt_node = [
-                    e for e in list(exempt_node) if e.tag == ns["cac"] + "TaxCategory"
-                ][0]
-                exempt_node = [
-                    e for e in list(exempt_node) if e.tag == ns["cbc"] + "Name"
-                ][0]
-                exempt_node.text = " + ".join([e.name for e in exempt_taxes])
 
     def generate_invoice_ubl_xml_etree(self, version="2.1"):
         self.ensure_one()
@@ -431,25 +433,54 @@ class AccountMove(models.Model):
         self._ubl_add_order_reference(xml_root, ns, version=version)
         self._ubl_add_contract_document_reference(xml_root, ns, version=version)
         self._ubl_add_attachments(xml_root, ns, version=version)
-        self._ubl_add_supplier_party(
-            False,
-            self.company_id,
-            "AccountingSupplierParty",
-            xml_root,
-            ns,
-            version=version,
+        has_vat = any(
+            tax.unece_type_id.code == "VAT" and tax.unece_categ_id.code != "O"
+            for tax in self.line_ids.tax_ids
         )
-        self._ubl_add_customer_party(
-            self.partner_id,
-            False,
-            "AccountingCustomerParty",
-            xml_root,
-            ns,
-            version=version,
-        )
-        # the field 'partner_shipping_id' is defined in the 'sale' module
-        if hasattr(self, "partner_shipping_id") and self.partner_shipping_id:
-            self._ubl_add_delivery(self.partner_shipping_id, xml_root, ns)
+        if self.move_type in ("out_invoice", "out_refund"):
+            self._ubl_add_supplier_party(
+                False,
+                self.company_id,
+                "AccountingSupplierParty",
+                xml_root,
+                ns,
+                vat=has_vat,
+                version=version,
+            )
+            self._ubl_add_customer_party(
+                self.partner_id,
+                False,
+                "AccountingCustomerParty",
+                xml_root,
+                ns,
+                vat=has_vat,
+                version=version,
+            )
+        else:
+            self._ubl_add_supplier_party(
+                self.partner_id,
+                False,
+                "AccountingSupplierParty",
+                xml_root,
+                ns,
+                vat=has_vat,
+                version=version,
+            )
+            self._ubl_add_customer_party(
+                False,
+                self.company_id,
+                "AccountingCustomerParty",
+                xml_root,
+                ns,
+                vat=has_vat,
+                version=version,
+            )
+
+        if self.move_type in ("out_invoice", "out_refund"):
+            # the field 'partner_shipping_id' is defined in the 'sale' module
+            if hasattr(self, "partner_shipping_id") and self.partner_shipping_id:
+                self._ubl_add_delivery(self.partner_shipping_id, xml_root, ns)
+
         if self.move_type == "out_invoice":
             # Put paymentmeans block even when invoice is paid ?
             payment_identifier = self.get_payment_identifier()

--- a/base_ubl/models/ubl.py
+++ b/base_ubl/models/ubl.py
@@ -178,6 +178,9 @@ class BaseUbl(models.AbstractModel):
             party_legal_entity, ns["cbc"] + "RegistrationName"
         )
         registration_name.text = commercial_partner.name
+        if commercial_partner.company_registry:
+            company_id = etree.SubElement(party_legal_entity, ns["cbc"] + "CompanyID")
+            company_id.text = commercial_partner.company_registry
         self._ubl_add_address(
             commercial_partner,
             "RegistrationAddress",
@@ -188,7 +191,7 @@ class BaseUbl(models.AbstractModel):
 
     @api.model
     def _ubl_add_party(
-        self, partner, company, node_name, parent_node, ns, version="2.1"
+        self, partner, company, node_name, parent_node, ns, vat=True, version="2.1"
     ):
         commercial_partner = partner.commercial_partner_id
         party = etree.SubElement(parent_node, ns["cac"] + node_name)
@@ -204,7 +207,11 @@ class BaseUbl(models.AbstractModel):
         if partner.lang:
             self._ubl_add_language(partner.lang, party, ns, version=version)
         self._ubl_add_address(partner, "PostalAddress", party, ns, version=version)
-        self._ubl_add_party_tax_scheme(commercial_partner, party, ns, version=version)
+        if vat:
+            # Do not declare VAT tax scheme if the document has no VAT
+            self._ubl_add_party_tax_scheme(
+                commercial_partner, party, ns, version=version
+            )
         if commercial_partner.is_company or company:
             self._ubl_add_party_legal_entity(
                 commercial_partner, party, ns, version="2.1"
@@ -216,7 +223,7 @@ class BaseUbl(models.AbstractModel):
 
     @api.model
     def _ubl_add_customer_party(
-        self, partner, company, node_name, parent_node, ns, version="2.1"
+        self, partner, company, node_name, parent_node, ns, vat=True, version="2.1"
     ):
         """Please read the docstring of the method _ubl_add_supplier_party"""
         if company:
@@ -234,7 +241,7 @@ class BaseUbl(models.AbstractModel):
             )
             customer_ref.text = partner_ref
         self._ubl_add_party(
-            partner, company, "Party", customer_party_root, ns, version=version
+            partner, company, "Party", customer_party_root, ns, vat=vat, version=version
         )
         # TODO: rewrite support for AccountingContact + add DeliveryContact
         # Additional optional args
@@ -250,7 +257,7 @@ class BaseUbl(models.AbstractModel):
 
     @api.model
     def _ubl_add_supplier_party(
-        self, partner, company, node_name, parent_node, ns, version="2.1"
+        self, partner, company, node_name, parent_node, ns, vat=True, version="2.1"
     ):
         """The company argument has been added to properly handle the
         'ref' field.
@@ -282,19 +289,27 @@ class BaseUbl(models.AbstractModel):
             )
             supplier_ref.text = partner_ref
         self._ubl_add_party(
-            partner, company, "Party", supplier_party_root, ns, version=version
+            partner, company, "Party", supplier_party_root, ns, vat=vat, version=version
         )
         return supplier_party_root
 
     @api.model
-    def _ubl_add_delivery(self, delivery_partner, parent_node, ns, version="2.1"):
+    def _ubl_add_delivery(
+        self, delivery_partner, parent_node, ns, vat=True, version="2.1"
+    ):
         delivery = etree.SubElement(parent_node, ns["cac"] + "Delivery")
         delivery_location = etree.SubElement(delivery, ns["cac"] + "DeliveryLocation")
         self._ubl_add_address(
             delivery_partner, "Address", delivery_location, ns, version=version
         )
         self._ubl_add_party(
-            delivery_partner, False, "DeliveryParty", delivery, ns, version=version
+            delivery_partner,
+            False,
+            "DeliveryParty",
+            delivery,
+            ns,
+            vat=vat,
+            version=version,
         )
 
     @api.model
@@ -496,11 +511,10 @@ class BaseUbl(models.AbstractModel):
     ):
         prec = self.env["decimal.precision"].precision_get("Account")
         tax_subtotal = etree.SubElement(parent_node, ns["cac"] + "TaxSubtotal")
-        if not float_is_zero(taxable_amount, precision_digits=prec):
-            taxable_amount_node = etree.SubElement(
-                tax_subtotal, ns["cbc"] + "TaxableAmount", currencyID=currency_code
-            )
-            taxable_amount_node.text = "%0.*f" % (prec, taxable_amount)
+        taxable_amount_node = etree.SubElement(
+            tax_subtotal, ns["cbc"] + "TaxableAmount", currencyID=currency_code
+        )
+        taxable_amount_node.text = "%0.*f" % (prec, taxable_amount)
         tax_amount_node = etree.SubElement(
             tax_subtotal, ns["cbc"] + "TaxAmount", currencyID=currency_code
         )
@@ -528,18 +542,47 @@ class BaseUbl(models.AbstractModel):
             tax_category, ns["cbc"] + "ID", schemeID="UN/ECE 5305", schemeAgencyID="6"
         )
         tax_category_id.text = tax.unece_categ_code
-        tax_name = etree.SubElement(tax_category, ns["cbc"] + "Name")
-        tax_name.text = tax.name
-        tax_percent = etree.SubElement(tax_category, ns["cbc"] + "Percent")
-        if tax.amount_type == "percent":
-            tax_percent.text = str(tax.amount)
-        else:
-            tax_percent.text = "0"
-        if tax.unece_categ_code == "E":
-            tax_exmption_reason = etree.SubElement(
+        if tax.unece_categ_code != "O":
+            tax_percent = etree.SubElement(tax_category, ns["cbc"] + "Percent")
+            if tax.amount_type == "percent":
+                tax_percent.text = str(tax.amount)
+            else:
+                tax_percent.text = "0"
+        if (
+            hasattr(tax, "ubl_cii_tax_exemption_reason_code")
+            and tax.ubl_cii_tax_exemption_reason_code
+        ):
+            tax_exemption_reason = etree.SubElement(
+                tax_category, ns["cbc"] + "TaxExemptionReasonCode"
+            )
+            tax_exemption_reason.text = tax.ubl_cii_tax_exemption_reason_code.replace(
+                "_", "-"
+            )
+        elif tax.unece_categ_code == "AE":
+            tax_exemption_reason = etree.SubElement(
                 tax_category, ns["cbc"] + "TaxExemptionReason"
             )
-            tax_exmption_reason.text = "Exempt"
+            tax_exemption_reason.text = "Reverse Charge"
+        elif tax.unece_categ_code == "E":
+            tax_exemption_reason = etree.SubElement(
+                tax_category, ns["cbc"] + "TaxExemptionReason"
+            )
+            tax_exemption_reason.text = "Exempt"
+        elif tax.unece_categ_code == "G":
+            tax_exemption_reason = etree.SubElement(
+                tax_category, ns["cbc"] + "TaxExemptionReason"
+            )
+            tax_exemption_reason.text = "Export"
+        elif tax.unece_categ_code == "K":
+            tax_exemption_reason = etree.SubElement(
+                tax_category, ns["cbc"] + "TaxExemptionReason"
+            )
+            tax_exemption_reason.text = "Intracommunity"
+        elif tax.unece_categ_code == "O":
+            tax_exemption_reason = etree.SubElement(
+                tax_category, ns["cbc"] + "TaxExemptionReason"
+            )
+            tax_exemption_reason.text = "Transaction outside the scope of VAT"
         tax_scheme_dict = self._ubl_get_tax_scheme_dict_from_tax(tax)
         self._ubl_add_tax_scheme(tax_scheme_dict, tax_category, ns, version=version)
 


### PR DESCRIPTION
Allow to use odoo standard VATEX exemption reason that should be part of any declared exempt tax, otherwise provide the corresponding exemption reason

Do not provide VAT Party identifiers when the invoice is outside scope of VAT. Add the company registry.

Remove VAT name, it's not part of peppol

In case of non-VAT tax converted to AllowanceCharge, provide the tax description instead of "Miscellaneous"

cc @nicolas-delbovier-acsone @sbejaoui @phschmidt 