### PR TITLE
[18.0][FIX] base_import_pdf_by_template_account: ref not in client side

### DIFF
--- a/base_import_pdf_by_template_account/views/base_import_pdf_template_views.xml
+++ b/base_import_pdf_by_template_account/views/base_import_pdf_template_views.xml
@@ -31,8 +31,10 @@
             ]"
         />
         <field name="domain">[('model', '=', 'account.move')]</field>
-        <field name="context">{'default_model_id': ref('account.model_account_move')}
-        </field>
+        <field
+            name="context"
+            eval="{'default_model_id': ref('account.model_account_move')}"
+        />
     </record>
     <menuitem
         id="menu_base_import_pdf_template_account_move"


### PR DESCRIPTION
Odoo Client Error

UncaughtPromiseError > EvalError
Uncaught Promise > Can not evaluate python expression: ({'default_model_id': ref('account.model_account_move')} ) Error: Name 'ref' is not defined

Occured on oca-edi-18-0-a6d3ef298ada.runboat.odoo-community.org on 2026-06-27 05:42:20 GMT

EvalError: Can not evaluate python expression: ({'default_model_id': ref('account.model_account_move')}
            )
    Error: Name 'ref' is not defined
    EvalError: Can not evaluate python expression: ({'default_model_id': ref('account.model_account_move')}
            )
    Error: Name 'ref' is not defined
        at evaluateExpr (http://oca-edi-18-0-a6d3ef298ada.runboat.odoo-community.org/web/assets/918a2cc/web.assets_web.min.js:3365:54)
        at makeContext (http://oca-edi-18-0-a6d3ef298ada.runboat.odoo-community.org/web/assets/918a2cc/web.assets_web.min.js:2092:576)
        at _preprocessAction (http://oca-edi-18-0-a6d3ef298ada.runboat.odoo-community.org/web/assets/918a2cc/web.assets_web.min.js:10040:16)
        at Object.doAction (http://oca-edi-18-0-a6d3ef298ada.runboat.odoo-community.org/web/assets/918a2cc/web.assets_web.min.js:10135:170)
        at async Object.selectMenu (http://oca-edi-18-0-a6d3ef298ada.runboat.odoo-community.org/web/assets/918a2cc/web.assets_web.min.js:10335:1)