### PR TITLE
[18.0][FIX] base_import_pdf_by_template_account: Do not change move_type when uploading a PDF

### DIFF
--- a/base_import_pdf_by_template_account/models/account_move.py
+++ b/base_import_pdf_by_template_account/models/account_move.py
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 Tecnativa - Víctor Martínez
+# Copyright 2024-2026 Tecnativa - Víctor Martínez
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 from odoo import models
 
@@ -15,9 +15,6 @@ class AccountMove(models.Model):
         total_templates = template_model.search_count([("model", "=", invoice._name)])
         if total_templates == 0:
             return False
-        invoice.move_type = (
-            "in_invoice" if invoice.journal_id.type == "purchase" else "out_invoice"
-        )
         wizard = self.env["wizard.base.import.pdf.upload"].create(
             {
                 "model": invoice._name,

--- a/base_import_pdf_by_template_account/tests/test_base_import_pdf_by_template_account.py
+++ b/base_import_pdf_by_template_account/tests/test_base_import_pdf_by_template_account.py
@@ -240,7 +240,8 @@ class TestBaseImportPdfByTemplateAccount(BaseCommon):
     def test_account_move_edi_decoder(self):
         attachment = self._create_ir_attachment("account_invoice_tecnativa.pdf")
         invoice = self.journal.with_context(
-            default_journal_id=self.journal.id
+            default_journal_id=self.journal.id,
+            default_move_type="in_invoice",
         )._create_document_from_attachment(attachment.id)
         self.assertEqual(len(invoice.attachment_ids), 1)
         self.assertEqual(attachment, invoice.attachment_ids)


### PR DESCRIPTION
FWP from 17.0: https://github.com/OCA/edi/pull/1297

Do not change move_type when uploading a PDF

Please @pedrobaeza and  @carlos-lopez-tecnativa can you review it?

@Tecnativa TT60782