### PR TITLE
[18.0][FIX] sale_order_import[_ubl]: avoid partner duplicated creation on import

### DIFF
--- a/sale_order_import/tests/test_order_import.py
+++ b/sale_order_import/tests/test_order_import.py
@@ -271,6 +271,7 @@ class TestOrderImport(TestCommon):
                 "country_code": "FR",
                 "email": "test@invoice.partner",
                 "name": "Test Invoice Address",
+                "street": "123 Main St",
             },
         )
         wiz = self.wiz_model.with_context(create_missing_invoice_partner=True)
@@ -283,6 +284,7 @@ class TestOrderImport(TestCommon):
         self.assertEqual(invoice_partner.country_id, self.env.ref("base.fr"))
         self.assertEqual(invoice_partner.email, "test@invoice.partner")
         self.assertEqual(invoice_partner.name, "Test Invoice Address")
+        self.assertEqual(invoice_partner.street, "123 Main St")
         self.assertEqual(order.partner_invoice_id, invoice_partner)
         self.assertIn("Created invoice partner", order.message_ids[0].body)
 
@@ -297,6 +299,7 @@ class TestOrderImport(TestCommon):
                 "country_code": "FR",
                 "email": "test@invoice.partner",
                 "name": "Test Invoice Address",
+                "street": "123 Main St",
             },
         )
         wiz = self.wiz_model

--- a/sale_order_import/wizard/sale_order_import.py
+++ b/sale_order_import/wizard/sale_order_import.py
@@ -422,24 +422,31 @@ class SaleOrderImport(models.TransientModel):
             parsed_order["partner"], [], partner_type="customer"
         )
         commercial_partner = partner.commercial_partner_id
-        partner_shipping_id = False
-        if parsed_order.get("ship_to"):
-            try:
-                partner_shipping_id = bdio._match_shipping_partner(
-                    parsed_order["ship_to"], partner, []
-                ).id
-            except UserError:
-                if not self._can_create_missing_shipping_partner():
-                    raise
-                partner_shipping_id = self._create_missing_shipping_partner(
-                    parsed_order["ship_to"], partner, []
-                ).id
         existing_quotations = self.env["sale.order"].search(
             self._search_existing_order_domain(
                 parsed_order, commercial_partner, [("state", "in", ("draft", "sent"))]
             )
         )
         if existing_quotations:
+            # Update the shipping partner if necessary
+            # NB: run this part of code only if a quotation exists already to prevent
+            # duplication of shipping partners in case the wizard tries to create a new
+            # one: if this snippet is executed *before* the ``if`` condition and a
+            # record is created, then a new one might be created again with the exact
+            # same data if no quotation exists and ``self.create_order_return_action()``
+            # is executed instead, leading to duplicated ``res.partner`` records
+            partner_shipping_id = False
+            if parsed_order.get("ship_to"):
+                try:
+                    partner_shipping_id = bdio._match_shipping_partner(
+                        parsed_order["ship_to"], partner, []
+                    ).id
+                except UserError:
+                    if not self._can_create_missing_shipping_partner():
+                        raise
+                    partner_shipping_id = self._create_missing_shipping_partner(
+                        parsed_order["ship_to"], partner, []
+                    ).id
             default_sale_id = False
             if len(existing_quotations) == 1:
                 default_sale_id = existing_quotations[0].id

