### PR TITLE
[16.0][FIX] account_invoice_import: do not use `taxes` and `account` of `import_config` over ones in `lines`

### DIFF
--- a/account_invoice_import/wizard/account_invoice_import.py
+++ b/account_invoice_import/wizard/account_invoice_import.py
@@ -442,6 +442,7 @@ class AccountInvoiceImport(models.TransientModel):
                 )
             if not product and import_config.get("product"):
                 product = import_config["product"]
+            account, taxes = None, None
             if product:
                 product = product.with_company(import_config["company"].id)
                 if parsed_inv["type"] in ("out_invoice", "out_refund"):
@@ -453,9 +454,6 @@ class AccountInvoiceImport(models.TransientModel):
                 taxes = product_taxes.filtered(
                     lambda tax: tax.company_id == import_config["company"]
                 )
-            else:
-                account = import_config["account"]
-                taxes = import_config["taxes"]
             if not taxes:
                 if parsed_inv["type"] in ("out_invoice", "out_refund"):
                     type_tax_use = "sale"
@@ -468,6 +466,11 @@ class AccountInvoiceImport(models.TransientModel):
                     type_tax_use=type_tax_use,
                     raise_exception=False,
                 )
+            # default to `import_config`
+            if not account and "account" in import_config:
+                account = import_config["account"]
+            if not taxes and "taxes" in import_config:
+                taxes = import_config["taxes"]
 
             fp = partner and partner.property_account_position_id or False
             if fp:


### PR DESCRIPTION
**Issue description**
When passing the `parsed_inv` of an invoice with `taxes` in defined `lines`, the value of line's `taxes` are replaced by the ones of `import_config`.
This may even happens if `import_config` is empty but the partner already has an invoice in Odoo: `import_config` is generated from the previous invoice of the partner.

**Suggested fix**
We want the real-data of `taxes` and `account` passed in `lines` to take the precedence on any passed `import_config` or guessed from partner's previous invoice.

This commit defaults to `import_config` taxes and account as *last* possible values.

Forward-port in v18.0 : https://github.com/OCA/edi/pull/1288