### PR TITLE
[14.0][IMP] account_invoice_import_invoice2data: adopt invoice2data 1.0 APIs

### DIFF
--- a/account_invoice_import_invoice2data/README.rst
+++ b/account_invoice_import_invoice2data/README.rst
@@ -233,6 +233,20 @@ Changelog
 =========
 
 
+14.0.2.5.0 (2026-08-02)
+~~~~~~~~~~~~~~~~~~~~~~~
+
+* [FIX] Restore compatibility with invoice2data >= 1.0. The pre-1.0 API
+  path ``invoice2data.main`` was removed upstream; import from
+  ``invoice2data`` directly.
+* [IMP] Surface actionable errors: on a matched-but-incomplete template,
+  the wizard now shows the template name + the specific fields that
+  could not be parsed (via ``raise_on_error=True`` and the new typed
+  exceptions ``NoTemplateFoundError`` / ``RequiredFieldsMissingError`` /
+  ``TemplateSyntaxError``).
+* [IMP] Log which template matched (``template_name``, added in
+  invoice2data 1.0) alongside the extracted result.
+
 14.0.2.2.0 (2023-03-03)
 ~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/account_invoice_import_invoice2data/__manifest__.py
+++ b/account_invoice_import_invoice2data/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     "name": "Account Invoice Import Invoice2data",
-    "version": "14.0.2.4.0",
+    "version": "14.0.2.5.0",
     "category": "Accounting/Accounting",
     "license": "AGPL-3",
     "summary": "Import supplier invoices using the invoice2data lib",
