### PR TITLE
[IMP] account_invoice_ubl_peppol: filter out section and note lines f…

### DIFF
--- a/account_invoice_ubl/models/account_move.py
+++ b/account_invoice_ubl/models/account_move.py
@@ -311,12 +311,18 @@ class AccountMove(models.Model):
         self._ubl_add_legal_monetary_total(xml_root, ns, version=version)
 
         line_number = 0
-        for iline in self.invoice_line_ids:
+        for iline in self._ubl_get_invoice_lines():
             line_number += 1
             self._ubl_add_invoice_line(
                 xml_root, iline, line_number, ns, version=version
             )
         return xml_root
+
+    def _ubl_get_invoice_lines(self):
+        """Return invoice lines to include in UBL XML.
+        This method can be overridden to filter lines.
+        """
+        return self.invoice_line_ids
 
     def generate_ubl_xml_string(self, version="2.1"):
         self.ensure_one()

--- a/account_invoice_ubl_peppol/models/account_move.py
+++ b/account_invoice_ubl_peppol/models/account_move.py
@@ -297,6 +297,12 @@ class AccountMove(models.Model):
                     invoiced_quantity.attrib["unitCode"] = uom_unece_code
         return res
 
+    def _ubl_get_invoice_lines(self):
+        """Filter out section and note lines for PEPPOL."""
+        return self.invoice_line_ids.filtered(
+            lambda l: l.display_type not in ("line_section", "line_note")
+        )
+
     @api.model
     def _ubl_add_tax_subtotal(
         self,


### PR DESCRIPTION
…rom UBL

- Add _ubl_get_invoice_lines() method in account_invoice_ubl to allow child modules to filter which invoice lines should be included in UBL XML
- Override this method in account_invoice_ubl_peppol to exclude section lines (display_type='line_section') and note lines (display_type='line_note')