### PR TITLE
[17.0][IMP] base_import_pdf_by_template: Use finditer() + groups() to define the value from text

### DIFF
--- a/base_import_pdf_by_template/models/base_import_pdf_template.py
+++ b/base_import_pdf_by_template/models/base_import_pdf_template.py
@@ -435,9 +435,20 @@ class BaseImportPdfTemplateLine(models.Model):
     def _get_field_value(self, text):
         field_value = False
         if self.pattern:
-            res = re.findall(self.pattern, text)
-            if res:
-                field_value = self._process_value(res[0])
+            matches = re.compile(self.pattern).finditer(text)
+            if matches:
+                text_res = ""
+                # This option allows us to concatenate all the values found if we do a
+                # pattern like this one: ([A-Z]{7})|([0-9]{5})
+                # ABCDEFG 01234
+                for match in matches:
+                    if match.groups():
+                        for m_group in match.groups():
+                            if m_group:
+                                text_res += m_group
+                    else:
+                        text_res = text[match.start() : match.end()]
+                field_value = self._process_value(text_res)
         return field_value
 
 

--- a/base_import_pdf_by_template_account/demo/base_import_pdf_template.xml
+++ b/base_import_pdf_by_template_account/demo/base_import_pdf_template.xml
@@ -100,7 +100,7 @@
             name="child_field_id"
             ref="account.field_account_move__invoice_line_ids"
         />
-        <field name="auto_detect_pattern">(B 8 7 5 3 0 4 3 2)</field>
+        <field name="auto_detect_pattern">(B87530432)</field>
         <field name="header_items">Producto,Cantidad,Precio,AnalyticDistribution</field>
     </record>
     <record
@@ -145,7 +145,9 @@
         <field name="related_model">lines</field>
         <field name="field_id" ref="account.field_account_move_line__quantity" />
         <field name="column">1</field>
-        <field name="pattern">\[[A-Z\d]+[_|-][A-Z\d]+\] [a-zA-Záí]* ([0-9]{1,3})</field>
+        <field
+            name="pattern"
+        >\[[A-Z\d]+[_|-][A-Z\d]+\] [a-zA-Záí ]* ([0-9]{1,3})</field>
         <field name="value_type">variable</field>
     </record>
     <record id="invoice_tecnativa_price_unit" model="base.import.pdf.template.line">

--- a/base_import_pdf_by_template_account/tests/test_base_import_pdf_by_template_account.py
+++ b/base_import_pdf_by_template_account/tests/test_base_import_pdf_by_template_account.py
@@ -82,7 +82,7 @@ class TestBaseImportPdfByTemplateAccount(BaseCommon):
                 "child_field_id": cls.env.ref(
                     "account.field_account_move__invoice_line_ids"
                 ).id,
-                "auto_detect_pattern": "(B 8 7 5 3 0 4 3 2)",
+                "auto_detect_pattern": "(B87530432)",
                 "header_items": "Producto,Cantidad,Precio,AnalyticDistribution",
                 "line_ids": [
                     (
@@ -140,7 +140,7 @@ class TestBaseImportPdfByTemplateAccount(BaseCommon):
                                 "account.field_account_move_line__quantity"
                             ).id,
                             "column": 1,
-                            "pattern": "\[[A-Z\d]+[_|-][A-Z\d]+\] [a-zA-Záí]* ([0-9]{1,3})",  # noqa: E501
+                            "pattern": "\[[A-Z\d]+[_|-][A-Z\d]+\] [a-zA-Záí ]* ([0-9]{1,3})",  # noqa: E501
                             "value_type": "variable",
                         },
                     ),


### PR DESCRIPTION
FWP from 15.0: https://github.com/OCA/edi/pull/1183

Use finditer() + groups() to define the value from text

Please @pedrobaeza and @sergio-teruel can you review it?

@Tecnativa TT56971