### PR TITLE
[FIX] account_invoice_import_facturx: line level allowances counted twice

### DIFF
--- a/account_invoice_import_facturx/readme/CONTRIBUTORS.md
+++ b/account_invoice_import_facturx/readme/CONTRIBUTORS.md
@@ -1,1 +1,3 @@
 - Alexis de Lattre \<<alexis.delattre@akretion.com>\>
+- [teamDSI](https://www.team-dsi.fr):
+  - Antoine Morit \<<amorit@team-dsi.fr>\>

--- a/account_invoice_import_facturx/tests/__init__.py
+++ b/account_invoice_import_facturx/tests/__init__.py
@@ -1,1 +1,2 @@
 from . import test_facturx
+from . import test_facturx_line_allowance

--- a/account_invoice_import_facturx/tests/files/Facture_FR_EN16931_line_allowance.xml
+++ b/account_invoice_import_facturx/tests/files/Facture_FR_EN16931_line_allowance.xml
@@ -1,0 +1,246 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<rsm:CrossIndustryInvoice
+    xmlns:qdt="urn:un:unece:uncefact:data:standard:QualifiedDataType:100"
+    xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100"
+    xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100"
+    xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+>
+    <rsm:ExchangedDocumentContext>
+        <ram:GuidelineSpecifiedDocumentContextParameter>
+            <ram:ID>urn:cen.eu:en16931:2017</ram:ID>
+        </ram:GuidelineSpecifiedDocumentContextParameter>
+    </rsm:ExchangedDocumentContext>
+    <rsm:ExchangedDocument>
+        <ram:ID>FA-2017-0010-AC</ram:ID>
+        <ram:TypeCode>380</ram:TypeCode>
+        <ram:IssueDateTime>
+            <udt:DateTimeString format="102">20171113</udt:DateTimeString>
+        </ram:IssueDateTime>
+        <ram:IncludedNote>
+            <ram:Content>Franco de port (commande &gt; 300 € HT)</ram:Content>
+        </ram:IncludedNote>
+    </rsm:ExchangedDocument>
+    <rsm:SupplyChainTradeTransaction>
+        <ram:IncludedSupplyChainTradeLineItem>
+            <ram:AssociatedDocumentLineDocument>
+                <ram:LineID>1</ram:LineID>
+            </ram:AssociatedDocumentLineDocument>
+            <ram:SpecifiedTradeProduct>
+                <ram:GlobalID schemeID="0160">3518370400049</ram:GlobalID>
+                <ram:SellerAssignedID>NOUG250</ram:SellerAssignedID>
+                <ram:Name>Nougat de l'Abbaye 250g</ram:Name>
+            </ram:SpecifiedTradeProduct>
+            <ram:SpecifiedLineTradeAgreement>
+                <ram:GrossPriceProductTradePrice>
+                    <ram:ChargeAmount>4.55</ram:ChargeAmount>
+                    <ram:AppliedTradeAllowanceCharge>
+                        <ram:ChargeIndicator>
+                            <udt:Indicator>false</udt:Indicator>
+                        </ram:ChargeIndicator>
+                        <ram:ActualAmount>0.45</ram:ActualAmount>
+                    </ram:AppliedTradeAllowanceCharge>
+                </ram:GrossPriceProductTradePrice>
+                <ram:NetPriceProductTradePrice>
+                    <ram:ChargeAmount>4.10</ram:ChargeAmount>
+                </ram:NetPriceProductTradePrice>
+            </ram:SpecifiedLineTradeAgreement>
+            <ram:SpecifiedLineTradeDelivery>
+                <ram:BilledQuantity unitCode="C62">20.000</ram:BilledQuantity>
+            </ram:SpecifiedLineTradeDelivery>
+            <ram:SpecifiedLineTradeSettlement>
+                <ram:ApplicableTradeTax>
+                    <ram:TypeCode>VAT</ram:TypeCode>
+                    <ram:CategoryCode>S</ram:CategoryCode>
+                    <ram:RateApplicablePercent>20.00</ram:RateApplicablePercent>
+                </ram:ApplicableTradeTax>
+                <ram:SpecifiedTradeAllowanceCharge>
+                    <ram:ChargeIndicator>
+                        <udt:Indicator>false</udt:Indicator>
+                    </ram:ChargeIndicator>
+                    <ram:ActualAmount>-2.00</ram:ActualAmount>
+                    <ram:ReasonCode>95</ram:ReasonCode>
+                    <ram:Reason>Remise</ram:Reason>
+                </ram:SpecifiedTradeAllowanceCharge>
+                <ram:SpecifiedTradeSettlementLineMonetarySummation>
+                    <ram:LineTotalAmount>80.00</ram:LineTotalAmount>
+                </ram:SpecifiedTradeSettlementLineMonetarySummation>
+            </ram:SpecifiedLineTradeSettlement>
+        </ram:IncludedSupplyChainTradeLineItem>
+        <ram:IncludedSupplyChainTradeLineItem>
+            <ram:AssociatedDocumentLineDocument>
+                <ram:LineID>2</ram:LineID>
+            </ram:AssociatedDocumentLineDocument>
+            <ram:SpecifiedTradeProduct>
+                <ram:GlobalID schemeID="0160">3518370200090</ram:GlobalID>
+                <ram:SellerAssignedID>BRAIS300</ram:SellerAssignedID>
+                <ram:Name>Biscuits aux raisins 300g</ram:Name>
+            </ram:SpecifiedTradeProduct>
+            <ram:SpecifiedLineTradeAgreement>
+                <ram:GrossPriceProductTradePrice>
+                    <ram:ChargeAmount>3.20</ram:ChargeAmount>
+                </ram:GrossPriceProductTradePrice>
+                <ram:NetPriceProductTradePrice>
+                    <ram:ChargeAmount>3.20</ram:ChargeAmount>
+                </ram:NetPriceProductTradePrice>
+            </ram:SpecifiedLineTradeAgreement>
+            <ram:SpecifiedLineTradeDelivery>
+                <ram:BilledQuantity unitCode="C62">15.000</ram:BilledQuantity>
+            </ram:SpecifiedLineTradeDelivery>
+            <ram:SpecifiedLineTradeSettlement>
+                <ram:ApplicableTradeTax>
+                    <ram:TypeCode>VAT</ram:TypeCode>
+                    <ram:CategoryCode>S</ram:CategoryCode>
+                    <ram:RateApplicablePercent>5.50</ram:RateApplicablePercent>
+                </ram:ApplicableTradeTax>
+                <ram:SpecifiedTradeSettlementLineMonetarySummation>
+                    <ram:LineTotalAmount>48.00</ram:LineTotalAmount>
+                </ram:SpecifiedTradeSettlementLineMonetarySummation>
+            </ram:SpecifiedLineTradeSettlement>
+        </ram:IncludedSupplyChainTradeLineItem>
+        <ram:IncludedSupplyChainTradeLineItem>
+            <ram:AssociatedDocumentLineDocument>
+                <ram:LineID>3</ram:LineID>
+            </ram:AssociatedDocumentLineDocument>
+            <ram:SpecifiedTradeProduct>
+                <ram:SellerAssignedID>HOLANCL</ram:SellerAssignedID>
+                <ram:Name>Huile d'olive à l'ancienne</ram:Name>
+            </ram:SpecifiedTradeProduct>
+            <ram:SpecifiedLineTradeAgreement>
+                <ram:GrossPriceProductTradePrice>
+                    <ram:ChargeAmount>19.80</ram:ChargeAmount>
+                </ram:GrossPriceProductTradePrice>
+                <ram:NetPriceProductTradePrice>
+                    <ram:ChargeAmount>19.80</ram:ChargeAmount>
+                </ram:NetPriceProductTradePrice>
+            </ram:SpecifiedLineTradeAgreement>
+            <ram:SpecifiedLineTradeDelivery>
+                <ram:BilledQuantity unitCode="LTR">25.000</ram:BilledQuantity>
+            </ram:SpecifiedLineTradeDelivery>
+            <ram:SpecifiedLineTradeSettlement>
+                <ram:ApplicableTradeTax>
+                    <ram:TypeCode>VAT</ram:TypeCode>
+                    <ram:CategoryCode>S</ram:CategoryCode>
+                    <ram:RateApplicablePercent>5.50</ram:RateApplicablePercent>
+                </ram:ApplicableTradeTax>
+                <ram:SpecifiedTradeSettlementLineMonetarySummation>
+                    <ram:LineTotalAmount>495.00</ram:LineTotalAmount>
+                </ram:SpecifiedTradeSettlementLineMonetarySummation>
+            </ram:SpecifiedLineTradeSettlement>
+        </ram:IncludedSupplyChainTradeLineItem>
+        <ram:ApplicableHeaderTradeAgreement>
+            <ram:SellerTradeParty>
+                <ram:Name>Au bon moulin</ram:Name>
+                <ram:SpecifiedLegalOrganization>
+                    <ram:ID schemeID="0002">99999999800010</ram:ID>
+                </ram:SpecifiedLegalOrganization>
+                <ram:DefinedTradeContact>
+                    <ram:PersonName>Tony Dubois</ram:PersonName>
+                    <ram:TelephoneUniversalCommunication>
+                        <ram:CompleteNumber>+33 4 72 07 08 56</ram:CompleteNumber>
+                    </ram:TelephoneUniversalCommunication>
+                    <ram:EmailURIUniversalCommunication>
+                        <ram:URIID
+                            schemeID="SMTP"
+                        >tony.dubois@aubonmoulin.fr</ram:URIID>
+                    </ram:EmailURIUniversalCommunication>
+                </ram:DefinedTradeContact>
+                <ram:PostalTradeAddress>
+                    <ram:PostcodeCode>84340</ram:PostcodeCode>
+                    <ram:LineOne>1242 chemin de l'olive</ram:LineOne>
+                    <ram:CityName>Malaucène</ram:CityName>
+                    <ram:CountryID>FR</ram:CountryID>
+                </ram:PostalTradeAddress>
+                <ram:SpecifiedTaxRegistration>
+                    <ram:ID schemeID="VA">FR11999999998</ram:ID>
+                </ram:SpecifiedTaxRegistration>
+            </ram:SellerTradeParty>
+            <ram:BuyerTradeParty>
+                <ram:Name>Ma jolie boutique</ram:Name>
+                <ram:SpecifiedLegalOrganization>
+                    <ram:ID schemeID="0002">78787878400035</ram:ID>
+                </ram:SpecifiedLegalOrganization>
+                <ram:DefinedTradeContact>
+                    <ram:PersonName>Alexandre Payet</ram:PersonName>
+                    <ram:TelephoneUniversalCommunication>
+                        <ram:CompleteNumber>+33 4 72 07 08 67</ram:CompleteNumber>
+                    </ram:TelephoneUniversalCommunication>
+                    <ram:EmailURIUniversalCommunication>
+                        <ram:URIID
+                            schemeID="SMTP"
+                        >alexandre.payet@majolieboutique.net</ram:URIID>
+                    </ram:EmailURIUniversalCommunication>
+                </ram:DefinedTradeContact>
+                <ram:PostalTradeAddress>
+                    <ram:PostcodeCode>69001</ram:PostcodeCode>
+                    <ram:LineOne>35 rue de la République</ram:LineOne>
+                    <ram:CityName>Lyon</ram:CityName>
+                    <ram:CountryID>FR</ram:CountryID>
+                </ram:PostalTradeAddress>
+                <ram:SpecifiedTaxRegistration>
+                    <ram:ID schemeID="VA">FR19787878784</ram:ID>
+                </ram:SpecifiedTaxRegistration>
+            </ram:BuyerTradeParty>
+            <ram:BuyerOrderReferencedDocument>
+                <ram:IssuerAssignedID>PO445</ram:IssuerAssignedID>
+            </ram:BuyerOrderReferencedDocument>
+            <ram:ContractReferencedDocument>
+                <ram:IssuerAssignedID>MSPE2017</ram:IssuerAssignedID>
+            </ram:ContractReferencedDocument>
+        </ram:ApplicableHeaderTradeAgreement>
+        <ram:ApplicableHeaderTradeDelivery>
+            <ram:ShipToTradeParty>
+                <ram:PostalTradeAddress>
+                    <ram:PostcodeCode>69001</ram:PostcodeCode>
+                    <ram:LineOne>35 rue de la République</ram:LineOne>
+                    <ram:CityName>Lyon</ram:CityName>
+                    <ram:CountryID>FR</ram:CountryID>
+                </ram:PostalTradeAddress>
+            </ram:ShipToTradeParty>
+        </ram:ApplicableHeaderTradeDelivery>
+        <ram:ApplicableHeaderTradeSettlement>
+            <ram:PaymentReference>FA-2017-0010</ram:PaymentReference>
+            <ram:InvoiceCurrencyCode>EUR</ram:InvoiceCurrencyCode>
+            <ram:SpecifiedTradeSettlementPaymentMeans>
+                <ram:TypeCode>30</ram:TypeCode>
+                <ram:Information>Virement sur compte Banque Fiducial</ram:Information>
+                <ram:PayeePartyCreditorFinancialAccount>
+                    <ram:IBANID>FR2012421242124212421242124</ram:IBANID>
+                </ram:PayeePartyCreditorFinancialAccount>
+                <ram:PayeeSpecifiedCreditorFinancialInstitution>
+                    <ram:BICID>FIDCFR21XXX</ram:BICID>
+                </ram:PayeeSpecifiedCreditorFinancialInstitution>
+            </ram:SpecifiedTradeSettlementPaymentMeans>
+            <ram:ApplicableTradeTax>
+                <ram:CalculatedAmount>16.00</ram:CalculatedAmount>
+                <ram:TypeCode>VAT</ram:TypeCode>
+                <ram:BasisAmount>80.00</ram:BasisAmount>
+                <ram:CategoryCode>S</ram:CategoryCode>
+                <ram:DueDateTypeCode>5</ram:DueDateTypeCode>
+                <ram:RateApplicablePercent>20.00</ram:RateApplicablePercent>
+            </ram:ApplicableTradeTax>
+            <ram:ApplicableTradeTax>
+                <ram:CalculatedAmount>29.87</ram:CalculatedAmount>
+                <ram:TypeCode>VAT</ram:TypeCode>
+                <ram:BasisAmount>543.00</ram:BasisAmount>
+                <ram:CategoryCode>S</ram:CategoryCode>
+                <ram:DueDateTypeCode>5</ram:DueDateTypeCode>
+                <ram:RateApplicablePercent>5.50</ram:RateApplicablePercent>
+            </ram:ApplicableTradeTax>
+            <ram:SpecifiedTradePaymentTerms>
+                <ram:Description>30% d'acompte, solde à 30 j</ram:Description>
+                <ram:DueDateDateTime>
+                    <udt:DateTimeString format="102">20171213</udt:DateTimeString>
+                </ram:DueDateDateTime>
+            </ram:SpecifiedTradePaymentTerms>
+            <ram:SpecifiedTradeSettlementHeaderMonetarySummation>
+                <ram:LineTotalAmount>623.00</ram:LineTotalAmount>
+                <ram:TaxBasisTotalAmount>623.00</ram:TaxBasisTotalAmount>
+                <ram:TaxTotalAmount currencyID="EUR">45.87</ram:TaxTotalAmount>
+                <ram:GrandTotalAmount>668.87</ram:GrandTotalAmount>
+                <ram:TotalPrepaidAmount>201.00</ram:TotalPrepaidAmount>
+                <ram:DuePayableAmount>467.87</ram:DuePayableAmount>
+            </ram:SpecifiedTradeSettlementHeaderMonetarySummation>
+        </ram:ApplicableHeaderTradeSettlement>
+    </rsm:SupplyChainTradeTransaction>
+</rsm:CrossIndustryInvoice>

--- a/account_invoice_import_facturx/tests/test_facturx_line_allowance.py
+++ b/account_invoice_import_facturx/tests/test_facturx_line_allowance.py
@@ -1,0 +1,55 @@
+# Copyright 2026 teamDSI
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+import base64
+
+from odoo.tests.common import TransactionCase
+from odoo.tools import file_open
+
+SAMPLE = "Facture_FR_EN16931_line_allowance.xml"
+
+
+class TestFacturxLineAllowance(TransactionCase):
+    """A line level allowance is already deducted from BT-131.
+
+    It must not be counted a second time, whatever the sign the issuer uses
+    for ram:ActualAmount.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.company = cls.env.ref("base.main_company")
+
+    def test_line_allowance_not_counted_twice(self):
+        f = file_open("account_invoice_import_facturx/tests/files/" + SAMPLE, "rb")
+        content = f.read()
+        f.close()
+        parsed = self.env["account.invoice.import"].parse_invoice(
+            base64.b64encode(content), SAMPLE, self.company
+        )
+        lines = parsed["lines"]
+        # 3 product lines plus the allowance carried by the first one.
+        self.assertEqual(len(lines), 4)
+        # The first line is billed 20 x 4.10 = 82.00 with a 2.00 allowance, so
+        # ram:LineTotalAmount is 80.00. The product line must carry the gross
+        # amount, otherwise the allowance is deducted a second time.
+        self.assertAlmostEqual(lines[0]["qty"], 20.0, places=2)
+        self.assertAlmostEqual(lines[0]["price_unit"], 4.10, places=2)
+        self.assertAlmostEqual(lines[0]["price_subtotal"], 82.00, places=2)
+        # The issuer writes the allowance as a negative ram:ActualAmount while
+        # BT-136 is defined as a positive amount, the direction being carried
+        # by ram:ChargeIndicator. Taking it as-is turns the allowance into a
+        # charge.
+        self.assertEqual(lines[1]["product"]["code"], "EDI-ALLOWANCE")
+        self.assertAlmostEqual(lines[1]["price_unit"], 2.00, places=2)
+        self.assertAlmostEqual(lines[1]["price_subtotal"], -2.00, places=2)
+        # The lines must add up to BT-106, otherwise _post_process_invoice()
+        # makes up the difference with an adjustment line.
+        self.assertAlmostEqual(
+            sum(line["price_subtotal"] for line in lines),
+            parsed["amount_untaxed"],
+            places=2,
+        )
+        self.assertAlmostEqual(parsed["amount_untaxed"], 623.00, places=2)
+        self.assertAlmostEqual(parsed["amount_total"], 668.87, places=2)

--- a/account_invoice_import_facturx/wizard/account_invoice_import.py
+++ b/account_invoice_import_facturx/wizard/account_invoice_import.py
@@ -251,8 +251,15 @@ class AccountInvoiceImport(models.TransientModel):
         if reason:
             acentry["name"] = reason
         # ChargeIndicator and ActualAmount are required field
-        acentry["price_unit"] = self.multi_xpath_helper(
-            acline, ["ram:ActualAmount"], namespaces, isfloat=True
+        # BT-92 and BT-136 are defined as positive amounts, the direction being
+        # carried by ram:ChargeIndicator alone. Some issuers send a negative
+        # ActualAmount for an allowance: taking it as-is negates the amount
+        # twice and turns the allowance into a charge.
+        acentry["price_unit"] = abs(
+            self.multi_xpath_helper(
+                acline, ["ram:ActualAmount"], namespaces, isfloat=True
+            )
+            or 0.0
         )
         ch_indic = self.multi_xpath_helper(
             acline, ["ram:ChargeIndicator/udt:Indicator"], namespaces
@@ -372,6 +379,7 @@ class AccountInvoiceImport(models.TransientModel):
             namespaces,
         )
         res = [vals]
+        ac_total = 0.0
         for ac_element in iline_allowance_charge_xpath:
             acentry = self.parse_facturx_allowance_charge(
                 ac_element,
@@ -381,8 +389,18 @@ class AccountInvoiceImport(models.TransientModel):
                 {},
                 namespaces,
             )
-            counters["lines"] += acentry["price_unit"] * acentry["qty"]
+            acentry["price_subtotal"] = acentry["price_unit"] * acentry["qty"]
+            ac_total += acentry["price_subtotal"]
             res.append(acentry)
+        if ac_total:
+            # BT-131 (LineTotalAmount) is already net of the line level
+            # allowances and charges, so the product line must carry the gross
+            # amount for the sum of the lines returned here to add up to
+            # BT-131. Otherwise every allowance is counted twice and the
+            # difference ends up on a global adjustment line.
+            gross = price_subtotal - ac_total
+            vals["price_unit"] = gross / qty
+            vals["price_subtotal"] = gross
         return res
 
     @api.model


### PR DESCRIPTION
BT-131 (`ram:LineTotalAmount`) is already net of the line level allowances and charges, but the parser used it as the amount of the product line and *then* appended each `ram:SpecifiedTradeAllowanceCharge` as a separate line. Every allowance was therefore counted twice, and the difference ended up on the global adjustment line built by `_post_process_invoice()`.

A real invoice received through a French accredited platform (PDP) made the problem obvious: 370 lines, 115 allowances, and a single "Adjustment" line of **-1471.95 EUR**, exactly twice the sum of the allowances, posted to the adjustment income account. The total was right, the breakdown was not: the expense account was overstated and revenue appeared out of nowhere.

The same invoice also showed that this issuer sends a **negative** `ram:ActualAmount` for its allowances, while BT-92 and BT-136 are defined as positive amounts, the direction being carried by `ram:ChargeIndicator` alone. Taking the amount as-is negated it twice and turned each allowance into a charge, which is how a "Remise" line ended up increasing the invoice.

This PR rebuilds the gross amount of the product line from BT-131 and the allowances and charges taken in absolute value, so that the lines returned always add up to BT-131 whatever the sign convention of the issuer.

Checked against 8 real Factur-X invoices from 5 issuers, including the 370-line one: the sum of the imported lines now matches BT-106 to the cent on all of them, with no adjustment line left, and the allowances read as negative amounts as they should.
