### PR TITLE
[14.0][ADD] account_invoice_import_invoice2data_db_templates

### DIFF
--- a/account_invoice_import_invoice2data_db_templates/__init__.py
+++ b/account_invoice_import_invoice2data_db_templates/__init__.py
@@ -1,0 +1,1 @@
+from . import models, wizard

--- a/account_invoice_import_invoice2data_db_templates/__manifest__.py
+++ b/account_invoice_import_invoice2data_db_templates/__manifest__.py
@@ -1,0 +1,28 @@
+# Copyright 2017-2023 Therp BV
+# Copyright 2025-2026 bosd
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+{
+    "name": "Account Invoice Import Invoice2data DB Templates",
+    "version": "14.0.1.0.0",
+    "category": "Accounting/Accounting",
+    "license": "AGPL-3",
+    "summary": (
+        "Store invoice2data templates in the database; use them alongside the "
+        "disk-based ones during invoice import."
+    ),
+    "author": "Therp BV,bosd,Odoo Community Association (OCA)",
+    "maintainers": ["bosd"],
+    "website": "https://github.com/OCA/edi",
+    "depends": ["account_invoice_import_invoice2data"],
+    "external_dependencies": {
+        "python": [
+            "invoice2data",
+        ],
+    },
+    "data": [
+        "security/invoice2data_template_groups.xml",
+        "security/ir.model.access.csv",
+        "views/invoice2data_template.xml",
+    ],
+    "installable": True,
+}

--- a/account_invoice_import_invoice2data_db_templates/models/__init__.py
+++ b/account_invoice_import_invoice2data_db_templates/models/__init__.py
@@ -1,0 +1,1 @@
+from . import invoice2data_template, invoice2data_template_field

