### PR TITLE
[18.0][IMP] base_import_pdf_by_template: Prevent time_format if not set

### DIFF
--- a/base_import_pdf_by_template/models/base_import_pdf_template.py
+++ b/base_import_pdf_by_template/models/base_import_pdf_template.py
@@ -405,7 +405,7 @@ class BaseImportPdfTemplateLine(models.Model):
         # We need to replace -short because it is not respected in databases with
         # different capitalization. (example: *d/*m/*Y and *d/*m/*y)
         date_format = self.date_format.replace("*", "%").replace("-short", "")
-        if self.field_ttype == "datetime":
+        if self.field_ttype == "datetime" and self.time_format:
             time_format = self.time_format.replace("*", "%")
             date_format += " " + time_format
         datetime_object = datetime.strptime(value, date_format)


### PR DESCRIPTION
FWP from 17.0: https://github.com/OCA/edi/pull/1374

Prevent time_format if not set

```
time_format = self.time_format.replace("*", "%")
AttributeError: 'bool' object has no attribute 'replace'
```

Please @pedrobaeza can ou review it?

@Tecnativa TT56270