--- a/sale_order_import_ubl/tests/files/UBL-Order-2.1-Example-CreateInvoicePartner.xml
+++ b/sale_order_import_ubl/tests/files/UBL-Order-2.1-Example-CreateInvoicePartner.xml
@@ -1,0 +1,411 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<Order
+    xmlns="urn:oasis:names:specification:ubl:schema:xsd:Order-2"
+    xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+    xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2"
+>
+    <cbc:UBLVersionID>2.1</cbc:UBLVersionID>
+    <cbc:CustomizationID
+    >urn:www.cenbii.eu:transaction:biicoretrdm001:ver1.0</cbc:CustomizationID>
+    <cbc:ProfileID
+        schemeAgencyID="BII"
+        schemeID="Profile"
+    >urn:www.cenbii.eu:profile:BII01:ver1.0</cbc:ProfileID>
+    <cbc:ID>34</cbc:ID>
+    <cbc:IssueDate>2010-01-20</cbc:IssueDate>
+    <cbc:IssueTime>12:30:00</cbc:IssueTime>
+    <cbc:Note>Information text for the whole order</cbc:Note>
+    <cbc:DocumentCurrencyCode>SEK</cbc:DocumentCurrencyCode>
+    <cbc:AccountingCostCode>Project123</cbc:AccountingCostCode>
+    <cac:ValidityPeriod>
+        <cbc:EndDate>2010-01-31</cbc:EndDate>
+    </cac:ValidityPeriod>
+    <cac:QuotationDocumentReference>
+        <cbc:ID>QuoteID123</cbc:ID>
+    </cac:QuotationDocumentReference>
+    <cac:OrderDocumentReference>
+        <cbc:ID>RjectedOrderID123</cbc:ID>
+    </cac:OrderDocumentReference>
+    <cac:OriginatorDocumentReference>
+        <cbc:ID>MAFO</cbc:ID>
+    </cac:OriginatorDocumentReference>
+    <cac:AdditionalDocumentReference>
+        <cbc:ID>Doc1</cbc:ID>
+        <cbc:DocumentType>Timesheet</cbc:DocumentType>
+        <cac:Attachment>
+            <cac:ExternalReference>
+                <cbc:URI>http://www.suppliersite.eu/sheet001.html</cbc:URI>
+            </cac:ExternalReference>
+        </cac:Attachment>
+    </cac:AdditionalDocumentReference>
+    <cac:AdditionalDocumentReference>
+        <cbc:ID>Doc2</cbc:ID>
+        <cbc:DocumentType>Drawing</cbc:DocumentType>
+        <cac:Attachment>
+            <cbc:EmbeddedDocumentBinaryObject
+                mimeCode="application/pdf"
+            >UjBsR09EbGhjZ0dTQUxNQUFBUUNBRU1tQ1p0dU1GUXhEUzhi</cbc:EmbeddedDocumentBinaryObject>
+        </cac:Attachment>
+    </cac:AdditionalDocumentReference>
+    <cac:Contract>
+        <cbc:ID>34322</cbc:ID>
+        <cbc:ContractType>FrameworkAgreementID123</cbc:ContractType>
+    </cac:Contract>
+    <cac:BuyerCustomerParty>
+        <cac:Party>
+            <cbc:EndpointID
+                schemeAgencyID="9"
+                schemeID="GLN"
+            >7300072311115</cbc:EndpointID>
+            <cac:PartyIdentification>
+                <cbc:ID schemeAgencyID="9" schemeID="GLN">7300070011115</cbc:ID>
+            </cac:PartyIdentification>
+            <cac:PartyIdentification>
+                <cbc:ID>PartyID123</cbc:ID>
+            </cac:PartyIdentification>
+            <cac:PartyName>
+                <cbc:Name>Johnssons byggvaror</cbc:Name>
+            </cac:PartyName>
+            <cac:PostalAddress>
+                <cbc:ID schemeAgencyID="9" schemeID="GLN">1234567890123</cbc:ID>
+                <cbc:Postbox>PoBox123</cbc:Postbox>
+                <cbc:StreetName>Rådhusgatan</cbc:StreetName>
+                <cbc:AdditionalStreetName>2nd floor</cbc:AdditionalStreetName>
+                <cbc:BuildingNumber>5</cbc:BuildingNumber>
+                <cbc:Department>Purchasing department</cbc:Department>
+                <cbc:CityName>Stockholm</cbc:CityName>
+                <cbc:PostalZone>11000</cbc:PostalZone>
+                <cbc:CountrySubentity>RegionX</cbc:CountrySubentity>
+                <cac:Country>
+                    <cbc:IdentificationCode>SE</cbc:IdentificationCode>
+                </cac:Country>
+            </cac:PostalAddress>
+            <cac:PartyTaxScheme>
+                <cbc:RegistrationName
+                >Herra Johnssons byggvaror AS</cbc:RegistrationName>
+                <cbc:CompanyID>SE1234567801</cbc:CompanyID>
+                <cac:RegistrationAddress>
+                    <cbc:CityName>Stockholm</cbc:CityName>
+                    <cac:Country>
+                        <cbc:IdentificationCode>SE</cbc:IdentificationCode>
+                    </cac:Country>
+                </cac:RegistrationAddress>
+                <cac:TaxScheme>
+                    <cbc:ID schemeID="UN/ECE 5153" schemeAgencyID="6">VAT</cbc:ID>
+                </cac:TaxScheme>
+            </cac:PartyTaxScheme>
+            <cac:PartyLegalEntity>
+                <cbc:RegistrationName>Johnssons Byggvaror AB</cbc:RegistrationName>
+                <cbc:CompanyID schemeID="SE:ORGNR">5532331183</cbc:CompanyID>
+                <cac:RegistrationAddress>
+                    <cbc:CityName>Stockholm</cbc:CityName>
+                    <cbc:CountrySubentity>RegionX</cbc:CountrySubentity>
+                    <cac:Country>
+                        <cbc:IdentificationCode>SE</cbc:IdentificationCode>
+                    </cac:Country>
+                </cac:RegistrationAddress>
+            </cac:PartyLegalEntity>
+            <cac:Contact>
+                <cbc:Telephone>123456</cbc:Telephone>
+                <cbc:Telefax>123456</cbc:Telefax>
+                <cbc:ElectronicMail>pelle@johnsson.se</cbc:ElectronicMail>
+            </cac:Contact>
+            <cac:Person>
+                <cbc:FirstName>Pelle</cbc:FirstName>
+                <cbc:FamilyName>Svensson</cbc:FamilyName>
+                <cbc:MiddleName>X</cbc:MiddleName>
+                <cbc:JobTitle>Boss</cbc:JobTitle>
+            </cac:Person>
+        </cac:Party>
+        <cac:DeliveryContact>
+            <cbc:Name>Eva Johnsson</cbc:Name>
+            <cbc:Telephone>1234356</cbc:Telephone>
+            <cbc:Telefax>123455</cbc:Telefax>
+            <cbc:ElectronicMail>eva@johnsson.se</cbc:ElectronicMail>
+        </cac:DeliveryContact>
+    </cac:BuyerCustomerParty>
+    <cac:SellerSupplierParty>
+        <cac:Party>
+            <cbc:EndpointID
+                schemeAgencyID="9"
+                schemeID="GLN"
+            >7302347231111</cbc:EndpointID>
+            <cac:PartyIdentification>
+                <cbc:ID>SellerPartyID123</cbc:ID>
+            </cac:PartyIdentification>
+            <cac:PartyName>
+                <cbc:Name>Moderna Produkter AB</cbc:Name>
+            </cac:PartyName>
+            <cac:PostalAddress>
+                <cbc:ID schemeAgencyID="9" schemeID="GLN">0987654321123</cbc:ID>
+                <cbc:Postbox>321</cbc:Postbox>
+                <cbc:StreetName>Kungsgatan</cbc:StreetName>
+                <cbc:AdditionalStreetName>suite12</cbc:AdditionalStreetName>
+                <cbc:BuildingNumber>22</cbc:BuildingNumber>
+                <cbc:Department>Sales department</cbc:Department>
+                <cbc:CityName>Stockholm</cbc:CityName>
+                <cbc:PostalZone>11000</cbc:PostalZone>
+                <cbc:CountrySubentity>RegionX</cbc:CountrySubentity>
+                <cac:Country>
+                    <cbc:IdentificationCode>SE</cbc:IdentificationCode>
+                </cac:Country>
+            </cac:PostalAddress>
+            <cac:PartyLegalEntity>
+                <cbc:RegistrationName>Moderna Produkter AB</cbc:RegistrationName>
+                <cbc:CompanyID schemeID="SE:ORGNR">5532332283</cbc:CompanyID>
+                <cac:RegistrationAddress>
+                    <cbc:CityName>Stockholm</cbc:CityName>
+                    <cbc:CountrySubentity>RegionX</cbc:CountrySubentity>
+                    <cac:Country>
+                        <cbc:IdentificationCode>SE</cbc:IdentificationCode>
+                    </cac:Country>
+                </cac:RegistrationAddress>
+            </cac:PartyLegalEntity>
+            <cac:Contact>
+                <cbc:Telephone>34557</cbc:Telephone>
+                <cbc:Telefax>3456767</cbc:Telefax>
+                <cbc:ElectronicMail>lars@moderna.se</cbc:ElectronicMail>
+            </cac:Contact>
+            <cac:Person>
+                <cbc:FirstName>Lars</cbc:FirstName>
+                <cbc:FamilyName>Petersen</cbc:FamilyName>
+                <cbc:MiddleName>M</cbc:MiddleName>
+                <cbc:JobTitle>Sales manager</cbc:JobTitle>
+            </cac:Person>
+        </cac:Party>
+    </cac:SellerSupplierParty>
+    <cac:OriginatorCustomerParty>
+        <cac:Party>
+            <cac:PartyIdentification>
+                <cbc:ID schemeAgencyID="9" schemeID="GLN">0987678321123</cbc:ID>
+            </cac:PartyIdentification>
+            <cac:PartyName>
+                <cbc:Name>Moderna Produkter AB</cbc:Name>
+            </cac:PartyName>
+            <cac:Contact>
+                <cbc:Telephone>346788</cbc:Telephone>
+                <cbc:Telefax>8567443</cbc:Telefax>
+                <cbc:ElectronicMail>sven@moderna.se</cbc:ElectronicMail>
+            </cac:Contact>
+            <cac:Person>
+                <cbc:FirstName>Sven</cbc:FirstName>
+                <cbc:FamilyName>Pereson</cbc:FamilyName>
+                <cbc:MiddleName>N</cbc:MiddleName>
+                <cbc:JobTitle>Stuffuser</cbc:JobTitle>
+            </cac:Person>
+        </cac:Party>
+    </cac:OriginatorCustomerParty>
+    <cac:AccountingCustomerParty>
+        <cac:Party>
+            <cbc:EndpointID
+                schemeAgencyID="9"
+                schemeID="GLN"
+            >7300072311116</cbc:EndpointID>
+            <cac:PartyIdentification>
+                <cbc:ID schemeAgencyID="9" schemeID="GLN">7300070011116</cbc:ID>
+            </cac:PartyIdentification>
+            <cac:PartyIdentification>
+                <cbc:ID>PartyID124</cbc:ID>
+            </cac:PartyIdentification>
+            <cac:PartyName>
+                <cbc:Name>Invoicing Address Name</cbc:Name>
+            </cac:PartyName>
+            <cac:PostalAddress>
+                <cbc:ID schemeAgencyID="9" schemeID="GLN">1234567890123</cbc:ID>
+                <cbc:Postbox>Inv123</cbc:Postbox>
+                <cbc:StreetName>Invoice Street</cbc:StreetName>
+                <cbc:AdditionalStreetName>Invoice floor</cbc:AdditionalStreetName>
+                <cbc:BuildingNumber>6</cbc:BuildingNumber>
+                <cbc:Department>Invoicing department</cbc:Department>
+                <cbc:CityName>Stockholm</cbc:CityName>
+                <cbc:PostalZone>11000</cbc:PostalZone>
+                <cbc:CountrySubentity>RegionY</cbc:CountrySubentity>
+                <cac:Country>
+                    <cbc:IdentificationCode>SE</cbc:IdentificationCode>
+                </cac:Country>
+            </cac:PostalAddress>
+            <cac:PartyTaxScheme>
+                <cbc:RegistrationName
+                >Herra Johnssons byggvaror AS</cbc:RegistrationName>
+                <cbc:CompanyID>SE123456789701</cbc:CompanyID>
+                <cac:RegistrationAddress>
+                    <cbc:CityName>Stockholm</cbc:CityName>
+                    <cac:Country>
+                        <cbc:IdentificationCode>SE</cbc:IdentificationCode>
+                    </cac:Country>
+                </cac:RegistrationAddress>
+                <cac:TaxScheme>
+                    <cbc:ID schemeID="UN/ECE 5153" schemeAgencyID="6">VAT</cbc:ID>
+                </cac:TaxScheme>
+            </cac:PartyTaxScheme>
+            <cac:Contact>
+                <cbc:ElectronicMail>test-invoice-partner@test.se</cbc:ElectronicMail>
+            </cac:Contact>
+        </cac:Party>
+        <cac:DeliveryContact>
+            <cbc:Name>Eva Johnsson</cbc:Name>
+            <cbc:Telephone>1234356</cbc:Telephone>
+            <cbc:Telefax>123455</cbc:Telefax>
+            <cbc:ElectronicMail>eva@johnsson.se</cbc:ElectronicMail>
+        </cac:DeliveryContact>
+    </cac:AccountingCustomerParty>
+    <cac:Delivery>
+        <cbc:LatestDeliveryDate>2010-02-26</cbc:LatestDeliveryDate>
+        <cbc:LatestDeliveryTime>18:00:00.0Z</cbc:LatestDeliveryTime>
+        <cac:DeliveryLocation>
+            <cac:Address>
+                <cbc:ID schemeAgencyID="9" schemeID="GLN">1234567890123</cbc:ID>
+                <cbc:Postbox>123</cbc:Postbox>
+                <cbc:StreetName>Rådhusgatan</cbc:StreetName>
+                <cbc:AdditionalStreetName>2nd floor</cbc:AdditionalStreetName>
+                <cbc:BuildingNumber>5</cbc:BuildingNumber>
+                <cbc:Department>Purchasing department</cbc:Department>
+                <cbc:CityName>Stockholm</cbc:CityName>
+                <cbc:PostalZone>11000</cbc:PostalZone>
+                <cbc:CountrySubentity>RegionX</cbc:CountrySubentity>
+                <cac:Country>
+                    <cbc:IdentificationCode>SE</cbc:IdentificationCode>
+                </cac:Country>
+            </cac:Address>
+        </cac:DeliveryLocation>
+        <cac:RequestedDeliveryPeriod>
+            <cbc:StartDate>2010-02-10</cbc:StartDate>
+            <cbc:EndDate>2010-02-25</cbc:EndDate>
+        </cac:RequestedDeliveryPeriod>
+        <cac:DeliveryParty>
+            <cac:PartyIdentification>
+                <cbc:ID schemeAgencyID="9" schemeID="GLN">67654328394567</cbc:ID>
+            </cac:PartyIdentification>
+            <cac:PartyName>
+                <cbc:Name>Swedish trucking</cbc:Name>
+            </cac:PartyName>
+            <cac:Contact>
+                <cbc:Name>Per</cbc:Name>
+                <cbc:Telephone>987098709</cbc:Telephone>
+                <cbc:Telefax>34673435</cbc:Telefax>
+                <cbc:ElectronicMail>bill@svetruck.se</cbc:ElectronicMail>
+            </cac:Contact>
+        </cac:DeliveryParty>
+    </cac:Delivery>
+    <cac:DeliveryTerms>
+        <cbc:ID schemeAgencyID="6" schemeID="IMCOTERM">FOT</cbc:ID>
+        <cbc:SpecialTerms>CAD</cbc:SpecialTerms>
+        <cac:DeliveryLocation>
+            <cbc:ID>STO</cbc:ID>
+        </cac:DeliveryLocation>
+    </cac:DeliveryTerms>
+    <cac:AllowanceCharge>
+        <cbc:ChargeIndicator>true</cbc:ChargeIndicator>
+        <cbc:AllowanceChargeReason>Transport documents</cbc:AllowanceChargeReason>
+        <cbc:Amount currencyID="SEK">100</cbc:Amount>
+    </cac:AllowanceCharge>
+    <cac:AllowanceCharge>
+        <cbc:ChargeIndicator>false</cbc:ChargeIndicator>
+        <cbc:AllowanceChargeReason
+        >Total order value discount</cbc:AllowanceChargeReason>
+        <cbc:Amount currencyID="SEK">100</cbc:Amount>
+    </cac:AllowanceCharge>
+    <cac:TaxTotal>
+        <cbc:TaxAmount currencyID="SEK">100</cbc:TaxAmount>
+    </cac:TaxTotal>
+    <cac:AnticipatedMonetaryTotal>
+        <cbc:LineExtensionAmount currencyID="SEK">6225</cbc:LineExtensionAmount>
+        <cbc:AllowanceTotalAmount currencyID="SEK">100</cbc:AllowanceTotalAmount>
+        <cbc:ChargeTotalAmount currencyID="SEK">100</cbc:ChargeTotalAmount>
+        <cbc:PayableAmount currencyID="SEK">6225</cbc:PayableAmount>
+    </cac:AnticipatedMonetaryTotal>
+    <cac:OrderLine>
+        <cbc:Note>Freetext note on line 1</cbc:Note>
+        <cac:LineItem>
+            <cbc:ID>1</cbc:ID>
+            <cbc:Quantity unitCode="LTR">120</cbc:Quantity>
+            <cbc:LineExtensionAmount currencyID="SEK">6000</cbc:LineExtensionAmount>
+            <cbc:TotalTaxAmount currencyID="SEK">10</cbc:TotalTaxAmount>
+            <cbc:PartialDeliveryIndicator>false</cbc:PartialDeliveryIndicator>
+            <cbc:AccountingCostCode>ProjectID123</cbc:AccountingCostCode>
+            <cac:Delivery>
+                <cac:RequestedDeliveryPeriod>
+                    <cbc:StartDate>2010-02-10</cbc:StartDate>
+                    <cbc:EndDate>2010-02-25</cbc:EndDate>
+                </cac:RequestedDeliveryPeriod>
+            </cac:Delivery>
+            <cac:OriginatorParty>
+                <cac:PartyIdentification>
+                    <cbc:ID schemeAgencyID="ZZZ" schemeID="ZZZ">EmployeeXXX</cbc:ID>
+                </cac:PartyIdentification>
+                <cac:PartyName>
+                    <cbc:Name>Josef K.</cbc:Name>
+                </cac:PartyName>
+            </cac:OriginatorParty>
+            <cac:Price>
+                <cbc:PriceAmount currencyID="SEK">50</cbc:PriceAmount>
+                <cbc:BaseQuantity unitCode="LTR">1</cbc:BaseQuantity>
+            </cac:Price>
+            <cac:Item>
+                <cbc:Description>Red paint</cbc:Description>
+                <cbc:Name>Falu Rödfärg</cbc:Name>
+                <cac:SellersItemIdentification>
+                    <cbc:ID>SItemNo001</cbc:ID>
+                </cac:SellersItemIdentification>
+                <cac:StandardItemIdentification>
+                    <cbc:ID schemeAgencyID="6" schemeID="GTIN">1234567890123</cbc:ID>
+                </cac:StandardItemIdentification>
+                <cac:AdditionalItemProperty>
+                    <cbc:Name>Paint type</cbc:Name>
+                    <cbc:Value>Acrylic</cbc:Value>
+                </cac:AdditionalItemProperty>
+                <cac:AdditionalItemProperty>
+                    <cbc:Name>Solvant</cbc:Name>
+                    <cbc:Value>Water</cbc:Value>
+                </cac:AdditionalItemProperty>
+            </cac:Item>
+        </cac:LineItem>
+    </cac:OrderLine>
+    <cac:OrderLine>
+        <cbc:Note>Freetext note on line 2</cbc:Note>
+        <cac:LineItem>
+            <cbc:ID>2</cbc:ID>
+            <cbc:Quantity unitCode="C62">15</cbc:Quantity>
+            <cbc:LineExtensionAmount currencyID="SEK">225</cbc:LineExtensionAmount>
+            <cbc:TotalTaxAmount currencyID="SEK">10</cbc:TotalTaxAmount>
+            <cbc:PartialDeliveryIndicator>false</cbc:PartialDeliveryIndicator>
+            <cbc:AccountingCostCode>ProjectID123</cbc:AccountingCostCode>
+            <cac:Delivery>
+                <cac:RequestedDeliveryPeriod>
+                    <cbc:StartDate>2010-02-10</cbc:StartDate>
+                    <cbc:EndDate>2010-02-25</cbc:EndDate>
+                </cac:RequestedDeliveryPeriod>
+            </cac:Delivery>
+            <cac:OriginatorParty>
+                <cac:PartyIdentification>
+                    <cbc:ID schemeAgencyID="ZZZ" schemeID="ZZZ">EmployeeXXX</cbc:ID>
+                </cac:PartyIdentification>
+                <cac:PartyName>
+                    <cbc:Name>Josef K.</cbc:Name>
+                </cac:PartyName>
+            </cac:OriginatorParty>
+            <cac:Price>
+                <cbc:PriceAmount currencyID="SEK">15</cbc:PriceAmount>
+                <cbc:BaseQuantity unitCode="C62">1</cbc:BaseQuantity>
+            </cac:Price>
+            <cac:Item>
+                <cbc:Description>Very good pencils for red paint.</cbc:Description>
+                <cbc:Name>Pensel 20 mm</cbc:Name>
+                <cac:SellersItemIdentification>
+                    <cbc:ID>SItemNo011</cbc:ID>
+                </cac:SellersItemIdentification>
+                <cac:StandardItemIdentification>
+                    <cbc:ID schemeAgencyID="6" schemeID="GTIN">1122334455</cbc:ID>
+                </cac:StandardItemIdentification>
+                <cac:AdditionalItemProperty>
+                    <cbc:Name>Hair color</cbc:Name>
+                    <cbc:Value>Black</cbc:Value>
+                </cac:AdditionalItemProperty>
+                <cac:AdditionalItemProperty>
+                    <cbc:Name>Width</cbc:Name>
+                    <cbc:Value>20mm</cbc:Value>
+                </cac:AdditionalItemProperty>
+            </cac:Item>
+        </cac:LineItem>
+    </cac:OrderLine>
+</Order>

