### PR TITLE
16.0 backport einvoice address

### DIFF
--- a/account_invoice_import_facturx/wizard/account_invoice_import.py
+++ b/account_invoice_import_facturx/wizard/account_invoice_import.py
@@ -124,6 +124,12 @@ class AccountInvoiceImport(models.TransientModel):
                     "/ram:PostalTradeAddress"
                     "/ram:CityName",  # ZUGFeRD 1.x
                 ],
+                "einvoice_address": [
+                    "//ram:ApplicableHeaderTradeAgreement"
+                    "/ram:SellerTradeParty"
+                    "/ram:URIUniversalCommunication"
+                    "/ram:URIID[@schemeID='0225']",  # Factur-X
+                ],
             },
             "company": {
                 "vat": [
@@ -135,6 +141,12 @@ class AccountInvoiceImport(models.TransientModel):
                     "/ram:BuyerTradeParty"
                     "/ram:SpecifiedTaxRegistration"
                     "/ram:ID[@schemeID='VA']",  # ZUGFeRD
+                ],
+                "einvoice_address": [
+                    "//ram:ApplicableHeaderTradeAgreement"
+                    "/ram:BuyerTradeParty"
+                    "/ram:URIUniversalCommunication"
+                    "/ram:URIID[@schemeID='0225']",  # Factur-X
                 ],
             },
             "invoice_number": [

--- a/account_invoice_import_facturx/wizard/account_invoice_import.py
+++ b/account_invoice_import_facturx/wizard/account_invoice_import.py
@@ -11,7 +11,7 @@ from odoo.tools.misc import format_amount
 logger = logging.getLogger(__name__)
 
 try:
-    from facturx import get_level, xml_check_xsd
+    from facturx import get_flavor, get_level, get_xml_namespaces, xml_check_xsd
 except ImportError:
     logger.debug("Cannot import facturx")
 
@@ -389,7 +389,8 @@ class AccountInvoiceImport(models.TransientModel):
     def parse_facturx_invoice(self, xml_root, company):  # noqa: C901
         """Parse Cross Industry Invoice XML file"""
         logger.debug("Starting to parse XML file as Factur-X/ZUGFeRD file")
-        namespaces = xml_root.nsmap
+        flavor = get_flavor(xml_root)
+        namespaces = get_xml_namespaces(flavor)
         # reminder: level is the profile
         try:
             level = get_level(xml_root)


### PR DESCRIPTION
Backport of #1354 to 16.0 (both commits, no other change).

Parse the electronic address of both trade parties, read from
`URIUniversalCommunication/URIID[@schemeID='0225']`, into
`parsed_inv['partner']['einvoice_address']` (seller) and
`parsed_inv['company']['einvoice_address']` (buyer).

This is what the French e-invoicing reform needs on incoming bills: the
buyer address identifies the directory line the invoice was sent to,
which is how the receiver binds the bill to a company directory line and
routes it to the right purchase journal. Without it that whole routing is
a silent no-op.

The second commit is required for the first one to work on real-world
files: `xml_root.nsmap` carries a `None` key when the Factur-X file
declares a default namespace, which makes every xpath lookup fail. The
namespace map is now asked to factur-x for the detected flavor.

Tested on a 16.0 database with the Akretion `fr-einvoicing` stack
backported to 16.0: the same Factur-X file imported on 16.0 and on an
18.0 reference gives the same vendor bill, field for field, including the
purchase journal bound to the company directory line.