### PR TITLE
[19.0][FIX] sale_order_import: propagate line currency

### DIFF
--- a/sale_order_import/tests/test_order_import.py
+++ b/sale_order_import/tests/test_order_import.py
@@ -342,6 +342,32 @@ class TestOrderImport(TestCommon):
         self.assertEqual(order.partner_shipping_id, shipping_partner)
         self.assertIn("Created shipping partner", order.message_ids[0].body)
 
+    def test_order_import_pricelist_rule_showing_discount(self):
+        """Tests order import against a pricelist rule that shows its
+        discount to the customer (percentage-based, with the Discounts
+        feature enabled).
+
+        Expected behavior: the order is created normally and the line's
+        currency matches the pricelist's currency.
+        """
+        self.env["res.config.settings"].create(
+            {"group_discount_per_so_line": True}
+        ).set_values()
+        product = self.env["product.product"].search(
+            [("default_code", "=", "FURN_8888")], limit=1
+        )
+        self.env["product.pricelist.item"].create(
+            {
+                "pricelist_id": self.pricelist.id,
+                "applied_on": "0_product_variant",
+                "product_id": product.id,
+                "compute_price": "percentage",
+                "percent_price": 10,
+            }
+        )
+        order = self.wiz_model.create_order(self.parsed_order, "pricelist")
+        self.assertEqual(order.order_line.currency_id, self.pricelist.currency_id)
+
     def test_create_missing_shipping_partner_disabled(self):
         """Tests creation of missing shipping partner when ctx flag is False or not set
 

--- a/sale_order_import/wizard/sale_order_import.py
+++ b/sale_order_import/wizard/sale_order_import.py
@@ -522,17 +522,23 @@ class SaleOrderImport(models.TransientModel):
         or a dict (in case of the creation of a new sale order)"""
         solo = self.env["sale.order.line"]
         vals = {}
-        # Ensure the company is loaded before we play onchanges.
-        # Yes, `company_id` is related to `order_id.company_id`
-        # but when we call `play_onchanges` it will be empty
-        # w/out this precaution.
+        # Ensure the company and currency are loaded before we play onchanges.
+        # Yes, `company_id`/`currency_id` are related to `order_id.company_id`/
+        # `order_id.currency_id`, but when we call `play_onchanges` they will
+        # be empty w/out this precaution: `currency_id` is a readonly compute
+        # field with no inverse, so `play_onchanges` on `sale.order` drops it
+        # from `so_vals`, and `play_onchanges` on `sale.order.line` then
+        # falls back to `default_get`, which bakes an explicit `False` into
+        # the line's cache instead of letting it compute from `order_id`.
         company_id = self._prepare_order_line_get_company_id(order)
+        currency_id = self._prepare_order_line_get_currency_id(order)
         vals.update(
             {
                 "product_id": product.id,
                 "product_uom_qty": import_line["qty"],
                 "product_uom_id": uom.id,
                 "company_id": company_id,
+                "currency_id": currency_id,
             }
         )
         assert price_source, "price_source must be defined"
@@ -575,6 +581,20 @@ class SaleOrderImport(models.TransientModel):
         elif isinstance(order, dict):
             company_id = order.get("company_id") or company_id
         return company_id
+
+    def _prepare_order_line_get_currency_id(self, order):
+        currency_id = self.env.company.currency_id.id
+        if isinstance(order, models.Model):
+            currency_id = order.currency_id.id
+        elif isinstance(order, dict):
+            pricelist_id = order.get("pricelist_id")
+            if pricelist_id:
+                currency_id = (
+                    self.env["product.pricelist"].browse(pricelist_id).currency_id.id
+                )
+            else:
+                currency_id = order.get("currency_id", currency_id)
+        return currency_id
 
     # TODO: add tests
     @api.model


### PR DESCRIPTION
`_prepare_create_order_line` already pre-populated `company_id` in `vals` before calling `play_onchanges` (see f26937de) because `sale.order.line.company_id` is a related field that ends up empty otherwise. `currency_id` has the exact same problem -- related, readonly, no inverse -- so `play_onchanges` drops it from `so_vals` and later bakes an explicit `False` into the line's cache, which crashes any percentage/formula pricelist rule with:

    ValueError: Expected singleton: res.currency()

Apply the same fix pattern: add `_prepare_order_line_get_currency_id`, mirroring `_prepare_order_line_get_company_id`, and pre-populate `currency_id` in `vals` before `play_onchanges` runs.