--- a/account_invoice_import_invoice2data_db_templates/models/invoice2data_template.py
+++ b/account_invoice_import_invoice2data_db_templates/models/invoice2data_template.py
@@ -1,0 +1,271 @@
+# Copyright 2017 Therp BV (foundational DB-storage design)
+# Copyright 2025-2026 bosd
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+"""Store invoice2data templates in the database.
+
+The model produces a ``list[InvoiceTemplate]`` that is appended to the
+disk-loaded templates by the ``account.invoice.import.invoice2data_parse_invoice``
+hook; the lib itself never sees the difference between a disk template and
+a DB one.
+"""
+
+import base64
+import json
+import logging
+import tempfile
+
+from odoo import _, api, fields, models
+from odoo.exceptions import UserError
+
+logger = logging.getLogger(__name__)
+
+try:
+    from invoice2data.extract.invoice_template import InvoiceTemplate
+    from invoice2data.extract.loader import ordered_load
+    from invoice2data.input.pdftotext import to_text
+except ImportError:  # pragma: no cover
+    ordered_load = None
+    InvoiceTemplate = None
+    to_text = None
+    logger.debug("invoice2data not importable; install invoice2data >= 1.0")
+
+
+class Invoice2dataTemplate(models.Model):
+    """A DB-stored invoice2data template.
+
+    Two authoring modes live side by side:
+
+    * **Power user**: paste / type the full JSON template into ``template``
+      and ignore the field editor.
+    * **Guided**: name + keywords + per-field rules via the ``field_ids``
+      one2many; the JSON is composed from those on read.
+
+    ``get_templates(template_type)`` is the only entry point the import
+    wizard needs.
+    """
+
+    _name = "invoice2data.template"
+    _description = "Template for invoice2data"
+    _inherit = ["mail.thread", "mail.activity.mixin"]
+    _order = "priority desc, name"
+
+    name = fields.Char(
+        required=True,
+        copy=False,
+        help="Used as the template_name passed to invoice2data.",
+    )
+    active = fields.Boolean(default=True)
+    template_type = fields.Selection(
+        selection=[("purchase_invoice", "Purchase Invoice")],
+        default="purchase_invoice",
+        required=True,
+        help=(
+            "Filters which DB templates are merged into the invoice2data "
+            "run for a given import wizard."
+        ),
+    )
+    priority = fields.Integer(
+        default=5,
+        help=(
+            "Higher-priority templates are tried first, matching the lib's "
+            "`priority:` semantics."
+        ),
+    )
+    keywords = fields.Text(
+        required=True,
+        help="One keyword per line; passed as the template's `keywords:` list.",
+    )
+    exclude_keywords = fields.Text(help="Optional; one keyword per line.")
+    template = fields.Text(
+        help=(
+            "Authoritative JSON for the template (full invoice2data schema). "
+            "When empty the JSON is auto-composed from name/keywords/fields."
+        ),
+    )
+    field_ids = fields.One2many(
+        comodel_name="invoice2data.template.field",
+        inverse_name="template_id",
+        copy=True,
+    )
+    last_test_result = fields.Text(readonly=True)
+    last_test_warnings = fields.Text(readonly=True)
+    preview_text = fields.Text(readonly=True)
+
+    _sql_constraints = [
+        (
+            "name_uniq",
+            "unique(name)",
+            "An invoice2data template with this name already exists.",
+        ),
+    ]
+
+    # === Public API consumed by the import wizard ===
+
+    @api.model
+    def get_templates(self, template_type):
+        """Return a list of ``InvoiceTemplate`` objects for the given type."""
+        if InvoiceTemplate is None:
+            logger.warning("invoice2data not importable; skipping DB templates")
+            return []
+        records = self.search(
+            [("template_type", "=", template_type), ("active", "=", True)]
+        )
+        return records._to_invoice_templates()
+
+    # === Authoring helpers ===
+
+    def _compose_template_dict(self):
+        """Build the invoice2data template dict from the structured fields."""
+        self.ensure_one()
+        data = {
+            "issuer": self.name,
+            "keywords": [
+                k.strip() for k in (self.keywords or "").splitlines() if k.strip()
+            ],
+            "exclude_keywords": [
+                k.strip()
+                for k in (self.exclude_keywords or "").splitlines()
+                if k.strip()
+            ],
+            "priority": self.priority,
+            "fields": {},
+        }
+        for line in self.field_ids:
+            data["fields"][line.name] = line._to_field_dict()
+        return data
+
+    def _to_invoice_templates(self):
+        """Materialise each DB row as an ``InvoiceTemplate`` instance."""
+        templates = []
+        for record in self:
+            try:
+                if record.template:
+                    candidates = ordered_load(record.template) or []
+                else:
+                    composed = json.dumps([record._compose_template_dict()])
+                    candidates = ordered_load(composed) or []
+            except Exception as exc:  # noqa: BLE001 -- never raise during import
+                logger.warning(
+                    "Failed to load DB invoice2data template %r: %s",
+                    record.name,
+                    exc,
+                )
+                continue
+            for tpl in candidates:
+                tpl["template_name"] = record.name
+                templates.append(tpl)
+        return templates
+
+    # === Form-view buttons ===
+
+    def action_preview(self):
+        """Run the lib's ``to_text`` on the latest chatter attachment."""
+        self.ensure_one()
+        if to_text is None:
+            raise UserError(_("invoice2data is not installed on the server."))
+        attachment = self._latest_attachment()
+        if not attachment:
+            raise UserError(
+                _("Attach a sample PDF to the chatter before running Preview.")
+            )
+        self.preview_text = self._extract_text(attachment)
+
+    def action_test(self):
+        """Run a full extract_data() against the latest chatter attachment."""
+        self.ensure_one()
+        try:
+            from invoice2data import extract_data
+            from invoice2data.extract.loader import read_templates
+        except ImportError as exc:
+            raise UserError(
+                _("invoice2data is not installed on the server: %s") % exc
+            ) from exc
+        attachment = self._latest_attachment()
+        if not attachment:
+            raise UserError(
+                _("Attach a sample PDF to the chatter before running Test.")
+            )
+        warnings = []
+        try:
+            templates = read_templates() + self._to_invoice_templates()
+            path = self._attachment_to_tempfile(attachment)
+            result = extract_data(path, templates=templates)
+        except Exception as exc:  # noqa: BLE001 -- surface via the form
+            self.last_test_warnings = str(exc)
+            self.last_test_result = ""
+            return
+        if not result:
+            warnings.append(_("invoice2data did not match this PDF."))
+        else:
+            for field in ("amount", "date", "invoice_number", "issuer"):
+                if not result.get(field):
+                    warnings.append(_("Required field missing: %s") % field)
+        self.last_test_result = json.dumps(result, indent=2, default=str)
+        self.last_test_warnings = "\n".join(warnings) if warnings else ""
+
+    def action_suggest_fields(self):
+        """Pre-fill ``field_ids`` from the lib's authoring helpers."""
+        self.ensure_one()
+        try:
+            from invoice2data.extract.template_builder import suggested_template
+        except ImportError as exc:
+            raise UserError(
+                _("invoice2data >= 1.0 is required for Suggest Fields: %s") % exc
+            ) from exc
+        attachment = self._latest_attachment()
+        if not attachment:
+            raise UserError(
+                _("Attach a sample PDF to the chatter before suggesting fields.")
+            )
+        text = self._extract_text(attachment)
+        draft = suggested_template(text, name=self.name or "draft")
+        existing = {row.name for row in self.field_ids}
+        rows = []
+        for fname, spec in (draft.get("fields") or {}).items():
+            if fname in existing:
+                continue
+            row_vals = {"name": fname}
+            if isinstance(spec, str):
+                row_vals.update({"parser": "regex", "regex": spec})
+            elif isinstance(spec, dict):
+                row_vals.update(
+                    {
+                        "parser": spec.get("parser", "regex"),
+                        "regex": spec.get("regex", ""),
+                    }
+                )
+                if (
+                    isinstance(spec.get("replace"), (list, tuple))
+                    and len(spec["replace"]) >= 2
+                ):
+                    row_vals["replace_pattern"] = spec["replace"][0]
+                    row_vals["replace_repl"] = spec["replace"][1]
+            rows.append((0, 0, row_vals))
+        if rows:
+            self.write({"field_ids": rows})
+
+    # === Helpers ===
+
+    def _latest_attachment(self):
+        return self.env["ir.attachment"].search(
+            [
+                ("res_model", "=", self._name),
+                ("res_id", "=", self.id),
+                ("mimetype", "=", "application/pdf"),
+            ],
+            order="create_date desc",
+            limit=1,
+        )
+
+    @staticmethod
+    def _attachment_to_tempfile(attachment):
+        """Spill an ir.attachment's bytes to a tempfile and return the path."""
+        with tempfile.NamedTemporaryFile(
+            "wb", prefix="i2d-db-", suffix=".pdf", delete=False
+        ) as handle:
+            handle.write(base64.b64decode(attachment.datas))
+            return handle.name
+
+    @classmethod
+    def _extract_text(cls, attachment):
+        return to_text(cls._attachment_to_tempfile(attachment))

