### PR TITLE
[19.0] [FIX] partner_identification_import: user_error_wrap signature

### DIFF
--- a/partner_identification_import/models/business_document_import.py
+++ b/partner_identification_import/models/business_document_import.py
@@ -57,14 +57,16 @@ class BusinessDocumentImport(models.AbstractModel):
                     )
                 )
             if unmatched:
-                raise self.user_error_wrap(
-                    "_hook_match_partner",
-                    partner_dict,
-                    self.env._(
+                self.user_error_wrap(
+                    method="_hook_match_partner",
+                    data_dict=partner_dict,
+                    error_msg=self.env._(
                         "Odoo couldn't find a partner corresponding to the "
                         "following information extracted from the business document:\n"
                         "%(join_unmatched)s",
                         join_unmatched="or\n".join(unmatched),
                     ),
+                    chatter_msg=chatter_msg,
+                    raise_exception=True,
                 )
         return super()._hook_match_partner(partner_dict, chatter_msg, domain, order)

--- a/partner_identification_import/tests/test_business_document_import.py
+++ b/partner_identification_import/tests/test_business_document_import.py
@@ -1,5 +1,6 @@
 # Copyright 2020 Jacques-Etienne Baudoux <je@bcim.be>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from odoo.exceptions import UserError
 from odoo.tests.common import TransactionCase
 
 
@@ -44,3 +45,10 @@ class TestBaseBusinessDocumentImport(TransactionCase):
         self.partner_dict["contact"] = "Contact2"
         res = self.bdio._match_partner(self.partner_dict, warn, partner_type=False)
         self.assertEqual(res, self.partner1)
+
+    def test_match_partner_unknown_id_number(self):
+        warn = []
+        self.partner_dict["id_number"][0]["value"] = "UNKNOWN"
+        with self.assertRaises(UserError) as cm:
+            self.bdio._match_partner(self.partner_dict, warn, partner_type=False)
+        self.assertIn("UNKNOWN", str(cm.exception))


### PR DESCRIPTION
`user_error_wrap` takes `chatter_msg` and `raise_exception` since 7d240847e, and raises the UserError itself. The hook still called it with the old positional arguments.