### PR TITLE
18.0 fix account_invoice_import_simple_pdf: optional invoice date

### DIFF
--- a/account_invoice_import_simple_pdf/models/res_partner.py
+++ b/account_invoice_import_simple_pdf/models/res_partner.py
@@ -433,14 +433,6 @@ class ResPartner(models.Model):
         amount_untaxed_count = field_list.count("amount_untaxed")
         amount_tax = field_list.count("amount_tax")
         amount_fields_count = amount_total_count + amount_untaxed_count + amount_tax
-        if "date" not in field_list:
-            raise UserError(
-                _(
-                    "You must configure a field extraction rule for "
-                    "field 'Date' for partner '%s'."
-                )
-                % self.display_name
-            )
         if amount_fields_count == 0:
             raise UserError(
                 _("There is no amount field configured for partner '%s'.")

--- a/account_invoice_import_simple_pdf/tests/test_invoice_import.py
+++ b/account_invoice_import_simple_pdf/tests/test_invoice_import.py
@@ -559,6 +559,34 @@ class TestInvoiceImportSimplePdf(TransactionCase):
         self.assertEqual(float_compare(iline.price_unit, 1509, precision_digits=2), 0)
         inv.unlink()
 
+    def test_complete_import_without_date(self):
+        """Invoice import must succeed and leave invoice_date unset
+        when no date field is configured for the partner."""
+        self.partner_ak.simple_pdf_field_ids.filtered(
+            lambda f: f.name == "date"
+        ).unlink()
+        wiz = self.env["account.invoice.import"].create(
+            {
+                "invoice_attachment_ids": [
+                    Command.create(
+                        {"datas": self.ak_pdf_file_b64, "name": self.ak_filename}
+                    )
+                ],
+                "company_id": self.company.id,
+            }
+        )
+        wiz.import_invoices()
+        invoices = self.env["account.move"].search(
+            [
+                ("partner_id", "=", self.partner_ak.id),
+                ("state", "=", "draft"),
+                ("move_type", "=", "in_invoice"),
+                ("company_id", "=", self.company.id),
+            ]
+        )
+        self.assertTrue(invoices)
+        self.assertFalse(invoices[0].invoice_date)
+
     def _complete_import_specific_method(self, method):
         icpo = self.env["ir.config_parameter"]
         key = "invoice_import_simple_pdf.pdf2txt"

--- a/account_invoice_import_simple_pdf/wizard/account_invoice_import.py
+++ b/account_invoice_import_simple_pdf/wizard/account_invoice_import.py
@@ -44,6 +44,13 @@ class AccountInvoiceImport(models.TransientModel):
         return res
 
     @api.model
+    def _prepare_create_invoice_vals(self, parsed_inv, import_config):
+        vals = super()._prepare_create_invoice_vals(parsed_inv, import_config)
+        if "invoice_date" in vals and not vals["invoice_date"]:
+            del vals["invoice_date"]
+        return vals
+
+    @api.model
     def _simple_pdf_text_extraction_pymupdf(self, fileobj, test_info):
         res = False
         version = None


### PR DESCRIPTION
In 15.0 this module didn't require an invoice date to be set and to be extracted. This fix makes the invoice date optional on 18.0. This is useful for invoices from which their date can't be extracted (e.g. because their date format doesn't match any of the supported patterns).

@hbrunn 