### PR TITLE
10.0

### DIFF
--- a/setup/account_invoice_factur-x/setup.py
+++ b/setup/account_invoice_factur-x/setup.py
@@ -2,5 +2,11 @@ import setuptools
 
 setuptools.setup(
     setup_requires=['setuptools-odoo'],
-    odoo_addon=True,
+    odoo_addon={
+        'external_dependencies_override': {
+            'python': {
+                'facturx': 'factur-x',
+            },
+        },
+    },
 )


### PR DESCRIPTION
[[FIX] account_invoice_factur-x: update facturx external dependency]

The Python package name has changed from facturx to factur-x.
Keep facturx as the Python import name and use factur-x as the pip
package dependency through external_dependencies_override.