### PR TITLE
[17.0][IMP] base_import_pdf_by_template: Prevent time_format if not set

### DIFF
--- a/base_business_document_import/i18n/de.po
+++ b/base_business_document_import/i18n/de.po
@@ -62,8 +62,8 @@ msgid ""
 "Approximate match: account %(account)s has been matched with account "
 "%(matched_account)s"
 msgstr ""
-"Ungefähre Übereinstimmung: Das Konto %(account) wurde mit dem Konto %"
-"(matched_account) abgeglichen"
+"Ungefähre Übereinstimmung: Das Konto %(account)s wurde mit dem Konto "
+"%(matched_account)s abgeglichen"
 
 #. module: base_business_document_import
 #: model:ir.model,name:base_business_document_import.model_business_document_import

--- a/base_import_pdf_by_template/models/base_import_pdf_template.py
+++ b/base_import_pdf_by_template/models/base_import_pdf_template.py
@@ -379,7 +379,7 @@ class BaseImportPdfTemplateLine(models.Model):
         # We need to replace -short because it is not respected in databases with
         # different capitalization. (example: *d/*m/*Y and *d/*m/*y)
         date_format = self.date_format.replace("*", "%").replace("-short", "")
-        if self.field_ttype == "datetime":
+        if self.field_ttype == "datetime" and self.time_format:
             time_format = self.time_format.replace("*", "%")
             date_format += " " + time_format
         datetime_object = datetime.strptime(value, date_format)


### PR DESCRIPTION
FWP from 15.0: https://github.com/OCA/edi/pull/1156

Prevent time_format if not set

```
time_format = self.time_format.replace("*", "%")
AttributeError: 'bool' object has no attribute 'replace'
```

Please @pedrobaeza can ou review it?

@Tecnativa TT56270