### PR TITLE
[17.0][FIX] base_import_pdf_by_template: Avoid the error caused by the wizard's default_model value

### DIFF
--- a/base_import_pdf_by_template/wizards/wizard_base_import_pdf_upload.py
+++ b/base_import_pdf_by_template/wizards/wizard_base_import_pdf_upload.py
@@ -215,7 +215,10 @@ class WizardBaseImportPdfUploadLine(models.TransientModel):
             if key.startswith("default_") and key != "default_fetchmail_server_id":
                 field_name = key.replace("default_", "")
                 field_value = ctx[key]
-                if model._fields[field_name].type == "many2one":
+                if (
+                    field_name in model._fields
+                    and model._fields[field_name].type == "many2one"
+                ):
                     field_value = model[field_name].browse(field_value)
                 try:
                     setattr(model_form, field_name, field_value)


### PR DESCRIPTION
Avoid the error caused by the wizard's default_model value

Example use case:
- Go to Sales > Import records (with template)
- Select a .pdf in the wizard
- Click the Import button

```
if model._fields[field_name].type == "many2one":
    KeyError: 'model'
```

It's already done in v18: https://github.com/OCA/edi/commit/613734ead5405dfb3535c96987217a74478b9532#diff-8bc11e59f7d505f9e63bcb8f45dcbda86d4cf06ff596456bd174697ee8934298R197-R226

Please @pedrobaeza and @cristina-hidalgo-tecnativa can you review it?

@Tecnativa TT61034