--- a/account_invoice_import_invoice2data_db_templates/models/invoice2data_template_field.py
+++ b/account_invoice_import_invoice2data_db_templates/models/invoice2data_template_field.py
@@ -96,10 +96,7 @@ class Invoice2dataTemplateField(models.Model):
                 )
             if line.parser == "static" and not line.static_value:
                 raise ValidationError(
-                    _(
-                        "Field '%(field)s' uses parser 'static' but has no "
-                        "value set."
-                    )
+                    _("Field '%(field)s' uses parser 'static' but has no " "value set.")
                     % {"field": line.name}
                 )
 

--- a/account_invoice_import_invoice2data_db_templates/models/invoice2data_template_field.py
+++ b/account_invoice_import_invoice2data_db_templates/models/invoice2data_template_field.py
@@ -1,0 +1,118 @@
+# Copyright 2025-2026 bosd
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+"""Per-field extraction rule for a DB-stored invoice2data template.
+
+Selection lists are driven from the lib's canonical schema
+(``invoice2data.extract.schema``) so adding a new canonical field there
+automatically becomes selectable here -- no parallel maintenance.
+"""
+
+import logging
+
+from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
+
+logger = logging.getLogger(__name__)
+
+
+def _field_selection(self):
+    """Best-effort selection list from the lib's canonical schema.
+
+    Odoo invokes selection callables with ``self`` bound, so the parameter
+    is required even though we do not use it.
+    """
+    try:
+        from invoice2data.extract import schema
+    except ImportError:
+        return [("invoice_number", "Invoice Number"), ("date", "Date")]
+    return [
+        (name, name.replace("_", " ").title()) for name in sorted(schema.INVOICE_FIELDS)
+    ]
+
+
+class Invoice2dataTemplateField(models.Model):
+    _name = "invoice2data.template.field"
+    _description = "Per-field extraction rule for a DB-stored invoice2data template"
+    _order = "sequence, id"
+
+    template_id = fields.Many2one(
+        comodel_name="invoice2data.template",
+        ondelete="cascade",
+        required=True,
+        index=True,
+    )
+    sequence = fields.Integer(default=10)
+    name = fields.Selection(
+        selection=_field_selection,
+        required=True,
+        help="Canonical invoice2data field name (from `extract/schema.py`).",
+    )
+    parser = fields.Selection(
+        selection=[
+            ("regex", "Regex"),
+            ("static", "Static value"),
+            ("lines", "Lines block (advanced)"),
+        ],
+        default="regex",
+        required=True,
+    )
+    regex = fields.Char(
+        help="Capture-group regex; used when parser is 'regex' or 'lines'.",
+    )
+    static_value = fields.Char(
+        help="Constant value emitted as-is; used when parser is 'static'.",
+    )
+    type = fields.Selection(
+        selection=[
+            ("char", "Text"),
+            ("int", "Integer"),
+            ("float", "Float"),
+            ("date", "Date"),
+        ],
+        default="char",
+    )
+    # Per-field `replace` (issue invoice2data#497)
+    replace_pattern = fields.Char(string="Replace pattern")
+    replace_repl = fields.Char(string="Replace with")
+    # Issue invoice2data#652
+    extract_number = fields.Boolean(
+        help=(
+            "Pluck the first numeric token from the captured value before "
+            "type coercion. Useful for `12123 Stk.` -> `12123`. Only honoured "
+            "when type is Integer or Float."
+        ),
+    )
+
+    @api.constrains("parser", "regex", "static_value")
+    def _check_parser_args(self):
+        for line in self:
+            if line.parser in {"regex", "lines"} and not line.regex:
+                raise ValidationError(
+                    _(
+                        "Field '%(field)s' uses parser '%(parser)s' but has "
+                        "no regex set."
+                    )
+                    % {"field": line.name, "parser": line.parser}
+                )
+            if line.parser == "static" and not line.static_value:
+                raise ValidationError(
+                    _(
+                        "Field '%(field)s' uses parser 'static' but has no "
+                        "value set."
+                    )
+                    % {"field": line.name}
+                )
+
+    def _to_field_dict(self):
+        """Render this row as the dict the invoice2data template expects."""
+        self.ensure_one()
+        if self.parser == "static":
+            return {"parser": "static", "value": self.static_value or ""}
+        spec = {"parser": self.parser, "regex": self.regex or ""}
+        if self.type and self.type != "char":
+            spec["type"] = self.type
+        if self.replace_pattern:
+            spec["replace"] = [self.replace_pattern, self.replace_repl or ""]
+        if self.extract_number and self.type in {"int", "float"}:
+            spec["extract_number"] = True
+        return spec