--- a/sale_order_import_ubl/tests/files/UBL-Order-2.1-Example-CreateShippingPartner.xml
+++ b/sale_order_import_ubl/tests/files/UBL-Order-2.1-Example-CreateShippingPartner.xml
@@ -1,0 +1,397 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<Order
+    xmlns="urn:oasis:names:specification:ubl:schema:xsd:Order-2"
+    xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+    xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2"
+>
+    <cbc:UBLVersionID>2.1</cbc:UBLVersionID>
+    <cbc:CustomizationID
+    >urn:www.cenbii.eu:transaction:biicoretrdm001:ver1.0</cbc:CustomizationID>
+    <cbc:ProfileID
+        schemeAgencyID="BII"
+        schemeID="Profile"
+    >urn:www.cenbii.eu:profile:BII01:ver1.0</cbc:ProfileID>
+    <cbc:ID>34</cbc:ID>
+    <cbc:IssueDate>2010-01-20</cbc:IssueDate>
+    <cbc:IssueTime>12:30:00</cbc:IssueTime>
+    <cbc:Note>Information text for the whole order</cbc:Note>
+    <cbc:DocumentCurrencyCode>SEK</cbc:DocumentCurrencyCode>
+    <cbc:AccountingCostCode>Project123</cbc:AccountingCostCode>
+    <cac:ValidityPeriod>
+        <cbc:EndDate>2010-01-31</cbc:EndDate>
+    </cac:ValidityPeriod>
+    <cac:QuotationDocumentReference>
+        <cbc:ID>QuoteID123</cbc:ID>
+    </cac:QuotationDocumentReference>
+    <cac:OrderDocumentReference>
+        <cbc:ID>RjectedOrderID123</cbc:ID>
+    </cac:OrderDocumentReference>
+    <cac:OriginatorDocumentReference>
+        <cbc:ID>MAFO</cbc:ID>
+    </cac:OriginatorDocumentReference>
+    <cac:AdditionalDocumentReference>
+        <cbc:ID>Doc1</cbc:ID>
+        <cbc:DocumentType>Timesheet</cbc:DocumentType>
+        <cac:Attachment>
+            <cac:ExternalReference>
+                <cbc:URI>http://www.suppliersite.eu/sheet001.html</cbc:URI>
+            </cac:ExternalReference>
+        </cac:Attachment>
+    </cac:AdditionalDocumentReference>
+    <cac:AdditionalDocumentReference>
+        <cbc:ID>Doc2</cbc:ID>
+        <cbc:DocumentType>Drawing</cbc:DocumentType>
+        <cac:Attachment>
+            <cbc:EmbeddedDocumentBinaryObject
+                mimeCode="application/pdf"
+            >UjBsR09EbGhjZ0dTQUxNQUFBUUNBRU1tQ1p0dU1GUXhEUzhi</cbc:EmbeddedDocumentBinaryObject>
+        </cac:Attachment>
+    </cac:AdditionalDocumentReference>
+    <cac:Contract>
+        <cbc:ID>34322</cbc:ID>
+        <cbc:ContractType>FrameworkAgreementID123</cbc:ContractType>
+    </cac:Contract>
+    <cac:BuyerCustomerParty>
+        <cac:Party>
+            <cbc:EndpointID
+                schemeAgencyID="9"
+                schemeID="GLN"
+            >7300072311115</cbc:EndpointID>
+            <cac:PartyIdentification>
+                <cbc:ID schemeAgencyID="9" schemeID="GLN">7300070011115</cbc:ID>
+            </cac:PartyIdentification>
+            <cac:PartyIdentification>
+                <cbc:ID>PartyID123</cbc:ID>
+            </cac:PartyIdentification>
+            <cac:PartyName>
+                <cbc:Name>Johnssons byggvaror</cbc:Name>
+            </cac:PartyName>
+            <cac:PostalAddress>
+                <cbc:ID schemeAgencyID="9" schemeID="GLN">1234567890123</cbc:ID>
+                <cbc:Postbox>PoBox123</cbc:Postbox>
+                <cbc:StreetName>Rådhusgatan</cbc:StreetName>
+                <cbc:AdditionalStreetName>2nd floor</cbc:AdditionalStreetName>
+                <cbc:BuildingNumber>5</cbc:BuildingNumber>
+                <cbc:Department>Purchasing department</cbc:Department>
+                <cbc:CityName>Stockholm</cbc:CityName>
+                <cbc:PostalZone>11000</cbc:PostalZone>
+                <cbc:CountrySubentity>RegionX</cbc:CountrySubentity>
+                <cac:Country>
+                    <cbc:IdentificationCode>SE</cbc:IdentificationCode>
+                </cac:Country>
+            </cac:PostalAddress>
+            <cac:PartyTaxScheme>
+                <cbc:RegistrationName
+                >Herra Johnssons byggvaror AS</cbc:RegistrationName>
+                <cbc:CompanyID>SE1234567801</cbc:CompanyID>
+                <cac:RegistrationAddress>
+                    <cbc:CityName>Stockholm</cbc:CityName>
+                    <cac:Country>
+                        <cbc:IdentificationCode>SE</cbc:IdentificationCode>
+                    </cac:Country>
+                </cac:RegistrationAddress>
+                <cac:TaxScheme>
+                    <cbc:ID schemeID="UN/ECE 5153" schemeAgencyID="6">VAT</cbc:ID>
+                </cac:TaxScheme>
+            </cac:PartyTaxScheme>
+            <cac:PartyLegalEntity>
+                <cbc:RegistrationName>Johnssons Byggvaror AB</cbc:RegistrationName>
+                <cbc:CompanyID schemeID="SE:ORGNR">5532331183</cbc:CompanyID>
+                <cac:RegistrationAddress>
+                    <cbc:CityName>Stockholm</cbc:CityName>
+                    <cbc:CountrySubentity>RegionX</cbc:CountrySubentity>
+                    <cac:Country>
+                        <cbc:IdentificationCode>SE</cbc:IdentificationCode>
+                    </cac:Country>
+                </cac:RegistrationAddress>
+            </cac:PartyLegalEntity>
+            <cac:Contact>
+                <cbc:Telephone>123456</cbc:Telephone>
+                <cbc:Telefax>123456</cbc:Telefax>
+                <cbc:ElectronicMail>pelle@johnsson.se</cbc:ElectronicMail>
+            </cac:Contact>
+            <cac:Person>
+                <cbc:FirstName>Pelle</cbc:FirstName>
+                <cbc:FamilyName>Svensson</cbc:FamilyName>
+                <cbc:MiddleName>X</cbc:MiddleName>
+                <cbc:JobTitle>Boss</cbc:JobTitle>
+            </cac:Person>
+        </cac:Party>
+        <cac:DeliveryContact>
+            <cbc:Name>Eva Johnsson</cbc:Name>
+            <cbc:Telephone>1234356</cbc:Telephone>
+            <cbc:Telefax>123455</cbc:Telefax>
+            <cbc:ElectronicMail>eva@johnsson.se</cbc:ElectronicMail>
+        </cac:DeliveryContact>
+    </cac:BuyerCustomerParty>
+    <cac:SellerSupplierParty>
+        <cac:Party>
+            <cbc:EndpointID
+                schemeAgencyID="9"
+                schemeID="GLN"
+            >7302347231111</cbc:EndpointID>
+            <cac:PartyIdentification>
+                <cbc:ID>SellerPartyID123</cbc:ID>
+            </cac:PartyIdentification>
+            <cac:PartyName>
+                <cbc:Name>Moderna Produkter AB</cbc:Name>
+            </cac:PartyName>
+            <cac:PostalAddress>
+                <cbc:ID schemeAgencyID="9" schemeID="GLN">0987654321123</cbc:ID>
+                <cbc:Postbox>321</cbc:Postbox>
+                <cbc:StreetName>Kungsgatan</cbc:StreetName>
+                <cbc:AdditionalStreetName>suite12</cbc:AdditionalStreetName>
+                <cbc:BuildingNumber>22</cbc:BuildingNumber>
+                <cbc:Department>Sales department</cbc:Department>
+                <cbc:CityName>Stockholm</cbc:CityName>
+                <cbc:PostalZone>11000</cbc:PostalZone>
+                <cbc:CountrySubentity>RegionX</cbc:CountrySubentity>
+                <cac:Country>
+                    <cbc:IdentificationCode>SE</cbc:IdentificationCode>
+                </cac:Country>
+            </cac:PostalAddress>
+            <cac:PartyLegalEntity>
+                <cbc:RegistrationName>Moderna Produkter AB</cbc:RegistrationName>
+                <cbc:CompanyID schemeID="SE:ORGNR">5532332283</cbc:CompanyID>
+                <cac:RegistrationAddress>
+                    <cbc:CityName>Stockholm</cbc:CityName>
+                    <cbc:CountrySubentity>RegionX</cbc:CountrySubentity>
+                    <cac:Country>
+                        <cbc:IdentificationCode>SE</cbc:IdentificationCode>
+                    </cac:Country>
+                </cac:RegistrationAddress>
+            </cac:PartyLegalEntity>
+            <cac:Contact>
+                <cbc:Telephone>34557</cbc:Telephone>
+                <cbc:Telefax>3456767</cbc:Telefax>
+                <cbc:ElectronicMail>lars@moderna.se</cbc:ElectronicMail>
+            </cac:Contact>
+            <cac:Person>
+                <cbc:FirstName>Lars</cbc:FirstName>
+                <cbc:FamilyName>Petersen</cbc:FamilyName>
+                <cbc:MiddleName>M</cbc:MiddleName>
+                <cbc:JobTitle>Sales manager</cbc:JobTitle>
+            </cac:Person>
+        </cac:Party>
+    </cac:SellerSupplierParty>
+    <cac:OriginatorCustomerParty>
+        <cac:Party>
+            <cac:PartyIdentification>
+                <cbc:ID schemeAgencyID="9" schemeID="GLN">0987678321123</cbc:ID>
+            </cac:PartyIdentification>
+            <cac:PartyName>
+                <cbc:Name>Moderna Produkter AB</cbc:Name>
+            </cac:PartyName>
+            <cac:Contact>
+                <cbc:Telephone>346788</cbc:Telephone>
+                <cbc:Telefax>8567443</cbc:Telefax>
+                <cbc:ElectronicMail>sven@moderna.se</cbc:ElectronicMail>
+            </cac:Contact>
+            <cac:Person>
+                <cbc:FirstName>Sven</cbc:FirstName>
+                <cbc:FamilyName>Pereson</cbc:FamilyName>
+                <cbc:MiddleName>N</cbc:MiddleName>
+                <cbc:JobTitle>Stuffuser</cbc:JobTitle>
+            </cac:Person>
+        </cac:Party>
+    </cac:OriginatorCustomerParty>
+    <cac:AccountingCustomerParty>
+        <cac:Party>
+            <cbc:EndpointID
+                schemeAgencyID="9"
+                schemeID="GLN"
+            >7300072311116</cbc:EndpointID>
+            <cac:PartyIdentification>
+                <cbc:ID schemeAgencyID="9" schemeID="GLN">7300070011116</cbc:ID>
+            </cac:PartyIdentification>
+            <cac:PartyIdentification>
+                <cbc:ID>PartyID124</cbc:ID>
+            </cac:PartyIdentification>
+            <cac:PartyName>
+                <cbc:Name>Pelle Svensson</cbc:Name>
+            </cac:PartyName>
+            <cac:PartyTaxScheme>
+                <cbc:RegistrationName
+                >Herra Johnssons byggvaror AS</cbc:RegistrationName>
+                <cbc:CompanyID>SE1234567801</cbc:CompanyID>
+                <cac:RegistrationAddress>
+                    <cbc:CityName>Stockholm</cbc:CityName>
+                    <cac:Country>
+                        <cbc:IdentificationCode>SE</cbc:IdentificationCode>
+                    </cac:Country>
+                </cac:RegistrationAddress>
+                <cac:TaxScheme>
+                    <cbc:ID schemeID="UN/ECE 5153" schemeAgencyID="6">VAT</cbc:ID>
+                </cac:TaxScheme>
+            </cac:PartyTaxScheme>
+            <cac:Contact>
+                <cbc:ElectronicMail>jack@johnsson.se</cbc:ElectronicMail>
+            </cac:Contact>
+        </cac:Party>
+        <cac:DeliveryContact>
+            <cbc:Name>Eva Johnsson</cbc:Name>
+            <cbc:Telephone>1234356</cbc:Telephone>
+            <cbc:Telefax>123455</cbc:Telefax>
+            <cbc:ElectronicMail>eva@johnsson.se</cbc:ElectronicMail>
+        </cac:DeliveryContact>
+    </cac:AccountingCustomerParty>
+    <cac:Delivery>
+        <cbc:LatestDeliveryDate>2010-02-26</cbc:LatestDeliveryDate>
+        <cbc:LatestDeliveryTime>18:00:00.0Z</cbc:LatestDeliveryTime>
+        <cac:DeliveryLocation>
+            <cac:Address>
+                <cbc:ID schemeAgencyID="9" schemeID="GLN">1234567890123</cbc:ID>
+                <cbc:Postbox>Deli123</cbc:Postbox>
+                <cbc:StreetName>Delivery Street</cbc:StreetName>
+                <cbc:AdditionalStreetName>Delivery floor</cbc:AdditionalStreetName>
+                <cbc:BuildingNumber>7</cbc:BuildingNumber>
+                <cbc:Department>Shipping department</cbc:Department>
+                <cbc:CityName>Stockholm</cbc:CityName>
+                <cbc:PostalZone>11000</cbc:PostalZone>
+                <cbc:CountrySubentity>RegionZ</cbc:CountrySubentity>
+                <cac:Country>
+                    <cbc:IdentificationCode>SE</cbc:IdentificationCode>
+                </cac:Country>
+            </cac:Address>
+        </cac:DeliveryLocation>
+        <cac:RequestedDeliveryPeriod>
+            <cbc:StartDate>2010-02-10</cbc:StartDate>
+            <cbc:EndDate>2010-02-25</cbc:EndDate>
+        </cac:RequestedDeliveryPeriod>
+        <cac:DeliveryParty>
+            <cac:PartyIdentification>
+                <cbc:ID schemeAgencyID="9" schemeID="GLN">67654328394567</cbc:ID>
+            </cac:PartyIdentification>
+            <cac:PartyName>
+                <cbc:Name>Swedish trucking</cbc:Name>
+            </cac:PartyName>
+            <cac:Contact>
+                <cbc:Name>Per</cbc:Name>
+                <cbc:Telephone>987098709</cbc:Telephone>
+                <cbc:Telefax>34673435</cbc:Telefax>
+                <cbc:ElectronicMail>bill@svetruck.se</cbc:ElectronicMail>
+            </cac:Contact>
+        </cac:DeliveryParty>
+    </cac:Delivery>
+    <cac:DeliveryTerms>
+        <cbc:ID schemeAgencyID="6" schemeID="IMCOTERM">FOT</cbc:ID>
+        <cbc:SpecialTerms>CAD</cbc:SpecialTerms>
+        <cac:DeliveryLocation>
+            <cbc:ID>STO</cbc:ID>
+        </cac:DeliveryLocation>
+    </cac:DeliveryTerms>
+    <cac:AllowanceCharge>
+        <cbc:ChargeIndicator>true</cbc:ChargeIndicator>
+        <cbc:AllowanceChargeReason>Transport documents</cbc:AllowanceChargeReason>
+        <cbc:Amount currencyID="SEK">100</cbc:Amount>
+    </cac:AllowanceCharge>
+    <cac:AllowanceCharge>
+        <cbc:ChargeIndicator>false</cbc:ChargeIndicator>
+        <cbc:AllowanceChargeReason
+        >Total order value discount</cbc:AllowanceChargeReason>
+        <cbc:Amount currencyID="SEK">100</cbc:Amount>
+    </cac:AllowanceCharge>
+    <cac:TaxTotal>
+        <cbc:TaxAmount currencyID="SEK">100</cbc:TaxAmount>
+    </cac:TaxTotal>
+    <cac:AnticipatedMonetaryTotal>
+        <cbc:LineExtensionAmount currencyID="SEK">6225</cbc:LineExtensionAmount>
+        <cbc:AllowanceTotalAmount currencyID="SEK">100</cbc:AllowanceTotalAmount>
+        <cbc:ChargeTotalAmount currencyID="SEK">100</cbc:ChargeTotalAmount>
+        <cbc:PayableAmount currencyID="SEK">6225</cbc:PayableAmount>
+    </cac:AnticipatedMonetaryTotal>
+    <cac:OrderLine>
+        <cbc:Note>Freetext note on line 1</cbc:Note>
+        <cac:LineItem>
+            <cbc:ID>1</cbc:ID>
+            <cbc:Quantity unitCode="LTR">120</cbc:Quantity>
+            <cbc:LineExtensionAmount currencyID="SEK">6000</cbc:LineExtensionAmount>
+            <cbc:TotalTaxAmount currencyID="SEK">10</cbc:TotalTaxAmount>
+            <cbc:PartialDeliveryIndicator>false</cbc:PartialDeliveryIndicator>
+            <cbc:AccountingCostCode>ProjectID123</cbc:AccountingCostCode>
+            <cac:Delivery>
+                <cac:RequestedDeliveryPeriod>
+                    <cbc:StartDate>2010-02-10</cbc:StartDate>
+                    <cbc:EndDate>2010-02-25</cbc:EndDate>
+                </cac:RequestedDeliveryPeriod>
+            </cac:Delivery>
+            <cac:OriginatorParty>
+                <cac:PartyIdentification>
+                    <cbc:ID schemeAgencyID="ZZZ" schemeID="ZZZ">EmployeeXXX</cbc:ID>
+                </cac:PartyIdentification>
+                <cac:PartyName>
+                    <cbc:Name>Josef K.</cbc:Name>
+                </cac:PartyName>
+            </cac:OriginatorParty>
+            <cac:Price>
+                <cbc:PriceAmount currencyID="SEK">50</cbc:PriceAmount>
+                <cbc:BaseQuantity unitCode="LTR">1</cbc:BaseQuantity>
+            </cac:Price>
+            <cac:Item>
+                <cbc:Description>Red paint</cbc:Description>
+                <cbc:Name>Falu Rödfärg</cbc:Name>
+                <cac:SellersItemIdentification>
+                    <cbc:ID>SItemNo001</cbc:ID>
+                </cac:SellersItemIdentification>
+                <cac:StandardItemIdentification>
+                    <cbc:ID schemeAgencyID="6" schemeID="GTIN">1234567890123</cbc:ID>
+                </cac:StandardItemIdentification>
+                <cac:AdditionalItemProperty>
+                    <cbc:Name>Paint type</cbc:Name>
+                    <cbc:Value>Acrylic</cbc:Value>
+                </cac:AdditionalItemProperty>
+                <cac:AdditionalItemProperty>
+                    <cbc:Name>Solvant</cbc:Name>
+                    <cbc:Value>Water</cbc:Value>
+                </cac:AdditionalItemProperty>
+            </cac:Item>
+        </cac:LineItem>
+    </cac:OrderLine>
+    <cac:OrderLine>
+        <cbc:Note>Freetext note on line 2</cbc:Note>
+        <cac:LineItem>
+            <cbc:ID>2</cbc:ID>
+            <cbc:Quantity unitCode="C62">15</cbc:Quantity>
+            <cbc:LineExtensionAmount currencyID="SEK">225</cbc:LineExtensionAmount>
+            <cbc:TotalTaxAmount currencyID="SEK">10</cbc:TotalTaxAmount>
+            <cbc:PartialDeliveryIndicator>false</cbc:PartialDeliveryIndicator>
+            <cbc:AccountingCostCode>ProjectID123</cbc:AccountingCostCode>
+            <cac:Delivery>
+                <cac:RequestedDeliveryPeriod>
+                    <cbc:StartDate>2010-02-10</cbc:StartDate>
+                    <cbc:EndDate>2010-02-25</cbc:EndDate>
+                </cac:RequestedDeliveryPeriod>
+            </cac:Delivery>
+            <cac:OriginatorParty>
+                <cac:PartyIdentification>
+                    <cbc:ID schemeAgencyID="ZZZ" schemeID="ZZZ">EmployeeXXX</cbc:ID>
+                </cac:PartyIdentification>
+                <cac:PartyName>
+                    <cbc:Name>Josef K.</cbc:Name>
+                </cac:PartyName>
+            </cac:OriginatorParty>
+            <cac:Price>
+                <cbc:PriceAmount currencyID="SEK">15</cbc:PriceAmount>
+                <cbc:BaseQuantity unitCode="C62">1</cbc:BaseQuantity>
+            </cac:Price>
+            <cac:Item>
+                <cbc:Description>Very good pencils for red paint.</cbc:Description>
+                <cbc:Name>Pensel 20 mm</cbc:Name>
+                <cac:SellersItemIdentification>
+                    <cbc:ID>SItemNo011</cbc:ID>
+                </cac:SellersItemIdentification>
+                <cac:StandardItemIdentification>
+                    <cbc:ID schemeAgencyID="6" schemeID="GTIN">1122334455</cbc:ID>
+                </cac:StandardItemIdentification>
+                <cac:AdditionalItemProperty>
+                    <cbc:Name>Hair color</cbc:Name>
+                    <cbc:Value>Black</cbc:Value>
+                </cac:AdditionalItemProperty>
+                <cac:AdditionalItemProperty>
+                    <cbc:Name>Width</cbc:Name>
+                    <cbc:Value>20mm</cbc:Value>
+                </cac:AdditionalItemProperty>
+            </cac:Item>
+        </cac:LineItem>
+    </cac:OrderLine>
+</Order>

