### PR TITLE
[15.0][FIX] edi_voxel_stock_picking_oca: cron calls a non existing method

### DIFF
--- a/edi_voxel_stock_picking_oca/data/ir_cron_data.xml
+++ b/edi_voxel_stock_picking_oca/data/ir_cron_data.xml
@@ -6,7 +6,7 @@
         <field name="name">Edi Voxel: Update stock picking export status</field>
         <field name="model_id" ref="stock.model_stock_picking" />
         <field name="state">code</field>
-        <field name="code">model.update_voxel_export_status_cron()</field>
+        <field name="code">model._cron_update_voxel_export_status()</field>
         <field name="user_id" ref="base.user_root" />
         <field name="interval_number">10</field>
         <field name="interval_type">minutes</field>


### PR DESCRIPTION
The scheduled action 'Edi Voxel: Update stock picking export status' calls 'update_voxel_export_status_cron()', but that method doesn't exist in 'voxel.mixin' (it is named '_cron_update_voxel_export_status'), so the cron fails on every run with:

        AttributeError: 'stock.picking' object has no attribute 'update_voxel_export_status_cron'

As a consequence the export status of the sent pickings is never updated. The equivalent cron in edi_voxel_account_invoice_oca already uses the right method name.

cc @Tecnativa TT63932

ping @sergio-teruel @carlosdauden 