--- a/account_invoice_import_invoice2data_db_templates/readme/CONTRIBUTORS.rst
+++ b/account_invoice_import_invoice2data_db_templates/readme/CONTRIBUTORS.rst
@@ -1,0 +1,2 @@
+* Original DB-storage design (2017): Therp BV
+* 14.0 module + GUI builder: `bosd <https://github.com/bosd>`_

--- a/account_invoice_import_invoice2data_db_templates/readme/DESCRIPTION.rst
+++ b/account_invoice_import_invoice2data_db_templates/readme/DESCRIPTION.rst
@@ -1,0 +1,24 @@
+This module extends *Account Invoice Import Invoice2data* with **DB-stored
+templates** and a **GUI editor** for authoring them.
+
+It implements the long-standing roadmap item the parent module references
+as *"An graphical template builder"*: instead of (or alongside) the
+disk-loaded ``invoice2data_templates_dir`` set, accountants can author
+templates directly in Odoo. Each ``invoice2data.template`` record is
+merged into the lib's template list at import time, so the cascade
+behaviour is unchanged.
+
+Two authoring modes live side by side:
+
+* **Guided** -- fill in *Name*, *Keywords* and a list of *Fields*
+  (canonical invoice2data field names, regex or static value, optional
+  ``replace`` pair, opt-in ``extract_number`` flag for text-mixed
+  numerics). The JSON is composed from those on save.
+* **Power user** -- paste a full invoice2data JSON template into the
+  *JSON* tab; the *Fields* tab is then ignored.
+
+A **Suggest fields** button uses the lib's authoring helpers
+(``invoice2data.extract.template_builder.suggested_template`` and the
+label-detection helpers) to pre-fill the field grid from the latest
+attached PDF -- the "guessing framework" the parent module's 2017 TODO
+list asked for.

--- a/account_invoice_import_invoice2data_db_templates/readme/ROADMAP.rst
+++ b/account_invoice_import_invoice2data_db_templates/readme/ROADMAP.rst
@@ -1,0 +1,7 @@
+* Visual PDF region picker for ``area:``-style templates -- click-to-define
+  rectangles on the PDF preview; ties into invoice2data's
+  ``camelot`` / Excalibur path.
+* AI authoring (``--new-template --ai`` from the lib) wired as an action,
+  with the provider configured via ``invoice2data.ai`` settings.
+* Per-record audit of which DB template matched on a given import (write
+  the match back to ``account.move`` for traceability).

--- a/account_invoice_import_invoice2data_db_templates/security/invoice2data_template_groups.xml
+++ b/account_invoice_import_invoice2data_db_templates/security/invoice2data_template_groups.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo noupdate="1">
+    <record id="group_invoice2data_template_manager" model="res.groups">
+        <field name="name">Manage invoice2data templates</field>
+        <field name="category_id" ref="base.module_category_accounting_accounting" />
+        <field name="implied_ids" eval="[(4, ref('account.group_account_invoice'))]" />
+        <field
+            name="comment"
+        >Author and edit DB-stored invoice2data templates used by the invoice import wizard.</field>
+    </record>
+</odoo>

--- a/account_invoice_import_invoice2data_db_templates/security/ir.model.access.csv
+++ b/account_invoice_import_invoice2data_db_templates/security/ir.model.access.csv
@@ -1,0 +1,5 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_invoice2data_template_user,invoice2data.template user,model_invoice2data_template,account.group_account_invoice,1,0,0,0
+access_invoice2data_template_manager,invoice2data.template manager,model_invoice2data_template,group_invoice2data_template_manager,1,1,1,1
+access_invoice2data_template_field_user,invoice2data.template.field user,model_invoice2data_template_field,account.group_account_invoice,1,0,0,0
+access_invoice2data_template_field_manager,invoice2data.template.field manager,model_invoice2data_template_field,group_invoice2data_template_manager,1,1,1,1

