### PR TITLE
[19.0][IMP] account_invoice_import: add option force_no_vat_deduction to _pre_process_parsed_inv_taxes()

### DIFF
--- a/account_invoice_import/wizard/account_invoice_import.py
+++ b/account_invoice_import/wizard/account_invoice_import.py
@@ -707,13 +707,14 @@ class AccountInvoiceImport(models.TransientModel):
             )
 
     @api.model
-    def _pre_process_parsed_inv_taxes(self, parsed_inv, company):
+    def _pre_process_parsed_inv_taxes(
+        self, parsed_inv, company, force_no_vat_deduction=False
+    ):
         """Handle taxes in pre_processing parsed invoice."""
         # Handle the case where we import an invoice with VAT in a company that
         # cannot deduct VAT
-        if (
-            parsed_inv["type"] in ("in_invoice", "in_refund")
-            and company._cannot_refund_vat()
+        if parsed_inv["type"] in ("in_invoice", "in_refund") and (
+            company._cannot_refund_vat() or force_no_vat_deduction
         ):
             parsed_inv["amount_tax"] = 0
             parsed_inv["amount_untaxed"] = parsed_inv["amount_total"]


### PR DESCRIPTION
Port of #1386 to 19.0 (cherry-pick, no adaptation needed — the method is identical on this branch).

The option lets a caller state that VAT must not be deducted on this particular vendor bill, on top of the existing company-level `_cannot_refund_vat()`. It is consumed by `l10n_fr_einvoicing_import` in [akretion/fr-einvoicing](https://github.com/akretion/fr-einvoicing), where an entity with both a taxable and a non-taxable sector can dedicate a directory line to the non-taxable one and flag it "no VAT deduction".

Default is `False`, so behaviour is unchanged for every existing caller.

Same change proposed for 16.0 in the companion PR.