@@ -14,7 +14,9 @@
     "depends": ["account_invoice_import"],
     "external_dependencies": {
         "python": [
-            "invoice2data",
+            # 1.0 dropped ``invoice2data.main`` and added typed exceptions +
+            # ``raise_on_error``; the wizard now depends on both.
+            "invoice2data>=1.0",
             "dateparser",
         ],
         "deb": ["poppler-utils"],

--- a/account_invoice_import_invoice2data/readme/HISTORY.rst
+++ b/account_invoice_import_invoice2data/readme/HISTORY.rst
@@ -1,4 +1,18 @@
 
+14.0.2.5.0 (2026-08-02)
+~~~~~~~~~~~~~~~~~~~~~~~
+
+* [FIX] Restore compatibility with invoice2data >= 1.0. The pre-1.0 API
+  path ``invoice2data.main`` was removed upstream; import from
+  ``invoice2data`` directly.
+* [IMP] Surface actionable errors: on a matched-but-incomplete template,
+  the wizard now shows the template name + the specific fields that
+  could not be parsed (via ``raise_on_error=True`` and the new typed
+  exceptions ``NoTemplateFoundError`` / ``RequiredFieldsMissingError`` /
+  ``TemplateSyntaxError``).
+* [IMP] Log which template matched (``template_name``, added in
+  invoice2data 1.0) alongside the extracted result.
+
 14.0.2.2.0 (2023-03-03)
 ~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/account_invoice_import_invoice2data/static/description/index.html
+++ b/account_invoice_import_invoice2data/static/description/index.html
@@ -382,14 +382,15 @@ ul.auto-toc {
 <li><a class="reference internal" href="#configuration" id="toc-entry-3">Configuration</a></li>
 <li><a class="reference internal" href="#known-issues-roadmap" id="toc-entry-4">Known issues / Roadmap</a></li>
 <li><a class="reference internal" href="#changelog" id="toc-entry-5">Changelog</a><ul>
-<li><a class="reference internal" href="#section-1" id="toc-entry-6">14.0.2.2.0 (2023-03-03)</a></li>
+<li><a class="reference internal" href="#section-1" id="toc-entry-6">14.0.2.5.0 (2026-08-02)</a></li>
+<li><a class="reference internal" href="#section-2" id="toc-entry-7">14.0.2.2.0 (2023-03-03)</a></li>
 </ul>
 </li>
-<li><a class="reference internal" href="#bug-tracker" id="toc-entry-7">Bug Tracker</a></li>
-<li><a class="reference internal" href="#credits" id="toc-entry-8">Credits</a><ul>
-<li><a class="reference internal" href="#authors" id="toc-entry-9">Authors</a></li>
-<li><a class="reference internal" href="#contributors" id="toc-entry-10">Contributors</a></li>
-<li><a class="reference internal" href="#maintainers" id="toc-entry-11">Maintainers</a></li>
+<li><a class="reference internal" href="#bug-tracker" id="toc-entry-8">Bug Tracker</a></li>
+<li><a class="reference internal" href="#credits" id="toc-entry-9">Credits</a><ul>
+<li><a class="reference internal" href="#authors" id="toc-entry-10">Authors</a></li>
+<li><a class="reference internal" href="#contributors" id="toc-entry-11">Contributors</a></li>
+<li><a class="reference internal" href="#maintainers" id="toc-entry-12">Maintainers</a></li>
 </ul>
 </li>
 </ul>
@@ -558,7 +559,22 @@ The invoice2data library does not have a strict standard on field names. This ma
 <div class="section" id="changelog">
 <h1><a class="toc-backref" href="#toc-entry-5">Changelog</a></h1>
 <div class="section" id="section-1">
-<h2><a class="toc-backref" href="#toc-entry-6">14.0.2.2.0 (2023-03-03)</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-6">14.0.2.5.0 (2026-08-02)</a></h2>
+<ul class="simple">
+<li>[FIX] Restore compatibility with invoice2data &gt;= 1.0. The pre-1.0 API
+path <tt class="docutils literal">invoice2data.main</tt> was removed upstream; import from
+<tt class="docutils literal">invoice2data</tt> directly.</li>
+<li>[IMP] Surface actionable errors: on a matched-but-incomplete template,
+the wizard now shows the template name + the specific fields that
+could not be parsed (via <tt class="docutils literal">raise_on_error=True</tt> and the new typed
+exceptions <tt class="docutils literal">NoTemplateFoundError</tt> / <tt class="docutils literal">RequiredFieldsMissingError</tt> /
+<tt class="docutils literal">TemplateSyntaxError</tt>).</li>
+<li>[IMP] Log which template matched (<tt class="docutils literal">template_name</tt>, added in
+invoice2data 1.0) alongside the extracted result.</li>
+</ul>
+</div>
+<div class="section" id="section-2">
+<h2><a class="toc-backref" href="#toc-entry-7">14.0.2.2.0 (2023-03-03)</a></h2>
 <ul class="simple">
 <li>[ADD] Support for invoicelines.
 (<a class="reference external" href="https://github.com/OCA/edi/issues/568">#74</a>)</li>
@@ -566,7 +582,7 @@ The invoice2data library does not have a strict standard on field names. This ma
 </div>
 </div>
 <div class="section" id="bug-tracker">
-<h1><a class="toc-backref" href="#toc-entry-7">Bug Tracker</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-8">Bug Tracker</a></h1>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/OCA/edi/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us to smash it by providing a detailed and welcomed
@@ -574,21 +590,21 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
-<h1><a class="toc-backref" href="#toc-entry-8">Credits</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-9">Credits</a></h1>
 <div class="section" id="authors">
-<h2><a class="toc-backref" href="#toc-entry-9">Authors</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-10">Authors</a></h2>
 <ul class="simple">
 <li>Akretion</li>
 </ul>
 </div>
 <div class="section" id="contributors">
-<h2><a class="toc-backref" href="#toc-entry-10">Contributors</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-11">Contributors</a></h2>
 <ul class="simple">
 <li>Alexis de Lattre &lt;<a class="reference external" href="mailto:alexis.delattre&#64;akretion.com">alexis.delattre&#64;akretion.com</a>&gt;</li>
 </ul>
 </div>
 <div class="section" id="maintainers">
-<h2><a class="toc-backref" href="#toc-entry-11">Maintainers</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-12">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
 <a class="reference external image-reference" href="https://odoo-community.org">
 <img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />

--- a/account_invoice_import_invoice2data/wizard/account_invoice_import.py
+++ b/account_invoice_import_invoice2data/wizard/account_invoice_import.py
@@ -15,14 +15,23 @@ from odoo.exceptions import UserError
 logger = logging.getLogger(__name__)
 
 try:
+    from invoice2data import extract_data
+    from invoice2data.exceptions import (
+        NoTemplateFoundError,
+        RequiredFieldsMissingError,
+        TemplateSyntaxError,
+    )
     from invoice2data.extract.loader import read_templates
-    from invoice2data.main import extract_data, logger as loggeri2data
 except ImportError:
     logger.debug("Cannot import invoice2data")
 try:
     from invoice2data.input import tesseract
 except ImportError:
     logger.debug("Cannot import tesseract")
+
+# Propagate the wizard's log level to every invoice2data sub-logger (they all
+# live under the "invoice2data" namespace since 1.0's __main__ / api split).
+loggeri2data = logging.getLogger("invoice2data")
 
 
 class AccountInvoiceImport(models.TransientModel):
@@ -95,10 +104,40 @@ class AccountInvoiceImport(models.TransientModel):
             templates += read_templates()
         logger.debug("Calling invoice2data.extract_data with templates=%s", templates)
         try:
-            invoice2data_res = extract_data(fileobj.name, templates=templates)
+            invoice2data_res = extract_data(
+                fileobj.name, templates=templates, raise_on_error=True
+            )
+        except RequiredFieldsMissingError as e:
+            # Template matched but couldn't parse a required field -- give the
+            # accountant the specific field names + which template they're
+            # debugging (opt-in behaviour added in invoice2data 1.0, #190).
+            fileobj.close()
+            raise UserError(
+                _(
+                    "PDF Invoice parsing failed: template %(template)s "
+                    "matched but could not parse required field(s): %(fields)s"
+                )
+                % {
+                    "template": e.template_name or _("<unknown>"),
+                    "fields": ", ".join(sorted(e.fields)),
+                }
+            ) from e
+        except TemplateSyntaxError as e:
+            # Bug in the template author's YAML -- fail loudly so an admin can
+            # fix it, don't mask as a generic import failure.
+            fileobj.close()
+            raise UserError(
+                _("Invalid invoice2data template: %s") % e
+            ) from e
+        except NoTemplateFoundError:
+            # Expected outcome for scanned or unfamiliar invoices -- fall
+            # through to the tesseract branch below.
+            invoice2data_res = False
         except Exception as e:
             fileobj.close()
-            raise UserError(_("PDF Invoice parsing failed. Error message: %s") % e)
+            raise UserError(
+                _("PDF Invoice parsing failed. Error message: %s") % e
+            ) from e
         if not invoice2data_res:
             if not shutil.which("tesseract"):
                 logger.warning(
@@ -116,11 +155,17 @@ class AccountInvoiceImport(models.TransientModel):
                 )
             except Exception as e:
                 fileobj.close()
-                raise UserError(_("PDF Invoice parsing failed. Error message: %s") % e)
+                raise UserError(
+                    _("PDF Invoice parsing failed. Error message: %s") % e
+                ) from e
             if not invoice2data_res:
                 fileobj.close()
                 return False
-        logger.info("Result of invoice2data PDF extraction: %s", invoice2data_res)
+        logger.info(
+            "invoice2data matched %s: %s",
+            invoice2data_res.get("template_name", "<unknown template>"),
+            invoice2data_res,
+        )
         fileobj.close()
         return self.invoice2data_to_parsed_inv(invoice2data_res)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 dateparser
 factur-x
 factur-x<=3.1
-invoice2data
+invoice2data>=1.0
 ovh
 phonenumbers
 pypdf>=3.1.0,<5.0


### PR DESCRIPTION
## Summary

[invoice2data 1.0](https://pypi.org/project/invoice2data/1.0.1/) (June 2026, currently 1.0.1) dropped the \`invoice2data.main\` module this wizard imports from, breaking the module for anyone who upgrades the lib. This PR restores compatibility and adopts the new typed-error surface along the way.

Reproducer for the incompatibility:
\`\`\`console
$ pip install "invoice2data>=1.0"
$ python -c "from invoice2data.main import extract_data"
ModuleNotFoundError: No module named 'invoice2data.main'
\`\`\`

## Changes

- **Import fix**: \`extract_data\` from \`invoice2data\` directly. The \`.main\` path was removed in 1.0.
- **Typed errors** (\`raise_on_error=True\`, invoice2data #190):
  - \`RequiredFieldsMissingError\` -> user message names the specific fields + the matched template ("template acme.yml matched but could not parse: date, amount") -- direct handle for a template author to fix.
  - \`TemplateSyntaxError\` -> distinguishes an admin-fixable template bug from a per-invoice parsing failure.
  - \`NoTemplateFoundError\` -> falls through to the tesseract branch cleanly (was previously masked by \`except Exception\`).
- **Show \`template_name\`** (invoice2data 1.0, #618) alongside the extracted result in the wizard log.
- **Log-level bridge** points at \`logging.getLogger("invoice2data")\` (parent namespace of every 1.0 sub-logger) instead of the removed \`invoice2data.main.logger\`.
- **Pin \`invoice2data>=1.0\`** in the manifest's external_dependencies + requirements.txt.

## Compatibility

Requires invoice2data >= 1.0. Downstream users on the previous pre-1.0 line should stay on the previous module version (14.0.2.4.0); this PR bumps to 14.0.2.5.0.

## Test plan

- [x] Manifest lints (\`external_dependencies\` shape valid)
- [x] Local wizard file imports cleanly with invoice2data 1.0.1 installed
- [ ] OCA CI (14.0 matrix)

## Follow-up

Same change is worth porting to the 16.0 migration branch (see the pending [PR #1220](https://github.com/OCA/edi/pull/1220)) once it lands. cc @MarwanBHL @alexis-via