--- a/account_invoice_import_invoice2data_db_templates/tests/__init__.py
+++ b/account_invoice_import_invoice2data_db_templates/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_db_templates

--- a/account_invoice_import_invoice2data_db_templates/tests/test_db_templates.py
+++ b/account_invoice_import_invoice2data_db_templates/tests/test_db_templates.py
@@ -1,0 +1,207 @@
+# Copyright 2025-2026 bosd
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+"""Tests for the DB-stored invoice2data templates module."""
+
+import json
+from unittest import mock
+
+from odoo.tests.common import TransactionCase
+
+
+class TestInvoice2dataDBTemplates(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.Template = cls.env["invoice2data.template"]
+        cls.Field = cls.env["invoice2data.template.field"]
+
+    # === JSON authoring path ===
+
+    def test_get_templates_loads_json_blob(self):
+        record = self.Template.create(
+            {
+                "name": "acme.test.json",
+                "keywords": "ACME",
+                "template": json.dumps(
+                    [
+                        {
+                            "issuer": "ACME",
+                            "keywords": ["ACME"],
+                            "exclude_keywords": [],
+                            "fields": {
+                                "invoice_number": r"Inv\s*#\s*(\d+)",
+                                "amount": r"Total\s+([\d.]+)",
+                            },
+                        }
+                    ]
+                ),
+            }
+        )
+        templates = record._to_invoice_templates()
+        self.assertEqual(len(templates), 1)
+        self.assertEqual(templates[0].get("template_name"), "acme.test.json")
+        self.assertEqual(templates[0]["issuer"], "ACME")
+
+    def test_invalid_json_does_not_raise(self):
+        record = self.Template.create(
+            {
+                "name": "acme.test.broken",
+                "keywords": "ACME",
+                "template": "this is not json",
+            }
+        )
+        self.assertEqual(record._to_invoice_templates(), [])
+
+    # === Structured authoring path ===
+
+    def test_compose_template_dict_from_fields(self):
+        record = self.Template.create(
+            {
+                "name": "acme.test.fields",
+                "keywords": "ACME\nVendor",
+                "exclude_keywords": "DRAFT",
+                "field_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "name": "invoice_number",
+                            "parser": "regex",
+                            "regex": r"Inv\s*#\s*(\d+)",
+                        },
+                    ),
+                    (
+                        0,
+                        0,
+                        {
+                            "name": "amount",
+                            "parser": "regex",
+                            "regex": r"Total\s+([\d.]+)",
+                            "type": "float",
+                        },
+                    ),
+                    (
+                        0,
+                        0,
+                        {
+                            "name": "vat",
+                            "parser": "static",
+                            "static_value": "FR12345678901",
+                        },
+                    ),
+                ],
+            }
+        )
+        composed = record._compose_template_dict()
+        self.assertEqual(composed["keywords"], ["ACME", "Vendor"])
+        self.assertEqual(composed["exclude_keywords"], ["DRAFT"])
+        self.assertEqual(
+            composed["fields"]["invoice_number"],
+            {"parser": "regex", "regex": r"Inv\s*#\s*(\d+)"},
+        )
+        self.assertEqual(composed["fields"]["amount"]["type"], "float")
+        self.assertEqual(
+            composed["fields"]["vat"],
+            {"parser": "static", "value": "FR12345678901"},
+        )
+
+    def test_field_with_replace_emits_pair(self):
+        record = self.Template.create(
+            {
+                "name": "acme.test.replace",
+                "keywords": "ACME",
+                "field_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "name": "vat",
+                            "parser": "regex",
+                            "regex": r"VAT\s+(\S+)",
+                            "replace_pattern": r"\W+",
+                            "replace_repl": "",
+                        },
+                    ),
+                ],
+            }
+        )
+        composed = record._compose_template_dict()
+        self.assertEqual(composed["fields"]["vat"]["replace"], [r"\W+", ""])
+
+    def test_extract_number_only_when_int_or_float(self):
+        record = self.Template.create(
+            {
+                "name": "acme.test.extract_number",
+                "keywords": "ACME",
+                "field_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "name": "amount",
+                            "parser": "regex",
+                            "regex": r"qty\s+(\d+\s+Stk\.)",
+                            "type": "int",
+                            "extract_number": True,
+                        },
+                    ),
+                    (
+                        0,
+                        0,
+                        {
+                            "name": "vat",
+                            "parser": "regex",
+                            "regex": r"VAT\s+(\S+)",
+                            "type": "char",
+                            "extract_number": True,
+                        },
+                    ),
+                ],
+            }
+        )
+        composed = record._compose_template_dict()
+        self.assertTrue(composed["fields"]["amount"]["extract_number"])
+        self.assertNotIn("extract_number", composed["fields"]["vat"])
+
+    def test_get_templates_filters_by_type_and_active(self):
+        active = self.Template.create(
+            {
+                "name": "acme.purchase.active",
+                "keywords": "ACME",
+                "template_type": "purchase_invoice",
+            }
+        )
+        self.Template.create(
+            {
+                "name": "acme.purchase.inactive",
+                "keywords": "ACME",
+                "template_type": "purchase_invoice",
+                "active": False,
+            }
+        )
+        names = [
+            tpl["template_name"]
+            for tpl in self.Template.get_templates("purchase_invoice")
+        ]
+        self.assertIn(active.name, names)
+        self.assertNotIn("acme.purchase.inactive", names)
+
+    def test_wizard_collect_includes_db_templates(self):
+        self.Template.create(
+            {
+                "name": "acme.purchase.wizardtest",
+                "keywords": "ACME",
+                "template_type": "purchase_invoice",
+            }
+        )
+        Wizard = self.env["account.invoice.import"]
+        with mock.patch(
+            "odoo.addons.account_invoice_import_invoice2data_db_templates"
+            ".wizard.account_invoice_import.read_templates",
+            return_value=[],
+        ):
+            collected = Wizard._invoice2data_collect_templates()
+        names = [
+            tpl["template_name"] for tpl in collected if "template_name" in tpl
+        ]
+        self.assertIn("acme.purchase.wizardtest", names)