--- a/sale_order_import_ubl/tests/test_ubl_order_import.py
+++ b/sale_order_import_ubl/tests/test_ubl_order_import.py
@@ -7,10 +7,10 @@
 import base64
 
 from odoo import fields
-from odoo.tests.common import TransactionCase
+from odoo.tests.common import RecordCapturer, TransactionCase
 from odoo.tools import mute_logger
 
-from .common import get_test_data
+from .common import _get_file_content, get_test_data
 
 
 class TestUblOrderImport(TransactionCase):
@@ -62,3 +62,82 @@ class TestUblOrderImport(TransactionCase):
                 self.assertEqual(
                     sorted(so.order_line.mapped("product_id").ids), expected_ids
                 )
+
+    @mute_logger("odoo.addons.sale_order_import.wizard.sale_order_import")
+    def test_ubl_order_import_create_missing_invoice_partner(self):
+        """Tests the creation of invoicing address when importing SO UBL files"""
+        filename = "UBL-Order-2.1-Example-CreateInvoicePartner.xml"
+        xml_file = _get_file_content(filename)
+        wiz = self.env["sale.order.import"].create(
+            {
+                "import_type": "xml",
+                "order_file": base64.b64encode(xml_file),
+                "order_filename": filename,
+                "create_missing_invoice_partner": True,
+            }
+        )
+        with RecordCapturer(self.env["res.partner"], []) as rc_partner:
+            action = wiz.import_order_button()
+        so = self.env["sale.order"].browse(action["res_id"])
+        invoice_partner = so.partner_invoice_id
+        self.assertEqual(rc_partner.records, invoice_partner)
+        self.assertRecordValues(
+            invoice_partner,
+            [
+                {
+                    "city": "Stockholm",
+                    "country_code": "SE",
+                    "country_id": self.env.ref("base.se").id,
+                    "email": "test-invoice-partner@test.se",
+                    "name": "Invoicing Address Name",
+                    "parent_id": so.partner_id.id,
+                    "phone": False,
+                    "ref": False,
+                    "street": "Invoice Street",
+                    "street2": "Invoice floor",
+                    "type": "invoice",
+                    "vat": False,
+                    "website": False,
+                    "zip": "11000",
+                }
+            ],
+        )
+
+    @mute_logger("odoo.addons.sale_order_import.wizard.sale_order_import")
+    def test_ubl_order_import_create_missing_shipping_partner(self):
+        """Tests the creation of delivery address when importing SO UBL files"""
+        filename = "UBL-Order-2.1-Example-CreateShippingPartner.xml"
+        xml_file = _get_file_content(filename)
+        wiz = self.env["sale.order.import"].create(
+            {
+                "import_type": "xml",
+                "order_file": base64.b64encode(xml_file),
+                "order_filename": filename,
+                "create_missing_shipping_partner": True,
+            }
+        )
+        with RecordCapturer(self.env["res.partner"], []) as rc_partner:
+            action = wiz.import_order_button()
+        so = self.env["sale.order"].browse(action["res_id"])
+        shipping_partner = so.partner_shipping_id
+        self.assertEqual(rc_partner.records, shipping_partner)
+        self.assertRecordValues(
+            shipping_partner,
+            [
+                {
+                    "city": "Stockholm",
+                    "country_code": "SE",
+                    "country_id": self.env.ref("base.se").id,
+                    "email": "bill@svetruck.se",
+                    "name": "Swedish trucking",
+                    "parent_id": so.partner_id.id,
+                    "phone": "987098709",
+                    "street": "Delivery Street",
+                    "street2": "Delivery floor",
+                    "type": "delivery",
+                    "vat": False,
+                    "website": False,
+                    "zip": "11000",
+                }
+            ],
+        )


### PR DESCRIPTION
Adds a bunch of missing tests, fix for `sale.order.import.import_order_button()` behavior (prevent partner duplication)

NB: as of 28/08/2026, 14:15, tests are failing for (apparently) unrelated reasons (failed tests all belong to `base_import_pdf_by_template_account`)