### PR TITLE
[FIX] account_invoice_import_ubl: read the item name (BT-153) for the line label

### DIFF
--- a/account_invoice_import_ubl/readme/CONTRIBUTORS.md
+++ b/account_invoice_import_ubl/readme/CONTRIBUTORS.md
@@ -1,2 +1,4 @@
 - Alexis de Lattre \<<alexis.delattre@akretion.com>\>
 - Andrea Stirpe \<<a.stirpe@onestein.nl>\>
+- [teamDSI](https://www.team-dsi.fr):
+  - Antoine Morit \<<amorit@team-dsi.fr>\>

--- a/account_invoice_import_ubl/tests/__init__.py
+++ b/account_invoice_import_ubl/tests/__init__.py
@@ -1,1 +1,2 @@
 from . import test_ubl
+from . import test_ubl_item_name

--- a/account_invoice_import_ubl/tests/files/UBLInvoice-item-name.xml
+++ b/account_invoice_import_ubl/tests/files/UBLInvoice-item-name.xml
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<Invoice
+    xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2"
+    xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+    xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2"
+>
+    <cbc:CustomizationID>urn:cen.eu:en16931:2017</cbc:CustomizationID>
+    <cbc:ID>SAMPLE-NAME-001</cbc:ID>
+    <cbc:IssueDate>2026-09-03</cbc:IssueDate>
+    <cbc:DueDate>2026-10-03</cbc:DueDate>
+    <cbc:InvoiceTypeCode>380</cbc:InvoiceTypeCode>
+    <cbc:DocumentCurrencyCode>EUR</cbc:DocumentCurrencyCode>
+    <cac:AccountingSupplierParty>
+        <cac:Party>
+            <cac:PartyName>
+                <cbc:Name>Sample Hosting Provider</cbc:Name>
+            </cac:PartyName>
+            <cac:PostalAddress>
+                <cbc:StreetName>2 rue de l'Exemple</cbc:StreetName>
+                <cbc:CityName>ROUBAIX</cbc:CityName>
+                <cbc:PostalZone>59100</cbc:PostalZone>
+                <cac:Country>
+                    <cbc:IdentificationCode>FR</cbc:IdentificationCode>
+                </cac:Country>
+            </cac:PostalAddress>
+            <cac:PartyTaxScheme>
+                <cbc:CompanyID>FR00000000000</cbc:CompanyID>
+                <cac:TaxScheme>
+                    <cbc:ID>VAT</cbc:ID>
+                </cac:TaxScheme>
+            </cac:PartyTaxScheme>
+        </cac:Party>
+    </cac:AccountingSupplierParty>
+    <cac:AccountingCustomerParty>
+        <cac:Party>
+            <cac:PartyName>
+                <cbc:Name>Sample Customer</cbc:Name>
+            </cac:PartyName>
+        </cac:Party>
+    </cac:AccountingCustomerParty>
+    <cac:TaxTotal>
+        <cbc:TaxAmount currencyID="EUR">12.00</cbc:TaxAmount>
+    </cac:TaxTotal>
+    <cac:LegalMonetaryTotal>
+        <cbc:LineExtensionAmount currencyID="EUR">60.00</cbc:LineExtensionAmount>
+        <cbc:TaxExclusiveAmount currencyID="EUR">60.00</cbc:TaxExclusiveAmount>
+        <cbc:TaxInclusiveAmount currencyID="EUR">72.00</cbc:TaxInclusiveAmount>
+        <cbc:PayableAmount currencyID="EUR">72.00</cbc:PayableAmount>
+    </cac:LegalMonetaryTotal>
+    <cac:InvoiceLine>
+        <cbc:ID>1</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">10.00</cbc:LineExtensionAmount>
+        <cac:Item>
+            <cbc:Description>a1acfd5913c2472b845a1474bb9c565c</cbc:Description>
+            <cbc:Name>Monthly subscription for instance b2-15</cbc:Name>
+            <cac:ClassifiedTaxCategory>
+                <cbc:ID>S</cbc:ID>
+                <cbc:Percent>20</cbc:Percent>
+                <cac:TaxScheme>
+                    <cbc:ID>VAT</cbc:ID>
+                </cac:TaxScheme>
+            </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+            <cbc:PriceAmount currencyID="EUR">10.00</cbc:PriceAmount>
+        </cac:Price>
+    </cac:InvoiceLine>
+    <cac:InvoiceLine>
+        <cbc:ID>2</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">20.00</cbc:LineExtensionAmount>
+        <cac:Item>
+            <cbc:Description>Legacy free-form description</cbc:Description>
+            <cac:ClassifiedTaxCategory>
+                <cbc:ID>S</cbc:ID>
+                <cbc:Percent>20</cbc:Percent>
+                <cac:TaxScheme>
+                    <cbc:ID>VAT</cbc:ID>
+                </cac:TaxScheme>
+            </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+            <cbc:PriceAmount currencyID="EUR">20.00</cbc:PriceAmount>
+        </cac:Price>
+    </cac:InvoiceLine>
+    <cac:InvoiceLine>
+        <cbc:ID>3</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">30.00</cbc:LineExtensionAmount>
+        <cac:Item>
+            <cac:ClassifiedTaxCategory>
+                <cbc:ID>S</cbc:ID>
+                <cbc:Percent>20</cbc:Percent>
+                <cac:TaxScheme>
+                    <cbc:ID>VAT</cbc:ID>
+                </cac:TaxScheme>
+            </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+            <cbc:PriceAmount currencyID="EUR">30.00</cbc:PriceAmount>
+        </cac:Price>
+    </cac:InvoiceLine>
+</Invoice>

--- a/account_invoice_import_ubl/tests/test_ubl_item_name.py
+++ b/account_invoice_import_ubl/tests/test_ubl_item_name.py
@@ -1,0 +1,38 @@
+# Copyright 2026 teamDSI
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+import base64
+
+from odoo.tests.common import TransactionCase
+from odoo.tools import file_open
+
+
+class TestUblItemName(TransactionCase):
+    """The label of an invoice line must come from BT-153, not BT-154."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.company = cls.env.ref("base.main_company")
+
+    def _parse(self, filename):
+        f = file_open("account_invoice_import_ubl/tests/files/" + filename, "rb")
+        content = f.read()
+        f.close()
+        return self.env["account.invoice.import"].parse_invoice(
+            base64.b64encode(content), filename, self.company
+        )
+
+    def test_line_name_prefers_item_name(self):
+        parsed = self._parse("UBLInvoice-item-name.xml")
+        self.assertEqual(len(parsed["lines"]), 3)
+        # BT-153 and BT-154 are both present and differ: the item name wins,
+        # so that an issuer using the description for an internal identifier
+        # does not end up with a UUID as the label of every line.
+        self.assertEqual(
+            parsed["lines"][0]["name"], "Monthly subscription for instance b2-15"
+        )
+        # Only BT-154 is present: the historical behaviour is preserved.
+        self.assertEqual(parsed["lines"][1]["name"], "Legacy free-form description")
+        # Neither is present: the dash fallback is preserved.
+        self.assertEqual(parsed["lines"][2]["name"], "-")

--- a/account_invoice_import_ubl/wizard/account_invoice_import.py
+++ b/account_invoice_import_ubl/wizard/account_invoice_import.py
@@ -64,8 +64,20 @@ class AccountInvoiceImport(models.TransientModel):
                     unece_uom = "C62"
                 uom = {"unece_code": unece_uom}
         product_dict = self.ubl_parse_product(iline, namespaces)
-        name_xpath = iline.xpath("cac:Item/cbc:Description", namespaces=namespaces)
-        name = name_xpath and name_xpath[0].text or "-"
+        # BT-153 (cac:Item/cbc:Name) is the item name and is mandatory in
+        # EN 16931, whereas BT-154 (cac:Item/cbc:Description) is optional and
+        # free-form. Some issuers leave the description empty (all the lines
+        # were then labelled "-") and others put an internal identifier in it,
+        # such as a UUID, while the readable label sits in cbc:Name. So read
+        # BT-153 first and only fall back on BT-154.
+        name = False
+        for name_tag in ("cac:Item/cbc:Name", "cac:Item/cbc:Description"):
+            name_xpath = iline.xpath(name_tag, namespaces=namespaces)
+            if name_xpath and name_xpath[0].text and name_xpath[0].text.strip():
+                name = name_xpath[0].text.strip()
+                break
+        if not name:
+            name = "-"
         price_subtotal_xpath = iline.xpath(
             "cbc:LineExtensionAmount", namespaces=namespaces
         )


### PR DESCRIPTION
`cac:Item/cbc:Name` is the item name and is mandatory in EN 16931, whereas `cac:Item/cbc:Description` is optional and free-form. The parser only ever read the latter and fell back on `-`.

Two real-world consequences, both seen on invoices received through a French accredited platform (PDP):

* an issuer that does not fill in the description produces an invoice whose lines are **all** labelled `-`, while `cbc:Name` holds `Gateway - general`, `Credit Card`, `Chargeback`...
* an issuer that puts an internal identifier in the description produces lines labelled with a UUID, repeated identically on every line of the invoice, while `cbc:Name` holds `Forfait mensuel pour une instance b2-15 (...)`.

This PR reads BT-153 first and keeps BT-154 as the fallback.

Checked against 6 real UBL invoices from 2 issuers: every line now carries a readable label, and no other value changes.