--- a/account_invoice_import_invoice2data_db_templates/tests/test_db_templates.py
+++ b/account_invoice_import_invoice2data_db_templates/tests/test_db_templates.py
@@ -9,11 +9,13 @@ from odoo.tests.common import TransactionCase
 
 
 class TestInvoice2dataDBTemplates(TransactionCase):
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-        cls.Template = cls.env["invoice2data.template"]
-        cls.Field = cls.env["invoice2data.template.field"]
+    def setUp(self):
+        # Odoo 14's ``TransactionCase.setUpClass`` does not yet set ``cls.env``
+        # -- only ``SavepointCase`` does. Bind the recordsets in ``setUp``
+        # (instance-level) so the tests run on 14.0.
+        super().setUp()
+        self.Template = self.env["invoice2data.template"]
+        self.Field = self.env["invoice2data.template.field"]
 
     # === JSON authoring path ===
 
@@ -201,7 +203,5 @@ class TestInvoice2dataDBTemplates(TransactionCase):
             return_value=[],
         ):
             collected = Wizard._invoice2data_collect_templates()
-        names = [
-            tpl["template_name"] for tpl in collected if "template_name" in tpl
-        ]
+        names = [tpl["template_name"] for tpl in collected if "template_name" in tpl]
         self.assertIn("acme.purchase.wizardtest", names)

--- a/account_invoice_import_invoice2data_db_templates/views/invoice2data_template.xml
+++ b/account_invoice_import_invoice2data_db_templates/views/invoice2data_template.xml
@@ -1,0 +1,175 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+    <record id="invoice2data_template_tree" model="ir.ui.view">
+        <field name="name">invoice2data.template.tree</field>
+        <field name="model">invoice2data.template</field>
+        <field name="arch" type="xml">
+            <tree>
+                <field name="name" />
+                <field name="template_type" />
+                <field name="priority" />
+                <field name="active" widget="boolean_toggle" />
+            </tree>
+        </field>
+    </record>
+
+    <record id="invoice2data_template_search" model="ir.ui.view">
+        <field name="name">invoice2data.template.search</field>
+        <field name="model">invoice2data.template</field>
+        <field name="arch" type="xml">
+            <search>
+                <field name="name" />
+                <field name="template_type" />
+                <filter
+                    string="Archived"
+                    name="archived"
+                    domain="[('active', '=', False)]"
+                />
+                <group string="Group By">
+                    <filter
+                        string="Type"
+                        name="group_type"
+                        context="{'group_by': 'template_type'}"
+                    />
+                </group>
+            </search>
+        </field>
+    </record>
+
+    <record id="invoice2data_template_form" model="ir.ui.view">
+        <field name="name">invoice2data.template.form</field>
+        <field name="model">invoice2data.template</field>
+        <field name="arch" type="xml">
+            <form>
+                <header>
+                    <button
+                        name="action_preview"
+                        type="object"
+                        string="Preview text"
+                        help="Run invoice2data's text extractor on the latest attached PDF."
+                    />
+                    <button
+                        name="action_test"
+                        type="object"
+                        string="Test"
+                        class="oe_highlight"
+                        help="Run a full extract_data() against the attached PDF using this template + the disk-loaded ones."
+                    />
+                    <button
+                        name="action_suggest_fields"
+                        type="object"
+                        string="Suggest fields"
+                        help="Use invoice2data's candidate / label-detection helpers to pre-fill the field grid."
+                    />
+                </header>
+                <sheet>
+                    <div class="oe_title">
+                        <label for="name" string="Template Name" />
+                        <h1><field name="name" placeholder="acme.invoice" /></h1>
+                    </div>
+                    <group>
+                        <group name="left">
+                            <field name="template_type" />
+                            <field name="priority" />
+                            <field name="active" invisible="1" />
+                        </group>
+                        <group name="right">
+                            <field
+                                name="keywords"
+                                placeholder="One per line. Used by invoice2data to pick this template."
+                            />
+                            <field
+                                name="exclude_keywords"
+                                placeholder="Optional. One per line."
+                            />
+                        </group>
+                    </group>
+                    <notebook>
+                        <page name="fields" string="Fields">
+                            <field name="field_ids" nolabel="1">
+                                <tree editable="bottom">
+                                    <field name="sequence" widget="handle" />
+                                    <field name="name" />
+                                    <field name="parser" />
+                                    <field
+                                        name="regex"
+                                        attrs="{'invisible': [('parser', '=', 'static')]}"
+                                    />
+                                    <field
+                                        name="static_value"
+                                        attrs="{'invisible': [('parser', '!=', 'static')]}"
+                                    />
+                                    <field name="type" />
+                                    <field name="replace_pattern" optional="hide" />
+                                    <field name="replace_repl" optional="hide" />
+                                    <field name="extract_number" optional="hide" />
+                                </tree>
+                            </field>
+                        </page>
+                        <page name="json" string="JSON (advanced)">
+                            <field
+                                name="template"
+                                widget="ace"
+                                options="{'mode': 'json'}"
+                                placeholder="Paste a full invoice2data JSON template here. Takes precedence over the Fields tab."
+                            />
+                        </page>
+                        <page name="results" string="Test results">
+                            <group>
+                                <field
+                                    name="preview_text"
+                                    readonly="1"
+                                    nolabel="1"
+                                    widget="text"
+                                />
+                            </group>
+                            <group>
+                                <field
+                                    name="last_test_warnings"
+                                    readonly="1"
+                                    nolabel="1"
+                                    widget="text"
+                                    class="alert alert-warning"
+                                    attrs="{'invisible': [('last_test_warnings', '=', False)]}"
+                                />
+                                <field
+                                    name="last_test_result"
+                                    readonly="1"
+                                    nolabel="1"
+                                    widget="text"
+                                />
+                            </group>
+                        </page>
+                    </notebook>
+                </sheet>
+                <div class="oe_chatter">
+                    <field name="message_follower_ids" widget="mail_followers" />
+                    <field name="activity_ids" widget="mail_activity" />
+                    <field name="message_ids" widget="mail_thread" />
+                </div>
+            </form>
+        </field>
+    </record>
+
+    <record id="invoice2data_template_action" model="ir.actions.act_window">
+        <field name="name">Invoice2data Templates</field>
+        <field name="res_model">invoice2data.template</field>
+        <field name="view_mode">tree,form</field>
+        <field name="search_view_id" ref="invoice2data_template_search" />
+        <field name="help" type="html">
+            <p class="o_view_nocontent_smiling_face">Author a DB template.</p>
+            <p>
+                DB-stored invoice2data templates live alongside the disk-loaded
+                ones. Attach a sample PDF to the chatter and use the
+                <em>Suggest fields</em> / <em>Test</em> buttons to iterate.
+            </p>
+        </field>
+    </record>
+
+    <menuitem
+        id="invoice2data_template_menu"
+        parent="account.menu_finance_configuration"
+        action="invoice2data_template_action"
+        sequence="80"
+    />
+</odoo>

--- a/account_invoice_import_invoice2data_db_templates/wizard/__init__.py
+++ b/account_invoice_import_invoice2data_db_templates/wizard/__init__.py
@@ -1,0 +1,1 @@
+from . import account_invoice_import

--- a/account_invoice_import_invoice2data_db_templates/wizard/account_invoice_import.py
+++ b/account_invoice_import_invoice2data_db_templates/wizard/account_invoice_import.py
@@ -66,9 +66,7 @@ class AccountInvoiceImport(models.TransientModel):
         )
         if not exclude_built_in:
             templates += read_templates()
-        templates += self.env["invoice2data.template"].get_templates(
-            "purchase_invoice"
-        )
+        templates += self.env["invoice2data.template"].get_templates("purchase_invoice")
         return templates
 
     def _invoice2data_try_tesseract(self, path, templates):

--- a/account_invoice_import_invoice2data_db_templates/wizard/account_invoice_import.py
+++ b/account_invoice_import_invoice2data_db_templates/wizard/account_invoice_import.py
@@ -1,0 +1,88 @@
+# Copyright 2025-2026 bosd
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+"""Merge DB-stored invoice2data templates into the import wizard.
+
+Extends the wizard contributed by ``account_invoice_import_invoice2data``
+to append the active DB templates to the list passed into
+``invoice2data.extract_data``.
+"""
+
+import logging
+import os
+import shutil
+from tempfile import NamedTemporaryFile
+
+from odoo import _, api, models, tools
+from odoo.exceptions import UserError
+
+logger = logging.getLogger(__name__)
+
+try:
+    from invoice2data import extract_data
+    from invoice2data.extract.loader import read_templates
+except ImportError:  # pragma: no cover
+    extract_data = None
+    read_templates = None
+
+
+class AccountInvoiceImport(models.TransientModel):
+    _inherit = "account.invoice.import"
+
+    @api.model
+    def invoice2data_parse_invoice(self, file_data, company):
+        """Reimplement the wizard's hook to merge DB templates."""
+        if extract_data is None or read_templates is None:
+            # Lib missing: propagate the upstream error path.
+            return super().invoice2data_parse_invoice(file_data, company)
+
+        logger.info("Trying to analyze PDF invoice with invoice2data lib + DB")
+        with NamedTemporaryFile(
+            "wb", prefix="odoo-aii-inv2data-pdf-", suffix=".pdf"
+        ) as fileobj:
+            fileobj.write(file_data)
+            fileobj.flush()
+            templates = self._invoice2data_collect_templates()
+            try:
+                result = extract_data(fileobj.name, templates=templates)
+            except Exception as exc:  # noqa: BLE001
+                raise UserError(
+                    _("PDF Invoice parsing failed. Error message: %s") % exc
+                ) from exc
+            if not result:
+                result = self._invoice2data_try_tesseract(fileobj.name, templates)
+            if not result:
+                return False
+        return self.invoice2data_to_parsed_inv(result)
+
+    @api.model
+    def _invoice2data_collect_templates(self):
+        """Build the (disk + DB) template list passed to ``extract_data``."""
+        templates = []
+        local_dir = tools.config.get("invoice2data_templates_dir", False)
+        if local_dir and os.path.isdir(local_dir):
+            templates += read_templates(local_dir)
+        exclude_built_in = tools.config.get(
+            "invoice2data_exclude_built_in_templates", False
+        )
+        if not exclude_built_in:
+            templates += read_templates()
+        templates += self.env["invoice2data.template"].get_templates(
+            "purchase_invoice"
+        )
+        return templates
+
+    def _invoice2data_try_tesseract(self, path, templates):
+        """OCR fallback path, mirroring the upstream wizard's behaviour."""
+        if not shutil.which("tesseract"):
+            logger.warning("Tesseract fallback unavailable; install tesseract-ocr")
+            return False
+        logger.info("Falling back on Tesseract OCR")
+        try:
+            from invoice2data.input import tesseract
+        except ImportError:
+            return False
+        try:
+            return extract_data(path, templates=templates, input_module=tesseract)
+        except Exception:  # noqa: BLE001
+            logger.exception("Tesseract fallback failed for %s", path)
+            return False

--- a/setup/account_invoice_import_invoice2data_db_templates/odoo/addons/account_invoice_import_invoice2data_db_templates
+++ b/setup/account_invoice_import_invoice2data_db_templates/odoo/addons/account_invoice_import_invoice2data_db_templates
@@ -1,0 +1,1 @@
+../../../../account_invoice_import_invoice2data_db_templates

--- a/setup/account_invoice_import_invoice2data_db_templates/setup.py
+++ b/setup/account_invoice_import_invoice2data_db_templates/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
### What this adds

A new addon, `account_invoice_import_invoice2data_db_templates`, that stores invoice2data templates in the Odoo database and merges them into the import wizard alongside the existing disk-loaded ones. Implements the **GUI template builder** the parent module's 2017 TODO list asked for.

**14.0 back-port** of OCA/edi#1365 (16.0). The parent module `account_invoice_import_invoice2data` already exists on 14.0, so this can land without depending on the 16.0 migration.

### Authoring modes

- **Guided:** name + keywords + per-field rules via a `field_ids` o2m; JSON is composed at save time.
- **Power user:** paste a full invoice2data JSON template into a dedicated tab; the Fields tab is then ignored.

The canonical field-name selection list is driven from `invoice2data.extract.schema` — adding a new canonical field upstream automatically becomes selectable here.

### Buttons on the form

- **Preview text** — runs the lib's `to_text` on the latest chatter attachment.
- **Test** — runs a full `extract_data()` against the attached PDF using this template + the disk-loaded ones.
- **Suggest fields** — wires `invoice2data.extract.template_builder.suggested_template` + the label-detection helpers to pre-fill the field grid from the latest attached PDF.

### First-class support for the 1.0 lib options

Per-field `replace` (invoice2data#497) and `extract_number` flag (invoice2data#652) are exposed as columns on the o2m, not buried in JSON.

### Differences from the 16.0 module

- Dropped the `web_ribbon` widget (14.0 has no built-in web_ribbon).
- Same models / wizard / tests otherwise.

### External dependency

`invoice2data >= 1.0` (now on PyPI). The 1.0 cut includes `ordered_load`, `suggested_template`, per-field `replace`, and the `extract_number` field option this module surfaces.

### Reviewers

cc @alexis-via — happy to rebase / split / squash per your preferences.